### PR TITLE
Support for cgroup v1 cpu and cpuset subsystem

### DIFF
--- a/integration_test.sh
+++ b/integration_test.sh
@@ -3,7 +3,7 @@
 root=$(pwd)
 cd integration_test/src/github.com/opencontainers/runtime-tools
 GOPATH=$root/integration_test make runtimetest validation-executables
-test_cases=("default/default.t" "linux_cgroups_devices/linux_cgroups_devices.t" "linux_cgroups_hugetlb/linux_cgroups_hugetlb.t" "linux_cgroups_pids/linux_cgroups_pids.t" "linux_cgroups_memory/linux_cgroups_memory.t" "linux_cgroups_network/linux_cgroups_network.t")
+test_cases=("default/default.t" "linux_cgroups_devices/linux_cgroups_devices.t" "linux_cgroups_hugetlb/linux_cgroups_hugetlb.t" "linux_cgroups_pids/linux_cgroups_pids.t" "linux_cgroups_memory/linux_cgroups_memory.t" "linux_cgroups_network/linux_cgroups_network.t" "linux_cgroups_cpus/linux_cgroups_cpus.t")
 for case in "${test_cases[@]}"; do
   echo "Running $case"
   if [ 0 -ne $(sudo RUST_BACKTRACE=1 YOUKI_LOG_LEVEL=debug RUNTIME=$root/target/x86_64-unknown-linux-gnu/debug/youki $root/integration_test/src/github.com/opencontainers/runtime-tools/validation/$case | grep "not ok" | wc -l) ]; then

--- a/src/cgroups/common.rs
+++ b/src/cgroups/common.rs
@@ -40,7 +40,7 @@ impl Display for Cgroup {
 }
 
 #[inline]
-pub fn write_cgroup_file<P: AsRef<Path>>(path: P, data: &str) -> Result<()> {
+pub fn write_cgroup_file_str<P: AsRef<Path>>(path: P, data: &str) -> Result<()> {
     fs::OpenOptions::new()
         .create(false)
         .write(true)
@@ -52,7 +52,7 @@ pub fn write_cgroup_file<P: AsRef<Path>>(path: P, data: &str) -> Result<()> {
 }
 
 #[inline]
-pub fn write_cgroup_file_<P: AsRef<Path>, T: ToString>(path: P, data: T) -> Result<()> {
+pub fn write_cgroup_file<P: AsRef<Path>, T: ToString>(path: P, data: T) -> Result<()> {
     fs::OpenOptions::new()
         .create(false)
         .write(true)
@@ -96,7 +96,10 @@ pub fn create_cgroup_manager<P: Into<PathBuf>>(cgroup_path: P) -> Result<Box<dyn
                         cgroup_path.into(),
                     )?))
                 }
-                _ => Ok(Box::new(v1::manager::Manager::new(cgroup_path.into())?)),
+                _ => {
+                    log::info!("cgroup manager V1 will be used");
+                    Ok(Box::new(v1::manager::Manager::new(cgroup_path.into())?))
+                }
             }
         }
         _ => bail!("could not find cgroup filesystem"),

--- a/src/cgroups/common.rs
+++ b/src/cgroups/common.rs
@@ -14,6 +14,7 @@ use procfs::process::Process;
 use crate::cgroups::v1;
 use crate::cgroups::v2;
 
+pub const CGROUP_PROCS: &str = "cgroup.procs";
 pub const DEFAULT_CGROUP_ROOT: &str = "/sys/fs/cgroup";
 
 pub trait CgroupManager {
@@ -46,6 +47,18 @@ pub fn write_cgroup_file<P: AsRef<Path>>(path: P, data: &str) -> Result<()> {
         .truncate(false)
         .open(path)?
         .write_all(data.as_bytes())?;
+
+    Ok(())
+}
+
+#[inline]
+pub fn write_cgroup_file_<P: AsRef<Path>, T: ToString>(path: P, data: T) -> Result<()> {
+    fs::OpenOptions::new()
+        .create(false)
+        .write(true)
+        .truncate(false)
+        .open(path)?
+        .write_all(data.to_string().as_bytes())?;
 
     Ok(())
 }
@@ -84,7 +97,7 @@ pub fn create_cgroup_manager<P: Into<PathBuf>>(cgroup_path: P) -> Result<Box<dyn
                     )?))
                 }
                 _ => Ok(Box::new(v1::manager::Manager::new(cgroup_path.into())?)),
-            } 
+            }
         }
         _ => bail!("could not find cgroup filesystem"),
     }

--- a/src/cgroups/v1/blkio.rs
+++ b/src/cgroups/v1/blkio.rs
@@ -3,7 +3,10 @@ use std::{
     path::Path,
 };
 
-use crate::cgroups::{common, v1::Controller};
+use crate::cgroups::{
+    common::{self, CGROUP_PROCS},
+    v1::Controller,
+};
 use oci_spec::{LinuxBlockIo, LinuxResources};
 
 const CGROUP_BLKIO_THROTTLE_READ_BPS: &str = "blkio.throttle.read_bps_device";
@@ -26,7 +29,7 @@ impl Controller for Blkio {
             Self::apply(cgroup_root, blkio)?;
         }
 
-        common::write_cgroup_file(&cgroup_root.join("cgroup.procs"), &pid.to_string())?;
+        common::write_cgroup_file(cgroup_root.join(CGROUP_PROCS), pid)?;
         Ok(())
     }
 }
@@ -34,28 +37,28 @@ impl Controller for Blkio {
 impl Blkio {
     fn apply(root_path: &Path, blkio: &LinuxBlockIo) -> anyhow::Result<()> {
         for trbd in &blkio.blkio_throttle_read_bps_device {
-            common::write_cgroup_file(
+            common::write_cgroup_file_str(
                 &root_path.join(CGROUP_BLKIO_THROTTLE_READ_BPS),
                 &format!("{}:{} {}", trbd.major, trbd.minor, trbd.rate),
             )?;
         }
 
         for twbd in &blkio.blkio_throttle_write_bps_device {
-            common::write_cgroup_file(
+            common::write_cgroup_file_str(
                 &root_path.join(CGROUP_BLKIO_THROTTLE_WRITE_BPS),
                 &format!("{}:{} {}", twbd.major, twbd.minor, twbd.rate),
             )?;
         }
 
         for trid in &blkio.blkio_throttle_read_iops_device {
-            common::write_cgroup_file(
+            common::write_cgroup_file_str(
                 &root_path.join(CGROUP_BLKIO_THROTTLE_READ_IOPS),
                 &format!("{}:{} {}", trid.major, trid.minor, trid.rate),
             )?;
         }
 
         for twid in &blkio.blkio_throttle_write_iops_device {
-            common::write_cgroup_file(
+            common::write_cgroup_file_str(
                 &root_path.join(CGROUP_BLKIO_THROTTLE_WRITE_IOPS),
                 &format!("{}:{} {}", twid.major, twid.minor, twid.rate),
             )?;

--- a/src/cgroups/v1/controller_type.rs
+++ b/src/cgroups/v1/controller_type.rs
@@ -2,6 +2,7 @@ use std::string::ToString;
 
 pub enum ControllerType {
     Cpu,
+    CpuSet,
     Devices,
     HugeTlb,
     Pids,
@@ -15,6 +16,7 @@ impl ToString for ControllerType {
     fn to_string(&self) -> String {
         match self {
             Self::Cpu => "cpu".into(),
+            Self::CpuSet => "cpuset".into(),
             Self::Devices => "devices".into(),
             Self::HugeTlb => "hugetlb".into(),
             Self::Pids => "pids".into(),

--- a/src/cgroups/v1/controller_type.rs
+++ b/src/cgroups/v1/controller_type.rs
@@ -1,6 +1,7 @@
 use std::string::ToString;
 
 pub enum ControllerType {
+    Cpu,
     Devices,
     HugeTlb,
     Pids,
@@ -13,6 +14,7 @@ pub enum ControllerType {
 impl ToString for ControllerType {
     fn to_string(&self) -> String {
         match self {
+            Self::Cpu => "cpu".into(),
             Self::Devices => "devices".into(),
             Self::HugeTlb => "hugetlb".into(),
             Self::Pids => "pids".into(),

--- a/src/cgroups/v1/cpu.rs
+++ b/src/cgroups/v1/cpu.rs
@@ -24,7 +24,7 @@ impl Controller for Cpu {
             Self::apply(cgroup_root, cpu)?;
         }
 
-        common::write_cgroup_file_(cgroup_root.join(CGROUP_PROCS), pid)?;
+        common::write_cgroup_file(cgroup_root.join(CGROUP_PROCS), pid)?;
         Ok(())
     }
 }
@@ -33,31 +33,31 @@ impl Cpu {
     fn apply(root_path: &Path, cpu: &LinuxCpu) -> Result<()> {
         if let Some(cpu_shares) = cpu.shares {
             if cpu_shares != 0 {
-                common::write_cgroup_file_(root_path.join(CGROUP_CPU_SHARES), cpu_shares)?;
+                common::write_cgroup_file(root_path.join(CGROUP_CPU_SHARES), cpu_shares)?;
             }
         }
 
         if let Some(cpu_period) = cpu.period {
             if cpu_period != 0 {
-                common::write_cgroup_file_(root_path.join(CGROUP_CPU_PERIOD), cpu_period)?;
+                common::write_cgroup_file(root_path.join(CGROUP_CPU_PERIOD), cpu_period)?;
             }
         }
 
         if let Some(cpu_quota) = cpu.quota {
             if cpu_quota != 0 {
-                common::write_cgroup_file_(root_path.join(CGROUP_CPU_QUOTA), cpu_quota)?;
+                common::write_cgroup_file(root_path.join(CGROUP_CPU_QUOTA), cpu_quota)?;
             }
         }
 
         if let Some(rt_runtime) = cpu.realtime_runtime {
             if rt_runtime != 0 {
-                common::write_cgroup_file_(root_path.join(CGROUP_CPU_RT_RUNTIME), rt_runtime)?;
+                common::write_cgroup_file(root_path.join(CGROUP_CPU_RT_RUNTIME), rt_runtime)?;
             }
         }
 
         if let Some(rt_period) = cpu.realtime_period {
             if rt_period != 0 {
-                common::write_cgroup_file_(root_path.join(CGROUP_CPU_RT_PERIOD), rt_period)?;
+                common::write_cgroup_file(root_path.join(CGROUP_CPU_RT_PERIOD), rt_period)?;
             }
         }
 
@@ -122,34 +122,35 @@ mod tests {
 
     #[test]
     fn test_set_rt_runtime() {
-         // arrange
-         const RUNTIME: i64 = 100000;
-         let (tmp, max) = setup("test_set_rt_runtime", CGROUP_CPU_RT_RUNTIME);
-         let cpu = LinuxCpuBuilder::new().with_realtime_runtime(RUNTIME).build();
- 
-         // act
-         Cpu::apply(&tmp, &cpu).expect("apply cpu");
- 
-         // assert
-         let content = fs::read_to_string(max)
-             .unwrap_or_else(|_| panic!("read {} file content", CGROUP_CPU_RT_RUNTIME));
-         assert_eq!(content, RUNTIME.to_string());
+        // arrange
+        const RUNTIME: i64 = 100000;
+        let (tmp, max) = setup("test_set_rt_runtime", CGROUP_CPU_RT_RUNTIME);
+        let cpu = LinuxCpuBuilder::new()
+            .with_realtime_runtime(RUNTIME)
+            .build();
+
+        // act
+        Cpu::apply(&tmp, &cpu).expect("apply cpu");
+
+        // assert
+        let content = fs::read_to_string(max)
+            .unwrap_or_else(|_| panic!("read {} file content", CGROUP_CPU_RT_RUNTIME));
+        assert_eq!(content, RUNTIME.to_string());
     }
 
     #[test]
     fn test_set_rt_period() {
-         // arrange
-         const PERIOD: u64 = 100000;
-         let (tmp, max) = setup("test_set_rt_period", CGROUP_CPU_RT_PERIOD);
-         let cpu = LinuxCpuBuilder::new().with_realtime_period(PERIOD).build();
- 
-         // act
-         Cpu::apply(&tmp, &cpu).expect("apply cpu");
- 
-         // assert
-         let content = fs::read_to_string(max)
-             .unwrap_or_else(|_| panic!("read {} file content", CGROUP_CPU_RT_PERIOD));
-         assert_eq!(content, PERIOD.to_string());
-    }
+        // arrange
+        const PERIOD: u64 = 100000;
+        let (tmp, max) = setup("test_set_rt_period", CGROUP_CPU_RT_PERIOD);
+        let cpu = LinuxCpuBuilder::new().with_realtime_period(PERIOD).build();
 
+        // act
+        Cpu::apply(&tmp, &cpu).expect("apply cpu");
+
+        // assert
+        let content = fs::read_to_string(max)
+            .unwrap_or_else(|_| panic!("read {} file content", CGROUP_CPU_RT_PERIOD));
+        assert_eq!(content, PERIOD.to_string());
+    }
 }

--- a/src/cgroups/v1/cpu.rs
+++ b/src/cgroups/v1/cpu.rs
@@ -1,0 +1,66 @@
+use std::{fs, path::Path};
+
+use anyhow::Result;
+use nix::unistd::Pid;
+use oci_spec::{LinuxCpu, LinuxResources};
+
+use crate::cgroups::common::{self, CGROUP_PROCS};
+
+use super::Controller;
+
+const CGROUP_CPU_SHARES: &str = "cpu.shares";
+const CGROUP_CPU_QUOTA: &str = "cpu.cfs_quota_us";
+const CGROUP_CPU_PERIOD: &str = "cpu.cfs_period_us";
+const CGROUP_CPU_RT_RUNTIME: &str = "cpu.rt_runtime_us";
+const CGROUP_CPU_RT_PERIOD: &str = "cpu.rt_period_us";
+
+pub struct Cpu {}
+
+impl Controller for Cpu {
+    fn apply(linux_resources: &LinuxResources, cgroup_root: &Path, pid: Pid) -> Result<()> {
+        log::debug!("Apply Cpu cgroup config");
+        fs::create_dir_all(cgroup_root)?;
+        if let Some(cpu) = &linux_resources.cpu {
+            Self::apply(cgroup_root, cpu)?;
+        }
+
+        common::write_cgroup_file_(cgroup_root.join(CGROUP_PROCS), pid)?;
+        Ok(())
+    }
+}
+
+impl Cpu {
+    fn apply(root_path: &Path, cpu: &LinuxCpu) -> Result<()> {
+        if let Some(cpu_shares) = cpu.shares {
+            if cpu_shares != 0 {
+                common::write_cgroup_file_(root_path.join(CGROUP_CPU_SHARES), cpu_shares)?;
+            }
+        }
+
+        if let Some(cpu_period) = cpu.period {
+            if cpu_period != 0 {
+                common::write_cgroup_file_(root_path.join(CGROUP_CPU_PERIOD), cpu_period)?;
+            }
+        }
+
+        if let Some(cpu_quota) = cpu.quota {
+            if cpu_quota != 0 {
+                common::write_cgroup_file_(root_path.join(CGROUP_CPU_QUOTA), cpu_quota)?;
+            }
+        }
+
+        if let Some(rt_runtime) = cpu.realtime_runtime {
+            if rt_runtime != 0 {
+                common::write_cgroup_file_(root_path.join(CGROUP_CPU_RT_RUNTIME), rt_runtime)?;
+            }
+        }
+
+        if let Some(rt_period) = cpu.realtime_period {
+            if rt_period != 0 {
+                common::write_cgroup_file_(root_path.join(CGROUP_CPU_RT_PERIOD), rt_period)?;
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/src/cgroups/v1/cpu.rs
+++ b/src/cgroups/v1/cpu.rs
@@ -64,3 +64,92 @@ impl Cpu {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cgroups::test::{set_fixture, setup, LinuxCpuBuilder};
+    use std::fs;
+
+    #[test]
+    fn test_set_shares() {
+        // arrange
+        let (tmp, shares) = setup("test_set_shares", CGROUP_CPU_SHARES);
+        let _ = set_fixture(&tmp, CGROUP_CPU_SHARES, "")
+            .unwrap_or_else(|_| panic!("set test fixture for {}", CGROUP_CPU_SHARES));
+        let cpu = LinuxCpuBuilder::new().with_shares(2048).build();
+
+        // act
+        Cpu::apply(&tmp, &cpu).expect("apply cpu");
+
+        // assert
+        let content = fs::read_to_string(shares)
+            .unwrap_or_else(|_| panic!("read {} file content", CGROUP_CPU_SHARES));
+        assert_eq!(content, 2048.to_string());
+    }
+
+    #[test]
+    fn test_set_quota() {
+        // arrange
+        const QUOTA: i64 = 200000;
+        let (tmp, max) = setup("test_set_quota", CGROUP_CPU_QUOTA);
+        let cpu = LinuxCpuBuilder::new().with_quota(QUOTA).build();
+
+        // act
+        Cpu::apply(&tmp, &cpu).expect("apply cpu");
+
+        // assert
+        let content = fs::read_to_string(max)
+            .unwrap_or_else(|_| panic!("read {} file content", CGROUP_CPU_QUOTA));
+        assert_eq!(content, QUOTA.to_string());
+    }
+
+    #[test]
+    fn test_set_period() {
+        // arrange
+        const PERIOD: u64 = 100000;
+        let (tmp, max) = setup("test_set_period", CGROUP_CPU_PERIOD);
+        let cpu = LinuxCpuBuilder::new().with_period(PERIOD).build();
+
+        // act
+        Cpu::apply(&tmp, &cpu).expect("apply cpu");
+
+        // assert
+        let content = fs::read_to_string(max)
+            .unwrap_or_else(|_| panic!("read {} file content", CGROUP_CPU_PERIOD));
+        assert_eq!(content, PERIOD.to_string());
+    }
+
+    #[test]
+    fn test_set_rt_runtime() {
+         // arrange
+         const RUNTIME: i64 = 100000;
+         let (tmp, max) = setup("test_set_rt_runtime", CGROUP_CPU_RT_RUNTIME);
+         let cpu = LinuxCpuBuilder::new().with_realtime_runtime(RUNTIME).build();
+ 
+         // act
+         Cpu::apply(&tmp, &cpu).expect("apply cpu");
+ 
+         // assert
+         let content = fs::read_to_string(max)
+             .unwrap_or_else(|_| panic!("read {} file content", CGROUP_CPU_RT_RUNTIME));
+         assert_eq!(content, RUNTIME.to_string());
+    }
+
+    #[test]
+    fn test_set_rt_period() {
+         // arrange
+         const PERIOD: u64 = 100000;
+         let (tmp, max) = setup("test_set_rt_period", CGROUP_CPU_RT_PERIOD);
+         let cpu = LinuxCpuBuilder::new().with_realtime_period(PERIOD).build();
+ 
+         // act
+         Cpu::apply(&tmp, &cpu).expect("apply cpu");
+ 
+         // assert
+         let content = fs::read_to_string(max)
+             .unwrap_or_else(|_| panic!("read {} file content", CGROUP_CPU_RT_PERIOD));
+         assert_eq!(content, PERIOD.to_string());
+    }
+
+}

--- a/src/cgroups/v1/cpuset.rs
+++ b/src/cgroups/v1/cpuset.rs
@@ -1,0 +1,42 @@
+use std::{fs, path::Path};
+
+use anyhow::Result;
+use nix::unistd::Pid;
+use oci_spec::{LinuxCpu, LinuxResources};
+
+use crate::cgroups::common::{self, CGROUP_PROCS};
+
+use super::Controller;
+
+const CGROUP_CPUSET_CPUS: &str = "cpuset.cpus";
+const CGROUP_CPUSET_MEMS: &str = "cpuset.mems";
+
+pub struct CpuSet {}
+
+impl Controller for CpuSet {
+    fn apply(linux_resources: &LinuxResources, cgroup_root: &Path, pid: Pid) -> Result<()> {
+        log::debug!("Apply CpuSet cgroup config");
+        fs::create_dir_all(cgroup_root)?;
+
+        if let Some(cpuset) = &linux_resources.cpu {
+            Self::apply(cgroup_root, cpuset)?;
+        }
+
+        common::write_cgroup_file_(cgroup_root.join(CGROUP_PROCS), pid)?;
+        Ok(())
+    }
+}
+
+impl CpuSet {
+    fn apply(root_path: &Path, cpuset: &LinuxCpu) -> Result<()> {
+        if let Some(cpus) = &cpuset.cpus {
+            common::write_cgroup_file(root_path.join(CGROUP_CPUSET_CPUS), cpus)?;
+        }
+
+        if let Some(mems) = &cpuset.mems {
+            common::write_cgroup_file(root_path.join(CGROUP_CPUSET_MEMS), mems)?;
+        }
+
+        Ok(())
+    }
+}

--- a/src/cgroups/v1/cpuset.rs
+++ b/src/cgroups/v1/cpuset.rs
@@ -22,7 +22,7 @@ impl Controller for CpuSet {
             Self::apply(cgroup_root, cpuset)?;
         }
 
-        common::write_cgroup_file_(cgroup_root.join(CGROUP_PROCS), pid)?;
+        common::write_cgroup_file(cgroup_root.join(CGROUP_PROCS), pid)?;
         Ok(())
     }
 }
@@ -30,11 +30,11 @@ impl Controller for CpuSet {
 impl CpuSet {
     fn apply(root_path: &Path, cpuset: &LinuxCpu) -> Result<()> {
         if let Some(cpus) = &cpuset.cpus {
-            common::write_cgroup_file(root_path.join(CGROUP_CPUSET_CPUS), cpus)?;
+            common::write_cgroup_file_str(root_path.join(CGROUP_CPUSET_CPUS), cpus)?;
         }
 
         if let Some(mems) = &cpuset.mems {
-            common::write_cgroup_file(root_path.join(CGROUP_CPUSET_MEMS), mems)?;
+            common::write_cgroup_file_str(root_path.join(CGROUP_CPUSET_MEMS), mems)?;
         }
 
         Ok(())

--- a/src/cgroups/v1/cpuset.rs
+++ b/src/cgroups/v1/cpuset.rs
@@ -40,3 +40,41 @@ impl CpuSet {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use super::*;
+    use crate::cgroups::test::{setup, LinuxCpuBuilder};
+
+    #[test]
+    fn test_set_cpus() {
+        // arrange
+        let (tmp, cpus) = setup("test_set_cpus", CGROUP_CPUSET_CPUS);
+        let cpuset = LinuxCpuBuilder::new().with_cpus("1-3".to_owned()).build();
+
+        // act
+        CpuSet::apply(&tmp, &cpuset).expect("apply cpuset");
+
+        // assert
+        let content = fs::read_to_string(&cpus)
+            .unwrap_or_else(|_| panic!("read {} file content", CGROUP_CPUSET_CPUS));
+        assert_eq!(content, "1-3");
+    }
+
+    #[test]
+    fn test_set_mems() {
+        // arrange
+        let (tmp, mems) = setup("test_set_mems", CGROUP_CPUSET_MEMS);
+        let cpuset = LinuxCpuBuilder::new().with_mems("1-3".to_owned()).build();
+
+        // act
+        CpuSet::apply(&tmp, &cpuset).expect("apply cpuset");
+
+        // assert
+        let content = fs::read_to_string(&mems)
+            .unwrap_or_else(|_| panic!("read {} file content", CGROUP_CPUSET_MEMS));
+        assert_eq!(content, "1-3");
+    }
+}

--- a/src/cgroups/v1/devices.rs
+++ b/src/cgroups/v1/devices.rs
@@ -3,7 +3,7 @@ use std::{fs::create_dir_all, path::Path};
 use anyhow::Result;
 use nix::unistd::Pid;
 
-use crate::cgroups::common;
+use crate::cgroups::common::{self, CGROUP_PROCS};
 use crate::{cgroups::v1::Controller, rootfs::default_devices};
 use oci_spec::{LinuxDeviceCgroup, LinuxDeviceType, LinuxResources};
 
@@ -27,7 +27,7 @@ impl Controller for Devices {
             Self::apply_device(&d, &cgroup_root)?;
         }
 
-        common::write_cgroup_file(cgroup_root.join("cgroup.procs"), &pid.to_string())?;
+        common::write_cgroup_file(cgroup_root.join(CGROUP_PROCS), pid)?;
         Ok(())
     }
 }
@@ -40,7 +40,7 @@ impl Devices {
             cgroup_root.join("devices.deny")
         };
 
-        common::write_cgroup_file(path, &device.to_string())?;
+        common::write_cgroup_file_str(path, &device.to_string())?;
         Ok(())
     }
 

--- a/src/cgroups/v1/hugetlb.rs
+++ b/src/cgroups/v1/hugetlb.rs
@@ -3,7 +3,10 @@ use std::{fs, path::Path};
 use anyhow::anyhow;
 use regex::Regex;
 
-use crate::cgroups::{common, v1::Controller};
+use crate::cgroups::{
+    common::{self, CGROUP_PROCS},
+    v1::Controller,
+};
 use oci_spec::{LinuxHugepageLimit, LinuxResources};
 
 pub struct Hugetlb {}
@@ -21,7 +24,7 @@ impl Controller for Hugetlb {
             Self::apply(cgroup_root, hugetlb)?
         }
 
-        common::write_cgroup_file(cgroup_root.join("cgroup.procs"), &pid.to_string())?;
+        common::write_cgroup_file(cgroup_root.join(CGROUP_PROCS), pid)?;
         Ok(())
     }
 }
@@ -42,7 +45,7 @@ impl Hugetlb {
 
         common::write_cgroup_file(
             &root_path.join(format!("hugetlb.{}.limit_in_bytes", hugetlb.page_size)),
-            &hugetlb.limit.to_string(),
+            &hugetlb.limit,
         )?;
         Ok(())
     }

--- a/src/cgroups/v1/manager.rs
+++ b/src/cgroups/v1/manager.rs
@@ -7,7 +7,7 @@ use nix::unistd::Pid;
 use procfs::process::Process;
 
 use super::{
-    blkio::Blkio, cpu::Cpu, devices::Devices, hugetlb::Hugetlb, memory::Memory,
+    blkio::Blkio, cpu::Cpu, cpuset::CpuSet, devices::Devices, hugetlb::Hugetlb, memory::Memory,
     network_classifier::NetworkClassifier, network_priority::NetworkPriority, pids::Pids,
     Controller, ControllerType,
 };
@@ -17,6 +17,7 @@ use oci_spec::LinuxResources;
 
 const CONTROLLERS: &[ControllerType] = &[
     ControllerType::Cpu,
+    ControllerType::CpuSet,
     ControllerType::Devices,
     ControllerType::HugeTlb,
     ControllerType::Memory,
@@ -89,6 +90,7 @@ impl CgroupManager for Manager {
         for subsys in &self.subsystems {
             match subsys.0.as_str() {
                 "cpu" => Cpu::apply(linux_resources, &subsys.1, pid)?,
+                "cpuset" => CpuSet::apply(linux_resources, &subsys.1, pid)?,
                 "devices" => Devices::apply(linux_resources, &subsys.1, pid)?,
                 "hugetlb" => Hugetlb::apply(linux_resources, &subsys.1, pid)?,
                 "memory" => Memory::apply(linux_resources, &subsys.1, pid)?,
@@ -96,7 +98,7 @@ impl CgroupManager for Manager {
                 "blkio" => Blkio::apply(linux_resources, &subsys.1, pid)?,
                 "net_prio" => NetworkPriority::apply(linux_resources, &subsys.1, pid)?,
                 "net_cls" => NetworkClassifier::apply(linux_resources, &subsys.1, pid)?,
-                _ => continue,
+                _ => unreachable!("every subsystem should have an associated controller"),
             }
         }
 

--- a/src/cgroups/v1/mod.rs
+++ b/src/cgroups/v1/mod.rs
@@ -1,6 +1,7 @@
 mod blkio;
 mod controller;
 mod controller_type;
+mod cpu;
 mod devices;
 mod hugetlb;
 pub mod manager;

--- a/src/cgroups/v1/mod.rs
+++ b/src/cgroups/v1/mod.rs
@@ -2,6 +2,7 @@ mod blkio;
 mod controller;
 mod controller_type;
 mod cpu;
+mod cpuset;
 mod devices;
 mod hugetlb;
 pub mod manager;

--- a/src/cgroups/v1/network_classifier.rs
+++ b/src/cgroups/v1/network_classifier.rs
@@ -4,6 +4,7 @@ use anyhow::Result;
 use nix::unistd::Pid;
 
 use crate::cgroups::common;
+use crate::cgroups::common::CGROUP_PROCS;
 use crate::cgroups::v1::Controller;
 use oci_spec::{LinuxNetwork, LinuxResources};
 
@@ -18,7 +19,7 @@ impl Controller for NetworkClassifier {
             Self::apply(cgroup_root, network)?;
         }
 
-        common::write_cgroup_file(cgroup_root.join("cgroup.procs"), &pid.to_string())?;
+        common::write_cgroup_file(cgroup_root.join(CGROUP_PROCS), pid)?;
         Ok(())
     }
 }
@@ -26,7 +27,7 @@ impl Controller for NetworkClassifier {
 impl NetworkClassifier {
     fn apply(root_path: &Path, network: &LinuxNetwork) -> Result<()> {
         if let Some(class_id) = network.class_id {
-            common::write_cgroup_file(&root_path.join("net_cls.classid"), &class_id.to_string())?;
+            common::write_cgroup_file(root_path.join("net_cls.classid"), class_id)?;
         }
 
         Ok(())

--- a/src/cgroups/v1/network_priority.rs
+++ b/src/cgroups/v1/network_priority.rs
@@ -4,6 +4,7 @@ use anyhow::Result;
 use nix::unistd::Pid;
 
 use crate::cgroups::common;
+use crate::cgroups::common::CGROUP_PROCS;
 use crate::cgroups::v1::Controller;
 use oci_spec::{LinuxNetwork, LinuxResources};
 
@@ -18,7 +19,7 @@ impl Controller for NetworkPriority {
             Self::apply(cgroup_root, network)?;
         }
 
-        common::write_cgroup_file(cgroup_root.join("cgroup.procs"), &pid.to_string())?;
+        common::write_cgroup_file(cgroup_root.join(CGROUP_PROCS), pid)?;
         Ok(())
     }
 }
@@ -26,7 +27,7 @@ impl Controller for NetworkPriority {
 impl NetworkPriority {
     fn apply(root_path: &Path, network: &LinuxNetwork) -> Result<()> {
         let priorities: String = network.priorities.iter().map(|p| p.to_string()).collect();
-        common::write_cgroup_file(&root_path.join("net_prio.ifpriomap"), &priorities.trim())?;
+        common::write_cgroup_file_str(root_path.join("net_prio.ifpriomap"), &priorities.trim())?;
 
         Ok(())
     }

--- a/src/cgroups/v1/pids.rs
+++ b/src/cgroups/v1/pids.rs
@@ -5,7 +5,10 @@ use std::{
 
 use anyhow::Result;
 
-use crate::cgroups::{common, v1::Controller};
+use crate::cgroups::{
+    common::{self, CGROUP_PROCS},
+    v1::Controller,
+};
 use oci_spec::{LinuxPids, LinuxResources};
 
 pub struct Pids {}
@@ -23,7 +26,7 @@ impl Controller for Pids {
             Self::apply(cgroup_root, pids)?;
         }
 
-        common::write_cgroup_file(cgroup_root.join("cgroup.procs"), &pid.to_string())?;
+        common::write_cgroup_file(cgroup_root.join(CGROUP_PROCS), pid)?;
         Ok(())
     }
 }
@@ -36,7 +39,7 @@ impl Pids {
             "max".to_string()
         };
 
-        common::write_cgroup_file(&root_path.join("pids.max"), &limit)?;
+        common::write_cgroup_file_str(&root_path.join("pids.max"), &limit)?;
         Ok(())
     }
 }

--- a/src/cgroups/v2/cpu.rs
+++ b/src/cgroups/v2/cpu.rs
@@ -33,7 +33,7 @@ impl Cpu {
             shares = Self::convert_shares_to_cgroup2(shares);
             if shares != 0 {
                 // will result in Erno 34 (numerical result out of range) otherwise
-                common::write_cgroup_file(&path.join(CGROUP_CPU_WEIGHT), &shares.to_string())?;
+                common::write_cgroup_file(path.join(CGROUP_CPU_WEIGHT), shares)?;
             }
         }
 
@@ -57,7 +57,7 @@ impl Cpu {
         // 250000 250000 -> 1 CPU worth of runtime every 250ms
         // 10000 50000 -> 20% of one CPU every 50ms
         let max = quota_string + " " + &period_string;
-        common::write_cgroup_file(&path.join(CGROUP_CPU_MAX), &max)?;
+        common::write_cgroup_file_str(path.join(CGROUP_CPU_MAX), &max)?;
 
         Ok(())
     }

--- a/src/cgroups/v2/cpuset.rs
+++ b/src/cgroups/v2/cpuset.rs
@@ -24,11 +24,11 @@ impl Controller for CpuSet {
 impl CpuSet {
     fn apply(path: &Path, cpuset: &LinuxCpu) -> Result<()> {
         if let Some(cpus) = &cpuset.cpus {
-            common::write_cgroup_file(&path.join(CGROUP_CPUSET_CPUS), cpus)?;
+            common::write_cgroup_file_str(path.join(CGROUP_CPUSET_CPUS), cpus)?;
         }
 
         if let Some(mems) = &cpuset.mems {
-            common::write_cgroup_file(&path.join(CGROUP_CPUSET_MEMS), mems)?;
+            common::write_cgroup_file_str(path.join(CGROUP_CPUSET_MEMS), mems)?;
         }
 
         Ok(())

--- a/src/cgroups/v2/manager.rs
+++ b/src/cgroups/v2/manager.rs
@@ -13,13 +13,12 @@ use super::{cpu::Cpu, cpuset::CpuSet, hugetlb::HugeTlb, io::Io, memory::Memory, 
 use crate::{
     cgroups::v2::controller::Controller,
     cgroups::{
-        common::{self, CgroupManager},
+        common::{self, CgroupManager, CGROUP_PROCS},
         v2::controller_type::ControllerType,
     },
     utils::PathBufExt,
 };
 
-const CGROUP_PROCS: &str = "cgroup.procs";
 const CGROUP_CONTROLLERS: &str = "cgroup.controllers";
 const CGROUP_SUBTREE_CONTROL: &str = "cgroup.subtree_control";
 
@@ -66,7 +65,7 @@ impl Manager {
             // if this were set, writing to the cgroups.procs file will fail with Erno 16 (device or resource busy)
             if components.peek().is_some() {
                 for controller in &controllers {
-                    common::write_cgroup_file(
+                    common::write_cgroup_file_str(
                         &current_path.join(CGROUP_SUBTREE_CONTROL),
                         controller,
                     )?;
@@ -74,7 +73,7 @@ impl Manager {
             }
         }
 
-        common::write_cgroup_file(&full_path.join(CGROUP_PROCS), &pid.to_string())?;
+        common::write_cgroup_file(&full_path.join(CGROUP_PROCS), pid)?;
         Ok(full_path)
     }
 


### PR DESCRIPTION
This implements the cpu and cpuset controller for cgroup v1 #9 . I also implemented @tsturzl suggestion from a previous PR to accept all types that implement ToString for write_cgroup_file. If you have already a String or &str you can use write_cgroup_file_str instead and avoid the String allocation. Lastly I noticed that cgroups are sometimes not cleaned up properly, so this hopefully improves the situation a bit.

