### PR TITLE
Added Integration test template

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,8 @@
+# Integration test
+
+## Usage
+Here is a preview implementation of the integration test.
+
+```
+$ cargo test --test integration
+```

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1,14 +1,16 @@
 use std::env;
 use std::process::{Command, Stdio};
+use std::path::PathBuf;
 
 #[test]
 fn main() {
-    let path_result = env::current_dir();
-    let path = match path_result {
-        Ok(path) => path.display().to_string(),
-        Err(_) => panic!("Path is not found"),
+    let current_dir_path_result = env::current_dir();
+    let current_dir_path = match current_dir_path_result {
+        Ok(path_buf) => path_buf,
+        Err(_) => panic!("directory is not found"),
     };
-    let status = Command::new(path + "/target/x86_64-unknown-linux-gnu/debug/youki")
+    let youki_path = current_dir_path.join(PathBuf::from("youki"));
+    let status = Command::new(youki_path)
         .stdout(Stdio::null())
         .arg("-h")
         .status()

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1,0 +1,17 @@
+use std::env;
+use std::process::{Command, Stdio};
+
+#[test]
+fn main() {
+    let path_result = env::current_dir();
+    let path = match path_result {
+        Ok(path) => path.display().to_string(),
+        Err(_) => panic!("Path is not found"),
+    };
+    let status = Command::new(path + "/target/x86_64-unknown-linux-gnu/debug/youki")
+        .stdout(Stdio::null())
+        .arg("-h")
+        .status()
+        .expect("failed to execute process");
+    assert!(status.success());
+}

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1,6 +1,6 @@
 use std::env;
-use std::process::{Command, Stdio};
 use std::path::PathBuf;
+use std::process::{Command, Stdio};
 
 #[test]
 fn main() {


### PR DESCRIPTION
I have added a template for future implementation of integration tests (#56) in rust.
To run it, use `cargo test --test integration`.

![Screenshot from 2021-06-06 22-36-07](https://user-images.githubusercontent.com/22878067/120926407-ac127c80-c717-11eb-83f4-ece81f53cd6c.png)
