### PR TITLE
Handle relative cgroup paths

### DIFF
--- a/integration_test.sh
+++ b/integration_test.sh
@@ -3,7 +3,12 @@
 root=$(pwd)
 cd integration_test/src/github.com/opencontainers/runtime-tools
 GOPATH=$root/integration_test make runtimetest validation-executables
-test_cases=("default/default.t" "linux_cgroups_devices/linux_cgroups_devices.t" "linux_cgroups_hugetlb/linux_cgroups_hugetlb.t" "linux_cgroups_pids/linux_cgroups_pids.t" "linux_cgroups_memory/linux_cgroups_memory.t" "linux_cgroups_network/linux_cgroups_network.t" "linux_cgroups_cpus/linux_cgroups_cpus.t")
+test_cases=("default/default.t" "linux_cgroups_devices/linux_cgroups_devices.t" "linux_cgroups_hugetlb/linux_cgroups_hugetlb.t" 
+"linux_cgroups_pids/linux_cgroups_pids.t" "linux_cgroups_memory/linux_cgroups_memory.t" "linux_cgroups_network/linux_cgroups_network.t" 
+"linux_cgroups_cpus/linux_cgroups_cpus.t" "linux_cgroups_relative_cpus/linux_cgroups_relative_cpus.t" 
+"linux_cgroups_relative_devices/linux_cgroups_relative_devices.t" "linux_cgroups_relative_hugetlb/linux_cgroups_relative_hugetlb.t" 
+"linux_cgroups_relative_memory/linux_cgroups_relative_memory.t" "linux_cgroups_relative_network/linux_cgroups_relative_network.t" 
+"linux_cgroups_relative_pids/linux_cgroups_relative_pids.t")
 for case in "${test_cases[@]}"; do
   echo "Running $case"
   if [ 0 -ne $(sudo RUST_BACKTRACE=1 YOUKI_LOG_LEVEL=debug RUNTIME=$root/youki $root/integration_test/src/github.com/opencontainers/runtime-tools/validation/$case | grep "not ok" | wc -l) ]; then

--- a/src/cgroups/v1/cpuset.rs
+++ b/src/cgroups/v1/cpuset.rs
@@ -18,12 +18,12 @@ impl Controller for CpuSet {
         log::debug!("Apply CpuSet cgroup config");
         fs::create_dir_all(cgroup_path)?;
 
+        Self::ensure_not_empty(cgroup_path, CGROUP_CPUSET_CPUS)?;
+        Self::ensure_not_empty(cgroup_path, CGROUP_CPUSET_MEMS)?;
+
         if let Some(cpuset) = &linux_resources.cpu {
             Self::apply(cgroup_path, cpuset)?;
         }
-
-        Self::ensure_not_empty(cgroup_path, CGROUP_CPUSET_CPUS)?;
-        Self::ensure_not_empty(cgroup_path, CGROUP_CPUSET_MEMS)?;
 
         common::write_cgroup_file(cgroup_path.join(CGROUP_PROCS), pid)?;
         Ok(())

--- a/src/cgroups/v1/manager.rs
+++ b/src/cgroups/v1/manager.rs
@@ -80,8 +80,10 @@ impl Manager {
             mount
                 .mount_point
                 .join_absolute_path(Path::new(&cgroup.pathname))?
-        } else {
+        } else if cgroup_path.is_absolute() {
             mount.mount_point.join_absolute_path(&cgroup_path)?
+        } else {
+            mount.mount_point.join(cgroup_path)
         };
 
         Ok(p)


### PR DESCRIPTION
This handles relative cgroup paths. Relative cgroup paths will be appended to the cgroup root, similar to absolute cgroup paths. Also handles a problem where cpuset parent values were not set, which lead to a permission denied error in the tests.