### PR TITLE
Add info command

### DIFF
--- a/src/cgroups/v1/controller_type.rs
+++ b/src/cgroups/v1/controller_type.rs
@@ -1,4 +1,4 @@
-use std::string::ToString;
+use std::fmt::Display;
 
 pub enum ControllerType {
     Cpu,
@@ -12,18 +12,32 @@ pub enum ControllerType {
     NetworkClassifier,
 }
 
-impl ToString for ControllerType {
-    fn to_string(&self) -> String {
-        match self {
-            Self::Cpu => "cpu".into(),
-            Self::CpuSet => "cpuset".into(),
-            Self::Devices => "devices".into(),
-            Self::HugeTlb => "hugetlb".into(),
-            Self::Pids => "pids".into(),
-            Self::Memory => "memory".into(),
-            Self::Blkio => "blkio".into(),
-            Self::NetworkPriority => "net_prio".into(),
-            Self::NetworkClassifier => "net_cls".into(),
-        }
+impl Display for ControllerType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let print = match *self {
+            Self::Cpu => "cpu",
+            Self::CpuSet => "cpuset",
+            Self::Devices => "devices",
+            Self::HugeTlb => "hugetlb",
+            Self::Pids => "pids",
+            Self::Memory => "memory",
+            Self::Blkio => "blkio",
+            Self::NetworkPriority => "net_prio",
+            Self::NetworkClassifier => "net_cls",
+        };
+
+        write!(f, "{}", print)
     }
 }
+
+pub const CONTROLLERS: &[ControllerType] = &[
+    ControllerType::Cpu,
+    ControllerType::CpuSet,
+    ControllerType::Devices,
+    ControllerType::HugeTlb,
+    ControllerType::Memory,
+    ControllerType::Pids,
+    ControllerType::Blkio,
+    ControllerType::NetworkPriority,
+    ControllerType::NetworkClassifier,
+];

--- a/src/cgroups/v1/cpuset.rs
+++ b/src/cgroups/v1/cpuset.rs
@@ -6,7 +6,7 @@ use oci_spec::{LinuxCpu, LinuxResources};
 
 use crate::cgroups::common::{self, CGROUP_PROCS};
 
-use super::{Controller, ControllerType};
+use super::{util, Controller, ControllerType};
 
 const CGROUP_CPUSET_CPUS: &str = "cpuset.cpus";
 const CGROUP_CPUSET_MEMS: &str = "cpuset.mems";
@@ -34,11 +34,11 @@ impl CpuSet {
     fn apply(cgroup_path: &Path, cpuset: &LinuxCpu) -> Result<()> {
         if let Some(cpus) = &cpuset.cpus {
             common::write_cgroup_file_str(cgroup_path.join(CGROUP_CPUSET_CPUS), cpus)?;
-        } 
+        }
 
         if let Some(mems) = &cpuset.mems {
             common::write_cgroup_file_str(cgroup_path.join(CGROUP_CPUSET_MEMS), mems)?;
-        } 
+        }
 
         Ok(())
     }
@@ -46,7 +46,7 @@ impl CpuSet {
     // if a task is moved into the cgroup and a value has not been set for cpus and mems
     // Errno 28 (no space left on device) will be returned. Therefore we set the value from the parent if required.
     fn ensure_not_empty(cgroup_path: &Path, interface_file: &str) -> Result<()> {
-        let mut current = common::get_cgroupv1_mount_path(&ControllerType::CpuSet.to_string())?;
+        let mut current = util::get_subsystem_mount_points(&ControllerType::CpuSet.to_string())?;
         let relative_cgroup_path = cgroup_path.strip_prefix(&current)?;
 
         for component in relative_cgroup_path.components() {

--- a/src/cgroups/v1/mod.rs
+++ b/src/cgroups/v1/mod.rs
@@ -10,6 +10,7 @@ mod memory;
 mod network_classifier;
 mod network_priority;
 mod pids;
+pub mod util;
 pub use controller::Controller;
 pub use controller_type::ControllerType;
 pub use manager::Manager;

--- a/src/cgroups/v1/util.rs
+++ b/src/cgroups/v1/util.rs
@@ -1,0 +1,48 @@
+use std::{collections::HashMap, path::PathBuf};
+
+use anyhow::{anyhow, Result};
+use procfs::process::Process;
+
+use super::controller_type::CONTROLLERS;
+
+pub fn list_subsystem_mount_points() -> Result<HashMap<String, PathBuf>> {
+    let mut mount_paths = HashMap::with_capacity(CONTROLLERS.len());
+
+    for controller in CONTROLLERS {
+        if let Ok(mount_point) = get_subsystem_mount_points(&controller.to_string()) {
+            mount_paths.insert(controller.to_string(), mount_point);
+        }
+    }
+
+    Ok(mount_paths)
+}
+
+pub fn get_subsystem_mount_points(subsystem: &str) -> Result<PathBuf> {
+    Process::myself()?
+        .mountinfo()?
+        .into_iter()
+        .find(|m| {
+            if m.fs_type == "cgroup" {
+                // Some systems mount net_prio and net_cls in the same directory
+                // other systems mount them in their own diretories. This
+                // should handle both cases.
+                if subsystem == "net_cls" {
+                    return m.mount_point.ends_with("net_cls,net_prio")
+                        || m.mount_point.ends_with("net_prio,net_cls")
+                        || m.mount_point.ends_with("net_cls");
+                } else if subsystem == "net_prio" {
+                    return m.mount_point.ends_with("net_cls,net_prio")
+                        || m.mount_point.ends_with("net_prio,net_cls")
+                        || m.mount_point.ends_with("net_prio");
+                }
+
+                if subsystem == "cpu" {
+                    return m.mount_point.ends_with("cpu,cpuacct")
+                        || m.mount_point.ends_with("cpu");
+                }
+            }
+            m.mount_point.ends_with(&subsystem)
+        })
+        .map(|m| m.mount_point)
+        .ok_or_else(|| anyhow!("could not find mountpoint for {}", subsystem))
+}

--- a/src/cgroups/v2/mod.rs
+++ b/src/cgroups/v2/mod.rs
@@ -7,3 +7,4 @@ mod io;
 pub mod manager;
 mod memory;
 mod pids;
+pub mod util;

--- a/src/cgroups/v2/util.rs
+++ b/src/cgroups/v2/util.rs
@@ -1,0 +1,13 @@
+use std::path::PathBuf;
+
+use anyhow::{anyhow, Result};
+use procfs::process::Process;
+
+pub fn get_unified_mount_point() -> Result<PathBuf> {
+    Process::myself()?
+        .mountinfo()?
+        .into_iter()
+        .find(|m| m.fs_type == "cgroup2")
+        .map(|m| m.mount_point)
+        .ok_or_else(|| anyhow!("could not find mountpoint for unified"))
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@
 //! Container Runtime written in Rust, inspired by [railcar](https://github.com/oracle/railcar)
 //! This crate provides a container runtime which can be used by a high-level container runtime to run containers.
 
+use procfs;
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -66,6 +67,8 @@ enum SubCommand {
     Delete(Delete),
     #[clap(version = "0.0.1", author = "utam0k <k0ma@utam0k.jp>")]
     State(StateArgs),
+    #[clap(version = "0.0.1", author = "utam0k <k0ma@utam0k.jp>")]
+    Info,
 }
 
 /// This is the entry point in the container runtime. The binary is run by a high-level container runtime,
@@ -161,6 +164,47 @@ fn main() -> Result<()> {
             let container = Container::load(container_root)?.refresh_status()?;
             println!("{}", serde_json::to_string_pretty(&container.state)?);
             std::process::exit(0);
+        }
+
+        SubCommand::Info => {
+            let uname = nix::sys::utsname::uname();
+            println!("{:<18}{}", "Kernel-Release", uname.release());
+            println!("{:<18}{}", "Kernel-Version", uname.version());
+            println!("{:<18}{}", "Architecture", uname.machine());
+
+            let cpu_info = procfs::CpuInfo::new()?;
+            println!("{:<18}{}", "Cores", cpu_info.num_cores());
+            let mem_info = procfs::Meminfo::new()?;
+            println!(
+                "{:<18}{}",
+                "Total Memory",
+                mem_info.mem_total / u64::pow(1024, 2)
+            );
+
+            let cgroup_fs: Vec<String> = cgroups::common::get_supported_cgroup_fs()?
+                .into_iter()
+                .map(|c| c.to_string())
+                .collect();
+            println!("{:<18}{}", "cgroup version", cgroup_fs.join(" and "));
+
+            println!("cgroup mounts");
+            let mut cgroup_v1_mounts: Vec<String> =
+                cgroups::v1::util::list_subsystem_mount_points()?
+                    .iter()
+                    .map(|kv| format!("  {:<16}{:?}", kv.0, kv.1))
+                    .collect();
+
+            cgroup_v1_mounts.sort();
+            for cgroup_mount in cgroup_v1_mounts {
+                println!("{}", cgroup_mount);
+            }
+
+            let unified = cgroups::v2::util::get_unified_mount_point();
+            if let Ok(mount_point) = unified {
+                println!("  {:<16}{:?}", "unified", mount_point);
+            }
+
+            Ok(())
         }
     }
 }


### PR DESCRIPTION
It would be useful to have a command that people can call when they are reporting problems that displays diagnostic information. `youki info `


```
Kernel-Release    5.8.0-55-generic
Kernel-Version    #62~20.04.1-Ubuntu SMP Wed Jun 2 08:55:04 UTC 2021
Architecture      x86_64
Cores             4
Total Memory      5890
cgroup version    v1 and v2
cgroup mounts
  blkio           "/sys/fs/cgroup/blkio"
  cpu             "/sys/fs/cgroup/cpu,cpuacct"
  cpuset          "/sys/fs/cgroup/cpuset"
  devices         "/sys/fs/cgroup/devices"
  hugetlb         "/sys/fs/cgroup/hugetlb"
  memory          "/sys/fs/cgroup/memory"
  net_cls         "/sys/fs/cgroup/net_cls,net_prio"
  net_prio        "/sys/fs/cgroup/net_cls,net_prio"
  pids            "/sys/fs/cgroup/pids"
  unified         "/sys/fs/cgroup/unified"
```
Feel free to suggest additional items that should be included.