### PR TITLE
Provide better error messages

### DIFF
--- a/src/cgroups/common.rs
+++ b/src/cgroups/common.rs
@@ -6,7 +6,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use anyhow::{anyhow, bail, Result};
+use anyhow::{anyhow, bail, Context, Result};
 use nix::unistd::Pid;
 use oci_spec::LinuxResources;
 use procfs::process::Process;
@@ -45,8 +45,10 @@ pub fn write_cgroup_file_str<P: AsRef<Path>>(path: P, data: &str) -> Result<()> 
         .create(false)
         .write(true)
         .truncate(false)
-        .open(path)?
-        .write_all(data.as_bytes())?;
+        .open(path.as_ref())
+        .with_context(|| format!("failed to open {:?}", path.as_ref()))?
+        .write_all(data.as_bytes())
+        .with_context(|| format!("failed to write to {:?}", path.as_ref()))?;
 
     Ok(())
 }
@@ -57,8 +59,10 @@ pub fn write_cgroup_file<P: AsRef<Path>, T: ToString>(path: P, data: T) -> Resul
         .create(false)
         .write(true)
         .truncate(false)
-        .open(path)?
-        .write_all(data.to_string().as_bytes())?;
+        .open(path.as_ref())
+        .with_context(|| format!("failed to open {:?}", path.as_ref()))?
+        .write_all(data.to_string().as_bytes())
+        .with_context(|| format!("failed to write to {:?}", path.as_ref()))?;
 
     Ok(())
 }


### PR DESCRIPTION
This adds the file name to the error message when we cannot write to a cgroup file.
Before: 
`No such file or directory (os error 2)`

After:
```
failed to open "/sys/fs/cgroup/blkio/docker/9d96321423f09dffdf2a9559971408d29c984bfb17746589ee83670f5da06f70/foo"

Caused by:
    No such file or directory (os error 2)
```