### PR TITLE
Extend info cmd with version and os

### DIFF
--- a/src/info.rs
+++ b/src/info.rs
@@ -1,0 +1,104 @@
+use procfs::{CpuInfo, Meminfo};
+use std::{fs, path::Path};
+
+use crate::cgroups;
+
+pub fn print_youki() {
+    println!("{:<18}{}", "Version", env!("CARGO_PKG_VERSION"));
+}
+
+pub fn print_kernel() {
+    let uname = nix::sys::utsname::uname();
+    println!("{:<18}{}", "Kernel-Release", uname.release());
+    println!("{:<18}{}", "Kernel-Version", uname.version());
+    println!("{:<18}{}", "Architecture", uname.machine());
+}
+
+// see https://www.freedesktop.org/software/systemd/man/os-release.html
+pub fn print_os() {
+    if let Some(os) = try_read_os_from("/etc/os-release") {
+        println!("{:<18}{}", "Operating System", os);
+    } else if let Some(os) = try_read_os_from("/usr/lib/os-release") {
+        println!("{:<18}{}", "Operating System", os);
+    }
+}
+
+fn try_read_os_from<P: AsRef<Path>>(path: P) -> Option<String> {
+    let os_release = path.as_ref();
+    if !os_release.exists() {
+        return None;
+    }
+
+    if let Ok(release_content) = fs::read_to_string(path) {
+        let pretty = find_parameter(&release_content, "PRETTY_NAME");
+
+        if let Some(pretty) = pretty {
+            return Some(pretty.trim_matches('"').to_owned());
+        }
+
+        let name = find_parameter(&release_content, "NAME");
+        let version = find_parameter(&release_content, "VERSION");
+
+        if let (Some(name), Some(version)) = (name, version) {
+            return Some(format!(
+                "{} {}",
+                name.trim_matches('"'),
+                version.trim_matches('"')
+            ));
+        }
+    }
+
+    None
+}
+
+fn find_parameter<'a>(content: &'a str, param_name: &str) -> Option<&'a str> {
+    let param_value = content
+        .lines()
+        .find(|l| l.starts_with(param_name))
+        .map(|l| l.split_terminator('=').last());
+
+    if let Some(Some(value)) = param_value {
+        return Some(value);
+    }
+
+    None
+}
+
+pub fn print_hardware() {
+    if let Ok(cpu_info) = CpuInfo::new() {
+        println!("{:<18}{}", "Cores", cpu_info.num_cores());
+    }
+
+    if let Ok(mem_info) = Meminfo::new() {
+        println!(
+            "{:<18}{}",
+            "Total Memory",
+            mem_info.mem_total / u64::pow(1024, 2)
+        );
+    }
+}
+
+pub fn print_cgroups() {
+    if let Ok(cgroup_fs) = cgroups::common::get_supported_cgroup_fs() {
+        let cgroup_fs: Vec<String> = cgroup_fs.into_iter().map(|c| c.to_string()).collect();
+        println!("{:<18}{}", "cgroup version", cgroup_fs.join(" and "));
+    }
+
+    println!("cgroup mounts");
+    if let Ok(v1_mounts) = cgroups::v1::util::list_subsystem_mount_points() {
+        let mut v1_mounts: Vec<String> = v1_mounts
+            .iter()
+            .map(|kv| format!("  {:<16}{}", kv.0, kv.1.display()))
+            .collect();
+
+        v1_mounts.sort();
+        for cgroup_mount in v1_mounts {
+            println!("{}", cgroup_mount);
+        }
+    }
+
+    let unified = cgroups::v2::util::get_unified_mount_point();
+    if let Ok(mount_point) = unified {
+        println!("  {:<16}{}", "unified", mount_point.display());
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ pub mod cgroups;
 pub mod command;
 pub mod container;
 pub mod create;
+pub mod info;
 pub mod logger;
 pub mod namespaces;
 pub mod notify_socket;


### PR DESCRIPTION
This extends the info command with youki's version and the operating system it is running on. It also now tries to write as much information as possible instead of bailing out at the first error.

```
Version           0.0.1
Kernel-Release    5.8.0-55-generic
Kernel-Version    #62~20.04.1-Ubuntu SMP Wed Jun 2 08:55:04 UTC 2021
Architecture      x86_64
Operating System  Ubuntu 20.04.2 LTS
Cores             4
Total Memory      5890
cgroup version    v1 and v2
cgroup mounts
  blkio           /sys/fs/cgroup/blkio
  cpu             /sys/fs/cgroup/cpu,cpuacct
  cpuacct         /sys/fs/cgroup/cpu,cpuacct
  cpuset          /sys/fs/cgroup/cpuset
  devices         /sys/fs/cgroup/devices
  freezer         /sys/fs/cgroup/freezer
  hugetlb         /sys/fs/cgroup/hugetlb
  memory          /sys/fs/cgroup/memory
  net_cls         /sys/fs/cgroup/net_cls,net_prio
  net_prio        /sys/fs/cgroup/net_cls,net_prio
  pids            /sys/fs/cgroup/pids
  unified         /sys/fs/cgroup/unified
```
