### PR TITLE
Add unit tests for tty module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -325,6 +325,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "instant"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61124eeebbd69b8190558df225adf7e4caafce0d743919e5d6b19652314ec5ec"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "itoa"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -341,6 +350,15 @@ name = "libc"
 version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "789da6d93f1b866ffe175afc5322a4d76c038605a1c3319bb57b06967ca98a36"
+
+[[package]]
+name = "lock_api"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0382880606dff6d15c9476c416d18690b72742aa7b605bb6dd6ec9030fbf07eb"
+dependencies = [
+ "scopeguard",
+]
 
 [[package]]
 name = "log"
@@ -486,6 +504,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "afb2e1c3ee07430c2cf76151675e583e0f19985fa6efae47d6848a3e2c824f85"
 
 [[package]]
+name = "parking_lot"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d7744ac029df22dca6284efe4e898991d28e3085c706c972bcd7da4a27a15eb"
+dependencies = [
+ "instant",
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7a782938e745763fe6907fc6ba86946d72f49fe7e21de074e08128a99fb018"
+dependencies = [
+ "cfg-if",
+ "instant",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "winapi",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -606,6 +649,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ab49abadf3f9e1c4bc499e8845e152ad87d2ad2d30371841171169e9d75feee"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "regex"
 version = "1.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -627,6 +679,12 @@ name = "ryu"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
+
+[[package]]
+name = "scopeguard"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "serde"
@@ -660,10 +718,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "serial_test"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0bccbcf40c8938196944a3da0e133e031a33f4d6b72db3bda3cc556e361905d"
+dependencies = [
+ "lazy_static",
+ "parking_lot",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2acd6defeddb41eb60bb468f8825d0cfd0c2a76bc03bfd235b6a1dc4f6a1ad5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f173ac3d1a7e3b28003f40de0b5ce7fe2710f9b9dc3fc38664cebee46b3b6527"
+
+[[package]]
+name = "smallvec"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e"
 
 [[package]]
 name = "strsim"
@@ -818,4 +904,5 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
+ "serial_test",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,3 +26,4 @@ oci_spec = { version = "0.1.0", path = "./oci_spec" }
 [dev-dependencies]
 oci_spec = { version = "0.1.0", path = "./oci_spec", features = ["proptests"] }
 quickcheck = "1"
+serial_test = "0.5.1"

--- a/src/cgroups/test.rs
+++ b/src/cgroups/test.rs
@@ -2,58 +2,14 @@
 
 use anyhow::Result;
 use std::{
-    fs,
-    io::Write,
-    ops::Deref,
+    io::Write,    
     path::{Path, PathBuf},
 };
 
 use oci_spec::LinuxCpu;
 
-pub struct TempDir {
-    path: Option<PathBuf>,
-}
+use crate::utils::{create_temp_dir, TempDir}; 
 
-impl TempDir {
-    pub fn new<P: Into<PathBuf>>(path: P) -> Result<Self> {
-        let p = path.into();
-        std::fs::create_dir_all(&p)?;
-        Ok(Self { path: Some(p) })
-    }
-
-    pub fn path(&self) -> &Path {
-        self.path
-            .as_ref()
-            .expect("temp dir has already been removed")
-    }
-
-    pub fn remove(&mut self) {
-        if let Some(p) = &self.path {
-            let _ = fs::remove_dir_all(p);
-            self.path = None;
-        }
-    }
-}
-
-impl Drop for TempDir {
-    fn drop(&mut self) {
-        self.remove();
-    }
-}
-
-impl AsRef<Path> for TempDir {
-    fn as_ref(&self) -> &Path {
-        self.path()
-    }
-}
-
-impl Deref for TempDir {
-    type Target = Path;
-
-    fn deref(&self) -> &Self::Target {
-        self.path()
-    }
-}
 
 pub fn setup(testname: &str, cgroup_file: &str) -> (TempDir, PathBuf) {
     let tmp = create_temp_dir(testname).expect("create temp directory for test");
@@ -74,11 +30,6 @@ pub fn set_fixture(temp_dir: &Path, filename: &str, val: &str) -> Result<PathBuf
         .write_all(val.as_bytes())?;
 
     Ok(full_path)
-}
-
-pub fn create_temp_dir(test_name: &str) -> Result<TempDir> {
-    let dir = TempDir::new(std::env::temp_dir().join(test_name))?;
-    Ok(dir)
 }
 
 pub struct LinuxCpuBuilder {

--- a/src/cgroups/v1/devices.rs
+++ b/src/cgroups/v1/devices.rs
@@ -98,7 +98,8 @@ impl Devices {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::cgroups::test::{create_temp_dir, set_fixture};
+    use crate::cgroups::test::set_fixture;
+    use crate::utils::create_temp_dir;
     use oci_spec::{LinuxDeviceCgroup, LinuxDeviceType};
     use std::fs::read_to_string;
 

--- a/src/cgroups/v1/freezer.rs
+++ b/src/cgroups/v1/freezer.rs
@@ -116,7 +116,8 @@ impl Freezer {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::cgroups::test::{create_temp_dir, set_fixture};
+    use crate::cgroups::test::set_fixture;
+    use crate::utils::create_temp_dir; 
     use oci_spec::FreezerState;
 
     #[test]

--- a/src/cgroups/v1/hugetlb.rs
+++ b/src/cgroups/v1/hugetlb.rs
@@ -58,7 +58,8 @@ impl Hugetlb {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::cgroups::test::{create_temp_dir, set_fixture};
+    use crate::cgroups::test::set_fixture;
+    use crate::utils::create_temp_dir; 
     use oci_spec::LinuxHugepageLimit;
     use std::fs::read_to_string;
 

--- a/src/cgroups/v1/memory.rs
+++ b/src/cgroups/v1/memory.rs
@@ -239,7 +239,8 @@ impl Memory {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::cgroups::test::{create_temp_dir, set_fixture};
+    use crate::cgroups::test::set_fixture;
+    use crate::utils::create_temp_dir; 
     use oci_spec::LinuxMemory;
 
     #[test]

--- a/src/cgroups/v1/network_classifier.rs
+++ b/src/cgroups/v1/network_classifier.rs
@@ -36,8 +36,8 @@ impl NetworkClassifier {
 
 #[cfg(test)]
 mod tests {
-    use crate::cgroups::test::{create_temp_dir, set_fixture};
-
+    use crate::cgroups::test::set_fixture;
+    use crate::utils::create_temp_dir;
     use super::*;
 
     #[test]

--- a/src/cgroups/v1/network_priority.rs
+++ b/src/cgroups/v1/network_priority.rs
@@ -36,7 +36,8 @@ impl NetworkPriority {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::cgroups::test::{create_temp_dir, set_fixture};
+    use crate::cgroups::test::set_fixture;
+    use crate::utils::create_temp_dir;
     use oci_spec::LinuxInterfacePriority;
 
     #[test]

--- a/src/cgroups/v1/pids.rs
+++ b/src/cgroups/v1/pids.rs
@@ -46,8 +46,8 @@ impl Pids {
 
 #[cfg(test)]
 mod tests {
-    use crate::cgroups::test::{create_temp_dir, set_fixture};
-
+    use crate::cgroups::test::set_fixture;
+    use crate::utils::create_temp_dir;
     use super::*;
     use oci_spec::LinuxPids;
 

--- a/src/cgroups/v2/cpu.rs
+++ b/src/cgroups/v2/cpu.rs
@@ -86,7 +86,8 @@ impl Cpu {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::cgroups::test::{create_temp_dir, set_fixture, setup, LinuxCpuBuilder};
+    use crate::cgroups::test::{set_fixture, setup, LinuxCpuBuilder};
+    use crate::utils::create_temp_dir;
     use std::fs;
 
     #[test]

--- a/src/tty.rs
+++ b/src/tty.rs
@@ -68,3 +68,79 @@ pub fn setup_console(console_fd: FileDescriptor) -> Result<()> {
     close(console_fd.as_raw_fd())?;
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    
+    use std::env;
+    use std::fs::{self, File};
+    use std::os::unix::net::UnixListener;
+    use std::path::PathBuf;
+
+    use serial_test::serial;
+    
+    use crate::utils::{create_temp_dir, TempDir};
+
+    
+    fn setup(testname: &str) -> Result<(TempDir, PathBuf, PathBuf)> {
+        let testdir = create_temp_dir(testname)?;
+        let rundir_path = Path::join(&testdir, "run");
+        let _ = fs::create_dir(&rundir_path)?;
+        let socket_path = Path::new(&rundir_path).join("socket");
+        let _ = File::create(&socket_path);
+        env::set_current_dir(&testdir)?;
+        Ok((testdir, rundir_path, socket_path))
+    }
+
+
+    #[test]
+    #[serial]
+    fn test_setup_console_socket() {
+        let init =  setup("test_setup_console_socket");
+        assert!(init.is_ok());
+        let (testdir, rundir_path, socket_path) = init.unwrap();
+        let lis = UnixListener::bind(Path::join(&testdir, "console-socket"));
+        assert!(lis.is_ok());
+        let fd = setup_console_socket(&&rundir_path, &socket_path);
+        assert!(fd.is_ok());
+        assert_ne!(fd.unwrap().as_raw_fd(), -1);
+    }
+
+    #[test]
+    #[serial]
+    fn test_setup_console_socket_empty() {
+        let init =  setup("test_setup_console_socket_empty");
+        assert!(init.is_ok());
+        let (_testdir, rundir_path, socket_path) = init.unwrap();
+        let fd = setup_console_socket(&rundir_path, &socket_path);
+        assert!(fd.is_ok());
+        assert_eq!(fd.unwrap().as_raw_fd(), -1);
+    }
+
+    #[test]
+    #[serial]
+    fn test_setup_console_socket_invalid() {
+        let init =  setup("test_setup_console_socket_invalid");
+        assert!(init.is_ok());
+        let (testdir, rundir_path, socket_path) = init.unwrap();
+        let _socket = File::create(Path::join(&testdir, "console-socket"));
+        assert!(_socket.is_ok());
+        let fd = setup_console_socket(&rundir_path, &socket_path);
+        assert!(fd.is_err());
+    }
+
+    #[test]
+    #[serial]
+    fn test_setup_console() {
+        let init =  setup("test_setup_console");
+        assert!(init.is_ok());
+        let (testdir, rundir_path, socket_path) = init.unwrap();
+        let lis = UnixListener::bind(Path::join(&testdir, "console-socket"));
+        assert!(lis.is_ok());
+        let fd = setup_console_socket(&&rundir_path, &socket_path);
+        let status = setup_console(fd.unwrap());
+        assert!(status.is_ok());
+    }  
+}
+

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -3,6 +3,7 @@
 use std::env;
 use std::ffi::CString;
 use std::fs;
+use std::ops::Deref;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
@@ -93,6 +94,56 @@ pub fn write_file<P: AsRef<Path>, C: AsRef<[u8]>>(path: P, contents: C) -> Resul
     let path = path.as_ref();
     fs::write(path, contents).with_context(|| format!("failed to write to {:?}", path))?;
     Ok(())
+}
+
+pub struct TempDir {
+    path: Option<PathBuf>,
+}
+
+impl TempDir {
+    pub fn new<P: Into<PathBuf>>(path: P) -> Result<Self> {
+        let p = path.into();
+        std::fs::create_dir_all(&p)?;
+        Ok(Self { path: Some(p) })
+    }
+
+    pub fn path(&self) -> &Path {
+        self.path
+            .as_ref()
+            .expect("temp dir has already been removed")
+    }
+
+    pub fn remove(&mut self) {
+        if let Some(p) = &self.path {
+            let _ = fs::remove_dir_all(p);
+            self.path = None;
+        }
+    }
+}
+
+impl Drop for TempDir {
+    fn drop(&mut self) {
+        self.remove();
+    }
+}
+
+impl AsRef<Path> for TempDir {
+    fn as_ref(&self) -> &Path {
+        self.path()
+    }
+}
+
+impl Deref for TempDir {
+    type Target = Path;
+
+    fn deref(&self) -> &Self::Target {
+        self.path()
+    }
+}
+
+pub fn create_temp_dir(test_name: &str) -> Result<TempDir> {
+    let dir = TempDir::new(std::env::temp_dir().join(test_name))?;
+    Ok(dir)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This PR addresses part of https://github.com/containers/youki/issues/8, by adding unit tests for the tty module.
It adds two dev-dependencies, tempfile for easing the creation of temporary directories and serial_test to force the tests to execute in serial, since we require setting the current working directory to the testdir for each test, since console-socket is expected to be in this current working directory