### PR TITLE
Seperate adding tasks to cgroups and applying resource restrictions

### DIFF
--- a/src/cgroups/common.rs
+++ b/src/cgroups/common.rs
@@ -19,7 +19,8 @@ pub const CGROUP_PROCS: &str = "cgroup.procs";
 pub const DEFAULT_CGROUP_ROOT: &str = "/sys/fs/cgroup";
 
 pub trait CgroupManager {
-    fn apply(&self, linux_resources: &LinuxResources, pid: Pid) -> Result<()>;
+    fn add_task(&self, pid: Pid) -> Result<()>;
+    fn apply(&self, linux_resources: &LinuxResources) -> Result<()>;
     fn remove(&self) -> Result<()>;
 }
 

--- a/src/cgroups/common.rs
+++ b/src/cgroups/common.rs
@@ -19,8 +19,11 @@ pub const CGROUP_PROCS: &str = "cgroup.procs";
 pub const DEFAULT_CGROUP_ROOT: &str = "/sys/fs/cgroup";
 
 pub trait CgroupManager {
+    /// Adds a task specified by its pid to the cgroup
     fn add_task(&self, pid: Pid) -> Result<()>;
+    /// Applies resource restrictions to the cgroup
     fn apply(&self, linux_resources: &LinuxResources) -> Result<()>;
+    /// Removes the cgroup
     fn remove(&self) -> Result<()>;
 }
 

--- a/src/cgroups/v1/controller.rs
+++ b/src/cgroups/v1/controller.rs
@@ -1,10 +1,18 @@
-use std::path::Path;
+use std::{fs, path::Path};
 
 use anyhow::Result;
 use nix::unistd::Pid;
 
 use oci_spec::LinuxResources;
 
+use crate::cgroups::common::{self, CGROUP_PROCS};
+
 pub trait Controller {
-    fn apply(linux_resources: &LinuxResources, cgroup_root: &Path, pid: Pid) -> Result<()>;
+    fn add_task(pid: Pid, cgroup_path: &Path) -> Result<()> {
+        fs::create_dir_all(cgroup_path)?;
+        common::write_cgroup_file(cgroup_path.join(CGROUP_PROCS), pid)?;
+        Ok(())
+    }
+
+    fn apply(linux_resources: &LinuxResources, cgroup_root: &Path) -> Result<()>;
 }

--- a/src/cgroups/v1/controller_type.rs
+++ b/src/cgroups/v1/controller_type.rs
@@ -1,5 +1,6 @@
 use std::fmt::Display;
 
+#[derive(Hash, PartialEq, Eq, Debug, Clone)]
 pub enum ControllerType {
     Cpu,
     CpuAcct,

--- a/src/cgroups/v1/cpu.rs
+++ b/src/cgroups/v1/cpu.rs
@@ -1,10 +1,9 @@
-use std::{fs, path::Path};
+use std::path::Path;
 
 use anyhow::Result;
-use nix::unistd::Pid;
 use oci_spec::{LinuxCpu, LinuxResources};
 
-use crate::cgroups::common::{self, CGROUP_PROCS};
+use crate::cgroups::common;
 
 use super::Controller;
 
@@ -17,14 +16,13 @@ const CGROUP_CPU_RT_PERIOD: &str = "cpu.rt_period_us";
 pub struct Cpu {}
 
 impl Controller for Cpu {
-    fn apply(linux_resources: &LinuxResources, cgroup_root: &Path, pid: Pid) -> Result<()> {
+    fn apply(linux_resources: &LinuxResources, cgroup_root: &Path) -> Result<()> {
         log::debug!("Apply Cpu cgroup config");
-        fs::create_dir_all(cgroup_root)?;
+
         if let Some(cpu) = &linux_resources.cpu {
             Self::apply(cgroup_root, cpu)?;
         }
 
-        common::write_cgroup_file(cgroup_root.join(CGROUP_PROCS), pid)?;
         Ok(())
     }
 }

--- a/src/cgroups/v1/cpuacct.rs
+++ b/src/cgroups/v1/cpuacct.rs
@@ -1,37 +1,33 @@
-use std::{fs, path::Path};
+use std::path::Path;
 
 use anyhow::Result;
-use nix::unistd::Pid;
 use oci_spec::LinuxResources;
-
-use crate::cgroups::common::{self, CGROUP_PROCS};
 
 use super::Controller;
 
 pub struct CpuAcct {}
 
 impl Controller for CpuAcct {
-    fn apply(_linux_resources: &LinuxResources, cgroup_path: &Path, pid: Pid) -> Result<()> {
-        log::debug!("Apply cpuacct cgroup config");
-        fs::create_dir_all(cgroup_path)?;
-
-        common::write_cgroup_file(cgroup_path.join(CGROUP_PROCS), pid)?;
+    fn apply(_linux_resources: &LinuxResources, _cgroup_path: &Path) -> Result<()> {
         Ok(())
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use std::fs;
+
+    use nix::unistd::Pid;
+
     use super::*;
-    use crate::cgroups::test::setup;
+    use crate::cgroups::{common::CGROUP_PROCS, test::setup};
 
     #[test]
-    fn test_apply() {
+    fn test_add_task() {
         let (tmp, procs) = setup("test_cpuacct_apply", CGROUP_PROCS);
-        let resource = LinuxResources::default();
         let pid = Pid::from_raw(1000);
 
-        CpuAcct::apply(&resource, &tmp, pid).expect("apply cpuacct");
+        CpuAcct::add_task(pid, &tmp).expect("apply cpuacct");
 
         let content = fs::read_to_string(&procs)
             .unwrap_or_else(|_| panic!("read {} file content", CGROUP_PROCS));

--- a/src/cgroups/v1/devices.rs
+++ b/src/cgroups/v1/devices.rs
@@ -1,18 +1,16 @@
-use std::{fs::create_dir_all, path::Path};
+use std::path::Path;
 
 use anyhow::Result;
-use nix::unistd::Pid;
 
-use crate::cgroups::common::{self, CGROUP_PROCS};
+use crate::cgroups::common;
 use crate::{cgroups::v1::Controller, rootfs::default_devices};
 use oci_spec::{LinuxDeviceCgroup, LinuxDeviceType, LinuxResources};
 
 pub struct Devices {}
 
 impl Controller for Devices {
-    fn apply(linux_resources: &LinuxResources, cgroup_root: &Path, pid: Pid) -> Result<()> {
+    fn apply(linux_resources: &LinuxResources, cgroup_root: &Path) -> Result<()> {
         log::debug!("Apply Devices cgroup config");
-        create_dir_all(&cgroup_root)?;
 
         for d in &linux_resources.devices {
             Self::apply_device(d, cgroup_root)?;
@@ -27,7 +25,6 @@ impl Controller for Devices {
             Self::apply_device(&d, &cgroup_root)?;
         }
 
-        common::write_cgroup_file(cgroup_root.join(CGROUP_PROCS), pid)?;
         Ok(())
     }
 }

--- a/src/cgroups/v1/manager.rs
+++ b/src/cgroups/v1/manager.rs
@@ -24,6 +24,7 @@ pub struct Manager {
 }
 
 impl Manager {
+    /// Constructs a new cgroup manager with cgroups_path being relative to the root of the subsystem
     pub fn new(cgroup_path: PathBuf) -> Result<Self> {
         let mut subsystems = HashMap::<CtrlType, PathBuf>::new();
         for subsystem in CONTROLLERS {

--- a/src/cgroups/v1/manager.rs
+++ b/src/cgroups/v1/manager.rs
@@ -7,7 +7,7 @@ use nix::unistd::Pid;
 
 use procfs::process::Process;
 
-use super::ControllerType;
+use super::ControllerType as CtrlType;
 use super::{
     blkio::Blkio, controller_type::CONTROLLERS, cpu::Cpu, cpuacct::CpuAcct, cpuset::CpuSet,
     devices::Devices, freezer::Freezer, hugetlb::Hugetlb, memory::Memory,
@@ -20,12 +20,12 @@ use crate::utils;
 use crate::{cgroups::common::CgroupManager, utils::PathBufExt};
 use oci_spec::LinuxResources;
 pub struct Manager {
-    subsystems: HashMap<ControllerType, PathBuf>,
+    subsystems: HashMap<CtrlType, PathBuf>,
 }
 
 impl Manager {
     pub fn new(cgroup_path: PathBuf) -> Result<Self> {
-        let mut subsystems = HashMap::<ControllerType, PathBuf>::new();
+        let mut subsystems = HashMap::<CtrlType, PathBuf>::new();
         for subsystem in CONTROLLERS {
             subsystems.insert(
                 subsystem.clone(),
@@ -62,16 +62,16 @@ impl CgroupManager for Manager {
     fn add_task(&self, pid: Pid) -> Result<()> {
         for subsys in &self.subsystems {
             match subsys.0 {
-                ControllerType::Cpu => Cpu::add_task(pid, subsys.1)?,
-                ControllerType::CpuAcct => CpuAcct::add_task(pid, subsys.1)?,
-                ControllerType::CpuSet => CpuSet::add_task(pid, subsys.1)?,
-                ControllerType::Devices => Devices::add_task(pid, subsys.1)?,
-                ControllerType::HugeTlb => Hugetlb::add_task(pid, subsys.1)?,
-                ControllerType::Memory => Memory::add_task(pid, subsys.1)?,
-                ControllerType::Pids => Pids::add_task(pid, subsys.1)?,
-                ControllerType::Blkio => Blkio::add_task(pid, subsys.1)?,
-                ControllerType::NetworkPriority => NetworkPriority::add_task(pid, subsys.1)?,
-                ControllerType::NetworkClassifier => NetworkClassifier::add_task(pid, subsys.1)?,
+                CtrlType::Cpu => Cpu::add_task(pid, subsys.1)?,
+                CtrlType::CpuAcct => CpuAcct::add_task(pid, subsys.1)?,
+                CtrlType::CpuSet => CpuSet::add_task(pid, subsys.1)?,
+                CtrlType::Devices => Devices::add_task(pid, subsys.1)?,
+                CtrlType::HugeTlb => Hugetlb::add_task(pid, subsys.1)?,
+                CtrlType::Memory => Memory::add_task(pid, subsys.1)?,
+                CtrlType::Pids => Pids::add_task(pid, subsys.1)?,
+                CtrlType::Blkio => Blkio::add_task(pid, subsys.1)?,
+                CtrlType::NetworkPriority => NetworkPriority::add_task(pid, subsys.1)?,
+                CtrlType::NetworkClassifier => NetworkClassifier::add_task(pid, subsys.1)?,
                 _ => continue,
             }
         }
@@ -82,21 +82,19 @@ impl CgroupManager for Manager {
     fn apply(&self, linux_resources: &LinuxResources) -> Result<()> {
         for subsys in &self.subsystems {
             match subsys.0 {
-                ControllerType::Cpu => Cpu::apply(linux_resources, &subsys.1)?,
-                ControllerType::CpuAcct => CpuAcct::apply(linux_resources, &subsys.1)?,
-                ControllerType::CpuSet => CpuSet::apply(linux_resources, &subsys.1)?,
-                ControllerType::Devices => Devices::apply(linux_resources, &subsys.1)?,
-                ControllerType::HugeTlb => Hugetlb::apply(linux_resources, &subsys.1)?,
-                ControllerType::Memory => Memory::apply(linux_resources, &subsys.1)?,
-                ControllerType::Pids => Pids::apply(linux_resources, &subsys.1)?,
-                ControllerType::Blkio => Blkio::apply(linux_resources, &subsys.1)?,
-                ControllerType::NetworkPriority => {
-                    NetworkPriority::apply(linux_resources, &subsys.1)?
-                }
-                ControllerType::NetworkClassifier => {
+                CtrlType::Cpu => Cpu::apply(linux_resources, &subsys.1)?,
+                CtrlType::CpuAcct => CpuAcct::apply(linux_resources, &subsys.1)?,
+                CtrlType::CpuSet => CpuSet::apply(linux_resources, &subsys.1)?,
+                CtrlType::Devices => Devices::apply(linux_resources, &subsys.1)?,
+                CtrlType::HugeTlb => Hugetlb::apply(linux_resources, &subsys.1)?,
+                CtrlType::Memory => Memory::apply(linux_resources, &subsys.1)?,
+                CtrlType::Pids => Pids::apply(linux_resources, &subsys.1)?,
+                CtrlType::Blkio => Blkio::apply(linux_resources, &subsys.1)?,
+                CtrlType::NetworkPriority => NetworkPriority::apply(linux_resources, &subsys.1)?,
+                CtrlType::NetworkClassifier => {
                     NetworkClassifier::apply(linux_resources, &subsys.1)?
                 }
-                ControllerType::Freezer => Freezer::apply(linux_resources, &subsys.1)?,
+                CtrlType::Freezer => Freezer::apply(linux_resources, &subsys.1)?,
             }
         }
 

--- a/src/cgroups/v1/network_classifier.rs
+++ b/src/cgroups/v1/network_classifier.rs
@@ -1,25 +1,21 @@
-use std::{fs::create_dir_all, path::Path};
+use std::path::Path;
 
 use anyhow::Result;
-use nix::unistd::Pid;
 
 use crate::cgroups::common;
-use crate::cgroups::common::CGROUP_PROCS;
 use crate::cgroups::v1::Controller;
 use oci_spec::{LinuxNetwork, LinuxResources};
 
 pub struct NetworkClassifier {}
 
 impl Controller for NetworkClassifier {
-    fn apply(linux_resources: &LinuxResources, cgroup_root: &Path, pid: Pid) -> Result<()> {
+    fn apply(linux_resources: &LinuxResources, cgroup_root: &Path) -> Result<()> {
         log::debug!("Apply NetworkClassifier cgroup config");
-        create_dir_all(&cgroup_root)?;
 
         if let Some(network) = linux_resources.network.as_ref() {
             Self::apply(cgroup_root, network)?;
         }
 
-        common::write_cgroup_file(cgroup_root.join(CGROUP_PROCS), pid)?;
         Ok(())
     }
 }

--- a/src/cgroups/v1/network_priority.rs
+++ b/src/cgroups/v1/network_priority.rs
@@ -1,25 +1,21 @@
-use std::{fs::create_dir_all, path::Path};
+use std::path::Path;
 
 use anyhow::Result;
-use nix::unistd::Pid;
 
 use crate::cgroups::common;
-use crate::cgroups::common::CGROUP_PROCS;
 use crate::cgroups::v1::Controller;
 use oci_spec::{LinuxNetwork, LinuxResources};
 
 pub struct NetworkPriority {}
 
 impl Controller for NetworkPriority {
-    fn apply(linux_resources: &LinuxResources, cgroup_root: &Path, pid: Pid) -> Result<()> {
+    fn apply(linux_resources: &LinuxResources, cgroup_root: &Path) -> Result<()> {
         log::debug!("Apply NetworkPriority cgroup config");
-        create_dir_all(&cgroup_root)?;
 
         if let Some(network) = linux_resources.network.as_ref() {
             Self::apply(cgroup_root, network)?;
         }
 
-        common::write_cgroup_file(cgroup_root.join(CGROUP_PROCS), pid)?;
         Ok(())
     }
 }

--- a/src/cgroups/v1/pids.rs
+++ b/src/cgroups/v1/pids.rs
@@ -1,14 +1,8 @@
-use std::{
-    fs::{self},
-    path::Path,
-};
+use std::path::Path;
 
 use anyhow::Result;
 
-use crate::cgroups::{
-    common::{self, CGROUP_PROCS},
-    v1::Controller,
-};
+use crate::cgroups::{common, v1::Controller};
 use oci_spec::{LinuxPids, LinuxResources};
 
 pub struct Pids {}
@@ -17,16 +11,13 @@ impl Controller for Pids {
     fn apply(
         linux_resources: &LinuxResources,
         cgroup_root: &std::path::Path,
-        pid: nix::unistd::Pid,
     ) -> anyhow::Result<()> {
         log::debug!("Apply pids cgroup config");
-        fs::create_dir_all(cgroup_root)?;
 
         if let Some(pids) = &linux_resources.pids {
             Self::apply(cgroup_root, pids)?;
         }
 
-        common::write_cgroup_file(cgroup_root.join(CGROUP_PROCS), pid)?;
         Ok(())
     }
 }

--- a/src/cgroups/v2/manager.rs
+++ b/src/cgroups/v2/manager.rs
@@ -34,28 +34,31 @@ const CONTROLLER_TYPES: &[ControllerType] = &[
 pub struct Manager {
     root_path: PathBuf,
     cgroup_path: PathBuf,
+    full_path: PathBuf,
 }
 
 impl Manager {
     pub fn new(root_path: PathBuf, cgroup_path: PathBuf) -> Result<Self> {
+        let full_path = root_path.join_absolute_path(&cgroup_path)?;
+
         Ok(Self {
             root_path,
             cgroup_path,
+            full_path,
         })
     }
 
-    fn create_unified_cgroup(&self, cgroup_path: &Path, pid: Pid) -> Result<PathBuf> {
-        let full_path = self.root_path.join_absolute_path(cgroup_path)?;
+    fn create_unified_cgroup(&self, pid: Pid) -> Result<()> {
         let controllers: Vec<String> = self
-            .get_available_controllers(&self.root_path)?
-            .into_iter()
+            .get_available_controllers()?
+            .iter()
             .map(|c| format!("{}{}", "+", c.to_string()))
             .collect();
 
         Self::write_controllers(&self.root_path, &controllers)?;
 
         let mut current_path = self.root_path.clone();
-        let mut components = cgroup_path.components().skip(1).peekable();
+        let mut components = self.cgroup_path.components().skip(1).peekable();
         while let Some(component) = components.next() {
             current_path = current_path.join(component);
             if !current_path.exists() {
@@ -70,15 +73,12 @@ impl Manager {
             }
         }
 
-        common::write_cgroup_file(&full_path.join(CGROUP_PROCS), pid)?;
-        Ok(full_path)
+        common::write_cgroup_file(&self.full_path.join(CGROUP_PROCS), pid)?;
+        Ok(())
     }
 
-    fn get_available_controllers<P: AsRef<Path>>(
-        &self,
-        cgroup_path: P,
-    ) -> Result<Vec<ControllerType>> {
-        let controllers_path = self.root_path.join(cgroup_path).join(CGROUP_CONTROLLERS);
+    fn get_available_controllers(&self) -> Result<Vec<ControllerType>> {
+        let controllers_path = self.root_path.join(CGROUP_CONTROLLERS);
         if !controllers_path.exists() {
             bail!(
                 "cannot get available controllers. {:?} does not exist",
@@ -112,17 +112,20 @@ impl Manager {
 }
 
 impl CgroupManager for Manager {
-    fn apply(&self, linux_resources: &LinuxResources, pid: Pid) -> Result<()> {
-        let full_cgroup_path = self.create_unified_cgroup(&self.cgroup_path, pid)?;
+    fn add_task(&self, pid: Pid) -> Result<()> {
+        self.create_unified_cgroup(pid)?;
+        Ok(())
+    }
 
+    fn apply(&self, linux_resources: &LinuxResources) -> Result<()> {
         for controller in CONTROLLER_TYPES {
             match controller {
-                ControllerType::Cpu => Cpu::apply(linux_resources, &full_cgroup_path)?,
-                ControllerType::CpuSet => CpuSet::apply(linux_resources, &full_cgroup_path)?,
-                ControllerType::HugeTlb => HugeTlb::apply(linux_resources, &&full_cgroup_path)?,
-                ControllerType::Io => Io::apply(linux_resources, &&full_cgroup_path)?,
-                ControllerType::Memory => Memory::apply(linux_resources, &full_cgroup_path)?,
-                ControllerType::Pids => Pids::apply(linux_resources, &&full_cgroup_path)?,
+                ControllerType::Cpu => Cpu::apply(linux_resources, &self.full_path)?,
+                ControllerType::CpuSet => CpuSet::apply(linux_resources, &self.full_path)?,
+                ControllerType::HugeTlb => HugeTlb::apply(linux_resources, &self.full_path)?,
+                ControllerType::Io => Io::apply(linux_resources, &self.full_path)?,
+                ControllerType::Memory => Memory::apply(linux_resources, &self.full_path)?,
+                ControllerType::Pids => Pids::apply(linux_resources, &self.full_path)?,
             }
         }
 
@@ -130,9 +133,8 @@ impl CgroupManager for Manager {
     }
 
     fn remove(&self) -> Result<()> {
-        let full_path = self.root_path.join_absolute_path(&self.cgroup_path)?;
-        log::debug!("remove cgroup {:?}", full_path);
-        fs::remove_dir_all(full_path)?;
+        log::debug!("remove cgroup {:?}", self.full_path);
+        fs::remove_dir_all(&self.full_path)?;
 
         Ok(())
     }

--- a/src/cgroups/v2/manager.rs
+++ b/src/cgroups/v2/manager.rs
@@ -38,6 +38,8 @@ pub struct Manager {
 }
 
 impl Manager {
+    /// Constructs a new cgroup manager with root path being the mount point
+    /// of a cgroup v2 fs and cgroup path being a relative path from the root
     pub fn new(root_path: PathBuf, cgroup_path: PathBuf) -> Result<Self> {
         let full_path = root_path.join_absolute_path(&cgroup_path)?;
 

--- a/src/cgroups/v2/systemd_manager.rs
+++ b/src/cgroups/v2/systemd_manager.rs
@@ -30,7 +30,8 @@ const CONTROLLER_TYPES: &[ControllerType] = &[
 /// SystemDCGroupManager is a driver for managing cgroups via systemd.
 pub struct SystemDCGroupManager {
     root_path: PathBuf,
-    cgroups_path: CgroupsPath,
+    cgroups_path: PathBuf,
+    full_path: PathBuf,
 }
 
 /// Represents the systemd cgroups path:
@@ -45,6 +46,19 @@ struct CgroupsPath {
 
 impl SystemDCGroupManager {
     pub fn new(root_path: PathBuf, cgroups_path: PathBuf) -> Result<Self> {
+        // TODO: create the systemd unit using a dbus client.
+        let cgroups_path = Self::new_cgroups_path(cgroups_path)?;
+        let cgroups_path = Self::get_cgroups_path(cgroups_path)?;
+        let full_path = root_path.join_absolute_path(&cgroups_path)?;
+
+        Ok(SystemDCGroupManager {
+            root_path,
+            cgroups_path,
+            full_path,
+        })
+    }
+
+    fn new_cgroups_path(cgroups_path: PathBuf) -> Result<CgroupsPath> {
         // cgroups path may never be empty as it is defaulted to `/youki`
         // see 'get_cgroup_path' under utils.rs.
         // if cgroups_path was provided it should be of the form [slice]:[scope_prefix]:[name],
@@ -69,35 +83,27 @@ impl SystemDCGroupManager {
             name = parts[2];
         }
 
-        // TODO: create the systemd unit using a dbus client.
-
-        Ok(SystemDCGroupManager {
-            root_path,
-            cgroups_path: CgroupsPath {
-                parent: parent.to_owned(),
-                scope: scope.to_owned(),
-                name: name.to_owned(),
-            },
+        Ok(CgroupsPath {
+            parent: parent.to_owned(),
+            scope: scope.to_owned(),
+            name: name.to_owned(),
         })
     }
 
     /// get_unit_name returns the unit (scope) name from the path provided by the user
     /// for example: foo:docker:bar returns in '/docker-bar.scope'
-    fn get_unit_name(&self) -> String {
+    fn get_unit_name(cgroups_path: CgroupsPath) -> String {
         // By default we create a scope unless specified explicitly.
-        if !self.cgroups_path.name.ends_with(".slice") {
-            return format!(
-                "{}-{}.scope",
-                self.cgroups_path.scope, self.cgroups_path.name
-            );
+        if !cgroups_path.name.ends_with(".slice") {
+            return format!("{}-{}.scope", cgroups_path.scope, cgroups_path.name);
         }
-        self.cgroups_path.name.clone()
+        cgroups_path.name.clone()
     }
 
     // systemd represents slice hierarchy using `-`, so we need to follow suit when
     // generating the path of slice. For example, 'test-a-b.slice' becomes
     // '/test.slice/test-a.slice/test-a-b.slice'.
-    fn expand_slice(&self, slice: &str) -> Result<PathBuf> {
+    fn expand_slice(slice: &str) -> Result<PathBuf> {
         let suffix = ".slice";
         if slice.len() <= suffix.len() || !slice.ends_with(suffix) {
             bail!("invalid slice name: {}", slice);
@@ -125,15 +131,15 @@ impl SystemDCGroupManager {
 
     // get_cgroups_path generates a cgroups path from the one provided by the user via cgroupsPath.
     // an example of the final path: "/machine.slice/docker-foo.scope"
-    fn get_cgroups_path(&self) -> Result<PathBuf> {
+    fn get_cgroups_path(cgroups_path: CgroupsPath) -> Result<PathBuf> {
         // the root slice is under 'machine.slice'.
         let mut slice = Path::new("/machine.slice").to_path_buf();
         // if the user provided a '.slice' (as in a branch of a tree)
         // we need to "unpack it".
-        if !self.cgroups_path.parent.is_empty() {
-            slice = self.expand_slice(&self.cgroups_path.parent)?;
+        if !cgroups_path.parent.is_empty() {
+            slice = Self::expand_slice(&cgroups_path.parent)?;
         }
-        let unit_name = self.get_unit_name();
+        let unit_name = Self::get_unit_name(cgroups_path);
         let cgroups_path = slice.join(unit_name);
         Ok(cgroups_path)
     }
@@ -141,9 +147,7 @@ impl SystemDCGroupManager {
     /// create_unified_cgroup verifies sure that *each level* in the downward path from the root cgroup
     /// down to the cgroup_path provided by the user is a valid cgroup hierarchy,
     /// containing the attached controllers and that it contains the container pid.
-    fn create_unified_cgroup(&self, pid: Pid) -> Result<PathBuf> {
-        let cgroups_path = self.get_cgroups_path()?;
-        let full_path = self.root_path.join_absolute_path(&cgroups_path)?;
+    fn create_unified_cgroup(&self, pid: Pid) -> Result<()> {
         let controllers: Vec<String> = self
             .get_available_controllers(&self.root_path)?
             .into_iter()
@@ -154,7 +158,7 @@ impl SystemDCGroupManager {
         Self::write_controllers(&self.root_path, &controllers)?;
 
         let mut current_path = self.root_path.clone();
-        let mut components = cgroups_path.components().skip(1).peekable();
+        let mut components = self.cgroups_path.components().skip(1).peekable();
         // Verify that *each level* in the downward path from the root cgroup
         // down to the cgroup_path provided by the user is a valid cgroup hierarchy.
         // containing the attached controllers.
@@ -172,8 +176,8 @@ impl SystemDCGroupManager {
             }
         }
 
-        common::write_cgroup_file(full_path.join(CGROUP_PROCS), &pid)?;
-        Ok(full_path)
+        common::write_cgroup_file(self.full_path.join(CGROUP_PROCS), &pid)?;
+        Ok(())
     }
 
     fn get_available_controllers<P: AsRef<Path>>(
@@ -212,21 +216,25 @@ impl SystemDCGroupManager {
 }
 
 impl CgroupManager for SystemDCGroupManager {
-    fn apply(&self, linux_resources: &LinuxResources, pid: Pid) -> Result<()> {
+    fn add_task(&self, pid: Pid) -> Result<()> {
         // Dont attach any pid to the cgroup if -1 is specified as a pid
         if pid.as_raw() == -1 {
             return Ok(());
         }
-        let full_cgroup_path = self.create_unified_cgroup(pid)?;
 
+        self.create_unified_cgroup(pid)?;
+        Ok(())
+    }
+
+    fn apply(&self, linux_resources: &LinuxResources) -> Result<()> {
         for controller in CONTROLLER_TYPES {
             match controller {
-                ControllerType::Cpu => Cpu::apply(linux_resources, &full_cgroup_path)?,
-                ControllerType::CpuSet => CpuSet::apply(linux_resources, &full_cgroup_path)?,
-                ControllerType::HugeTlb => HugeTlb::apply(linux_resources, &&full_cgroup_path)?,
-                ControllerType::Io => Io::apply(linux_resources, &&full_cgroup_path)?,
-                ControllerType::Memory => Memory::apply(linux_resources, &full_cgroup_path)?,
-                ControllerType::Pids => Pids::apply(linux_resources, &&full_cgroup_path)?,
+                ControllerType::Cpu => Cpu::apply(linux_resources, &self.full_path)?,
+                ControllerType::CpuSet => CpuSet::apply(linux_resources, &self.full_path)?,
+                ControllerType::HugeTlb => HugeTlb::apply(linux_resources, &self.full_path)?,
+                ControllerType::Io => Io::apply(linux_resources, &self.full_path)?,
+                ControllerType::Memory => Memory::apply(linux_resources, &self.full_path)?,
+                ControllerType::Pids => Pids::apply(linux_resources, &self.full_path)?,
             }
         }
 
@@ -244,13 +252,8 @@ mod tests {
 
     #[test]
     fn expand_slice_works() -> Result<()> {
-        let manager = SystemDCGroupManager::new(
-            PathBuf::from("/sys/fs/cgroup"),
-            PathBuf::from("test-a-b.slice:docker:foo"),
-        )?;
-
         assert_eq!(
-            manager.expand_slice("test-a-b.slice")?,
+            SystemDCGroupManager::expand_slice("test-a-b.slice")?,
             PathBuf::from("/test.slice/test-a.slice/test-a-b.slice"),
         );
 
@@ -259,13 +262,12 @@ mod tests {
 
     #[test]
     fn get_cgroups_path_works_with_a_complex_slice() -> Result<()> {
-        let manager = SystemDCGroupManager::new(
-            PathBuf::from("/sys/fs/cgroup"),
-            PathBuf::from("test-a-b.slice:docker:foo"),
-        )?;
+        let cgroups_path =
+            SystemDCGroupManager::new_cgroups_path(PathBuf::from("test-a-b.slice:docker:foo"))
+                .expect("");
 
         assert_eq!(
-            manager.get_cgroups_path()?,
+            SystemDCGroupManager::get_cgroups_path(cgroups_path)?,
             PathBuf::from("/test.slice/test-a.slice/test-a-b.slice/docker-foo.scope"),
         );
 
@@ -274,13 +276,12 @@ mod tests {
 
     #[test]
     fn get_cgroups_path_works_with_a_simple_slice() -> Result<()> {
-        let manager = SystemDCGroupManager::new(
-            PathBuf::from("/sys/fs/cgroup"),
-            PathBuf::from("machine.slice:libpod:foo"),
-        )?;
+        let cgroups_path =
+            SystemDCGroupManager::new_cgroups_path(PathBuf::from("machine.slice:libpod:foo"))
+                .expect("");
 
         assert_eq!(
-            manager.get_cgroups_path()?,
+            SystemDCGroupManager::get_cgroups_path(cgroups_path)?,
             PathBuf::from("/machine.slice/libpod-foo.scope"),
         );
 
@@ -289,13 +290,11 @@ mod tests {
 
     #[test]
     fn get_cgroups_path_works_with_scope() -> Result<()> {
-        let manager = SystemDCGroupManager::new(
-            PathBuf::from("/sys/fs/cgroup"),
-            PathBuf::from(":docker:foo"),
-        )?;
+        let cgroups_path =
+            SystemDCGroupManager::new_cgroups_path(PathBuf::from(":docker:foo")).expect("");
 
         assert_eq!(
-            manager.get_cgroups_path()?,
+            SystemDCGroupManager::get_cgroups_path(cgroups_path)?,
             PathBuf::from("/machine.slice/docker-foo.scope"),
         );
 

--- a/src/process/fork.rs
+++ b/src/process/fork.rs
@@ -69,7 +69,8 @@ pub fn fork_first<P: AsRef<Path>>(
             let init_pid = parent.wait_for_child_ready(child)?;
             log::debug!("init pid is {:?}", init_pid);
             if rootless.is_none() && linux.resources.is_some() {
-                cmanager.apply(&linux.resources.as_ref().unwrap(), Pid::from_raw(init_pid))?;
+                cmanager.add_task(Pid::from_raw(init_pid))?;
+                cmanager.apply(&linux.resources.as_ref().unwrap())?;
             }
 
             // update status and pid of the container process


### PR DESCRIPTION
This is part of #20. We need to be able to move a task into a cgroup without having to apply resource restrictions again.