### PR TITLE
Require only requested cgroups to be present

### DIFF
--- a/src/cgroups/v1/blkio.rs
+++ b/src/cgroups/v1/blkio.rs
@@ -12,14 +12,24 @@ const CGROUP_BLKIO_THROTTLE_WRITE_IOPS: &str = "blkio.throttle.write_iops_device
 pub struct Blkio {}
 
 impl Controller for Blkio {
+    type Resource = LinuxBlockIo;
+
     fn apply(linux_resources: &LinuxResources, cgroup_root: &Path) -> Result<()> {
         log::debug!("Apply blkio cgroup config");
 
-        if let Some(blkio) = &linux_resources.block_io {
+        if let Some(blkio) = Self::needs_to_handle(linux_resources) {
             Self::apply(cgroup_root, blkio)?;
         }
 
         Ok(())
+    }
+
+    fn needs_to_handle(linux_resources: &LinuxResources) -> Option<&Self::Resource> {
+        if let Some(blkio) = &linux_resources.block_io {
+            return Some(blkio);
+        }
+
+        None
     }
 }
 

--- a/src/cgroups/v1/controller.rs
+++ b/src/cgroups/v1/controller.rs
@@ -8,11 +8,18 @@ use oci_spec::LinuxResources;
 use crate::cgroups::common::{self, CGROUP_PROCS};
 
 pub trait Controller {
+    type Resource;
+
+    /// Adds a new task specified by its pid to the cgroup
     fn add_task(pid: Pid, cgroup_path: &Path) -> Result<()> {
         fs::create_dir_all(cgroup_path)?;
         common::write_cgroup_file(cgroup_path.join(CGROUP_PROCS), pid)?;
         Ok(())
     }
 
+    /// Applies resource restrictions to the cgroup
     fn apply(linux_resources: &LinuxResources, cgroup_root: &Path) -> Result<()>;
+
+    /// Checks if the controller needs to handle this request
+    fn needs_to_handle(linux_resources: &LinuxResources) -> Option<&Self::Resource>;
 }

--- a/src/cgroups/v1/cpuacct.rs
+++ b/src/cgroups/v1/cpuacct.rs
@@ -8,8 +8,15 @@ use super::Controller;
 pub struct CpuAcct {}
 
 impl Controller for CpuAcct {
+    type Resource = ();
+
     fn apply(_linux_resources: &LinuxResources, _cgroup_path: &Path) -> Result<()> {
         Ok(())
+    }
+
+    // apply never needs to be called, for accounting only
+    fn needs_to_handle(_linux_resources: &LinuxResources) -> Option<&Self::Resource> {
+        None
     }
 }
 

--- a/src/cgroups/v1/devices.rs
+++ b/src/cgroups/v1/devices.rs
@@ -9,6 +9,8 @@ use oci_spec::{LinuxDeviceCgroup, LinuxDeviceType, LinuxResources};
 pub struct Devices {}
 
 impl Controller for Devices {
+    type Resource = ();
+
     fn apply(linux_resources: &LinuxResources, cgroup_root: &Path) -> Result<()> {
         log::debug!("Apply Devices cgroup config");
 
@@ -26,6 +28,11 @@ impl Controller for Devices {
         }
 
         Ok(())
+    }
+
+    // always needs to be called due to default devices
+    fn needs_to_handle(_linux_resources: &LinuxResources) -> Option<&Self::Resource> {
+        Some(&())
     }
 }
 

--- a/src/cgroups/v1/memory.rs
+++ b/src/cgroups/v1/memory.rs
@@ -22,10 +22,12 @@ const CGROUP_KERNEL_TCP_MEMORY_LIMIT: &str = "memory.kmem.tcp.limit_in_bytes";
 pub struct Memory {}
 
 impl Controller for Memory {
+    type Resource = LinuxMemory;
+
     fn apply(linux_resources: &LinuxResources, cgroup_root: &Path) -> Result<()> {
         log::debug!("Apply Memory cgroup config");
 
-        if let Some(memory) = &linux_resources.memory {
+        if let Some(memory) = Self::needs_to_handle(linux_resources) {
             let reservation = memory.reservation.unwrap_or(0);
 
             Self::apply(&memory, cgroup_root)?;
@@ -73,6 +75,14 @@ impl Controller for Memory {
         }
 
         Ok(())
+    }
+
+    fn needs_to_handle(linux_resources: &LinuxResources) -> Option<&Self::Resource> {
+        if let Some(memory) = &linux_resources.memory {
+            return Some(memory);
+        }
+
+        None
     }
 }
 

--- a/src/cgroups/v1/network_classifier.rs
+++ b/src/cgroups/v1/network_classifier.rs
@@ -9,14 +9,24 @@ use oci_spec::{LinuxNetwork, LinuxResources};
 pub struct NetworkClassifier {}
 
 impl Controller for NetworkClassifier {
+    type Resource = LinuxNetwork;
+
     fn apply(linux_resources: &LinuxResources, cgroup_root: &Path) -> Result<()> {
         log::debug!("Apply NetworkClassifier cgroup config");
 
-        if let Some(network) = linux_resources.network.as_ref() {
+        if let Some(network) = Self::needs_to_handle(linux_resources) {
             Self::apply(cgroup_root, network)?;
         }
 
         Ok(())
+    }
+
+    fn needs_to_handle(linux_resources: &LinuxResources) -> Option<&Self::Resource> {
+        if let Some(network) = &linux_resources.network {
+            return Some(network);
+        }
+
+        None
     }
 }
 

--- a/src/cgroups/v1/network_priority.rs
+++ b/src/cgroups/v1/network_priority.rs
@@ -9,14 +9,24 @@ use oci_spec::{LinuxNetwork, LinuxResources};
 pub struct NetworkPriority {}
 
 impl Controller for NetworkPriority {
+    type Resource = LinuxNetwork;
+
     fn apply(linux_resources: &LinuxResources, cgroup_root: &Path) -> Result<()> {
         log::debug!("Apply NetworkPriority cgroup config");
 
-        if let Some(network) = linux_resources.network.as_ref() {
+        if let Some(network) = Self::needs_to_handle(linux_resources) {
             Self::apply(cgroup_root, network)?;
         }
 
         Ok(())
+    }
+
+    fn needs_to_handle(linux_resources: &LinuxResources) -> Option<&Self::Resource> {
+        if let Some(network) = &linux_resources.network {
+            return Some(network);
+        }
+
+        None
     }
 }
 

--- a/src/cgroups/v1/pids.rs
+++ b/src/cgroups/v1/pids.rs
@@ -1,4 +1,4 @@
-use std::path::Path;
+use std::path::{Path};
 
 use anyhow::Result;
 
@@ -8,10 +8,12 @@ use oci_spec::{LinuxPids, LinuxResources};
 pub struct Pids {}
 
 impl Controller for Pids {
+    type Resource = LinuxPids;
+
     fn apply(
         linux_resources: &LinuxResources,
-        cgroup_root: &std::path::Path,
-    ) -> anyhow::Result<()> {
+        cgroup_root: &Path,
+    ) -> Result<()> {
         log::debug!("Apply pids cgroup config");
 
         if let Some(pids) = &linux_resources.pids {
@@ -19,6 +21,14 @@ impl Controller for Pids {
         }
 
         Ok(())
+    }
+
+    fn needs_to_handle(linux_resources: &LinuxResources) -> Option<&Self::Resource> {
+        if let Some(pids) = &linux_resources.pids {
+            return Some(pids);
+        }
+
+        None
     }
 }
 

--- a/src/cgroups/v1/util.rs
+++ b/src/cgroups/v1/util.rs
@@ -3,21 +3,22 @@ use std::{collections::HashMap, path::PathBuf};
 use anyhow::{anyhow, Result};
 use procfs::process::Process;
 
-use super::controller_type::CONTROLLERS;
+use super::{ControllerType, controller_type::CONTROLLERS};
 
-pub fn list_subsystem_mount_points() -> Result<HashMap<String, PathBuf>> {
+pub fn list_subsystem_mount_points() -> Result<HashMap<ControllerType, PathBuf>> {
     let mut mount_paths = HashMap::with_capacity(CONTROLLERS.len());
 
     for controller in CONTROLLERS {
-        if let Ok(mount_point) = get_subsystem_mount_points(&controller.to_string()) {
-            mount_paths.insert(controller.to_string(), mount_point);
+        if let Ok(mount_point) = get_subsystem_mount_point(controller) {
+            mount_paths.insert(controller.to_owned(), mount_point);
         }
     }
 
     Ok(mount_paths)
 }
 
-pub fn get_subsystem_mount_points(subsystem: &str) -> Result<PathBuf> {
+pub fn get_subsystem_mount_point(subsystem: &ControllerType) -> Result<PathBuf> {
+    let subsystem = subsystem.to_string();
     Process::myself()?
         .mountinfo()?
         .into_iter()


### PR DESCRIPTION
Fixes #109. Previously we required all cgroups subsystems to be present even if no resource restrictions were specified in the config.json that would have required that subsystem. Now only the subsystems necessary to to satisfy the request need to be available.