### PR TITLE
Reduce size of binary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,17 +24,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28b2cd92db5cbd74e8e5028f7e27dd7aa3090e89e4f2a197cc7c8dfb69c7063b"
 
 [[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi",
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -107,14 +96,12 @@ version = "3.0.0-beta.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4bd1061998a501ee7d4b6d449020df3266ca3124b941ec56cf2005c3779ca142"
 dependencies = [
- "atty",
  "bitflags",
  "clap_derive",
  "indexmap",
  "lazy_static",
  "os_str_bytes",
  "strsim",
- "termcolor",
  "textwrap",
  "unicode-width",
  "vec_map",
@@ -879,15 +866,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "termcolor"
-version = "1.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
-dependencies = [
- "winapi-util",
-]
-
-[[package]]
 name = "textwrap"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -985,15 +963,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
-name = "winapi-util"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1018,7 +987,6 @@ dependencies = [
  "prctl",
  "procfs",
  "quickcheck",
- "regex",
  "serde",
  "serde_json",
  "serial_test",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,8 +5,12 @@ authors = ["utam0k <k0ma@utam0k.jp>"]
 edition = "2018"
 description = "A container runtime written in Rust"
 
+[dependencies.clap]
+version = "3.0.0-beta.2"
+default-features = false
+features = ["std", "suggestions", "derive"]
+
 [dependencies]
-clap = "3.0.0-beta.2"
 nix = "0.19.1"
 procfs = "0.9.1"
 caps = "0.5.1"
@@ -20,7 +24,6 @@ mio = { version = "0.7", features = ["os-ext", "os-poll"] }
 chrono = { version="0.4", features = ["serde"] }
 once_cell = "1.6.0"
 futures = { version = "0.3", features = ["thread-pool"] }
-regex = "1.5"
 oci_spec = { version = "0.1.0", path = "./oci_spec" }
 systemd = { version = "0.8", default-features = false }
 dbus = "0.9.2"
@@ -30,3 +33,6 @@ tabwriter = "1"
 oci_spec = { version = "0.1.0", path = "./oci_spec", features = ["proptests"] }
 quickcheck = "1"
 serial_test = "0.5.1"
+
+[profile.release]
+lto = true


### PR DESCRIPTION
This reduces the size of the youki release binary by 51% from 7019736 bytes to 3449632 bytes. This is achieved by using link time optimization (reduction of ~2MB) and pruning the dependencies (removal of regex crate and restricting the features from clap to what we actually use). 
I also tried codegen-units=1 but the size reduction is negligible. Stripping the symbols from the binary on the other hand cuts the size in half again to about 1.6 MB, but this is not included in this PR as we would lose readable stack traces.