### PR TITLE
Document capabilities rs and refactor its drop_privileges function

### DIFF
--- a/docs/doc-draft.md
+++ b/docs/doc-draft.md
@@ -92,3 +92,7 @@ This also provides implementation for Linux syscalls for the trait.
 
 [oci runtime specification]: https://github.com/opencontainers/runtime-spec/blob/master/runtime.md
 [runc man pages]: (https://github.com/opencontainers/runc/blob/master/man/runc.8.md)
+
+## Capabilities
+
+- [Simple explanation of capabilities](https://blog.container-solutions.com/linux-capabilities-in-practice)

--- a/src/command/linux.rs
+++ b/src/command/linux.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use std::{any::Any, mem, path::Path, ptr};
 
 use anyhow::{bail, Result};
-use caps::{errors::CapsError, CapSet, CapsHashSet};
+use caps::{errors::CapsError, CapSet, Capability, CapsHashSet};
 use libc::{c_char, uid_t};
 use nix::{
     errno::Errno,
@@ -114,7 +114,31 @@ impl Syscall for LinuxSyscall {
 
     /// Set capabilities for container process
     fn set_capability(&self, cset: CapSet, value: &CapsHashSet) -> Result<(), CapsError> {
-        caps::set(None, cset, value)
+        match cset {
+            // caps::set cannot set capabilities in bounding set,
+            // so we do it differently
+            CapSet::Bounding => {
+                // get all capabilities
+                let all = caps::all();
+                // the difference will give capabilities
+                // which are to be unset
+                // for each such =, drop that capability
+                // after this, only those which are to be set will remain set
+                for c in all.difference(value) {
+                    match c {
+                        Capability::CAP_PERFMON
+                        | Capability::CAP_CHECKPOINT_RESTORE
+                        | Capability::CAP_BPF => {
+                            log::warn!("{:?} is not supported.", c);
+                            continue;
+                        }
+                        _ => caps::drop(None, CapSet::Bounding, *c)?,
+                    }
+                }
+                Ok(())
+            }
+            _ => caps::set(None, cset, value),
+        }
     }
 
     /// Sets hostname for process


### PR DESCRIPTION
This PR is part of #14 , it documents capabilities.rs
This also refactors the drop_privileges function in it :
Before it had
```
let all = caps::all();
    log::debug!("dropping bounding capabilities to {:?}", cs.bounding);
    for c in all.difference(&to_set(&cs.bounding)) {
        match c {
            Capability::CAP_PERFMON | Capability::CAP_CHECKPOINT_RESTORE | Capability::CAP_BPF => {
                log::warn!("{:?} is not supported.", c);
                continue;
            }
            _ => caps::drop(None, CapSet::Bounding, *c)?,
        }
    }
```
as part of it, but in my opinion, this should not be responsibility of drop_privileges function, but the Syscall structure abstraction should take care of it in its implementation. Thus I have moved this part to LinuxSyscall::set_capabilities.
