### PR TITLE
Document Info module, and change info.exec -> Info::print

### DIFF
--- a/src/info.rs
+++ b/src/info.rs
@@ -1,3 +1,4 @@
+//! Contains functions related to printing information about system running Youki
 use std::{fs, path::Path};
 
 use anyhow::Result;
@@ -10,7 +11,7 @@ use crate::cgroups;
 pub struct Info {}
 
 impl Info {
-    pub fn exec(&self) -> Result<()> {
+    pub fn print() -> Result<()> {
         print_youki();
         print_kernel();
         print_os();
@@ -21,10 +22,12 @@ impl Info {
     }
 }
 
+/// print Version of Youki
 pub fn print_youki() {
     println!("{:<18}{}", "Version", env!("CARGO_PKG_VERSION"));
 }
 
+/// Print Kernel Release, Version and Architecture
 pub fn print_kernel() {
     let uname = nix::sys::utsname::uname();
     println!("{:<18}{}", "Kernel-Release", uname.release());
@@ -32,6 +35,7 @@ pub fn print_kernel() {
     println!("{:<18}{}", "Architecture", uname.machine());
 }
 
+/// Prints OS Distribution information
 // see https://www.freedesktop.org/software/systemd/man/os-release.html
 pub fn print_os() {
     if let Some(os) = try_read_os_from("/etc/os-release") {
@@ -41,6 +45,7 @@ pub fn print_os() {
     }
 }
 
+/// Helper function to read the OS Distribution info
 fn try_read_os_from<P: AsRef<Path>>(path: P) -> Option<String> {
     let os_release = path.as_ref();
     if !os_release.exists() {
@@ -69,6 +74,7 @@ fn try_read_os_from<P: AsRef<Path>>(path: P) -> Option<String> {
     None
 }
 
+/// Helper function to find keyword values in OS info string
 fn find_parameter<'a>(content: &'a str, param_name: &str) -> Option<&'a str> {
     let param_value = content
         .lines()
@@ -82,6 +88,7 @@ fn find_parameter<'a>(content: &'a str, param_name: &str) -> Option<&'a str> {
     None
 }
 
+/// Print Hardware information of system
 pub fn print_hardware() {
     if let Ok(cpu_info) = CpuInfo::new() {
         println!("{:<18}{}", "Cores", cpu_info.num_cores());
@@ -96,6 +103,7 @@ pub fn print_hardware() {
     }
 }
 
+/// Print cgroups info of system
 pub fn print_cgroups() {
     if let Ok(cgroup_fs) = cgroups::common::get_supported_cgroup_fs() {
         let cgroup_fs: Vec<String> = cgroup_fs.into_iter().map(|c| c.to_string()).collect();

--- a/src/main.rs
+++ b/src/main.rs
@@ -53,7 +53,7 @@ enum SubCommand {
     #[clap(version = "0.0.1", author = "utam0k <k0ma@utam0k.jp>")]
     State(state::State),
     #[clap(version = "0.0.1", author = "utam0k <k0ma@utam0k.jp>")]
-    Info(info::Info),
+    Info,
     #[clap(version = "0.0.1", author = "utam0k <k0ma@utam0k.jp>")]
     List(list::List),
 }
@@ -82,7 +82,7 @@ fn main() -> Result<()> {
         SubCommand::Kill(kill) => kill.exec(root_path),
         SubCommand::Delete(delete) => delete.exec(root_path, systemd_cgroup),
         SubCommand::State(state) => state.exec(root_path),
-        SubCommand::Info(info) => info.exec(),
+        SubCommand::Info => info::Info::print(),
         SubCommand::List(list) => list.exec(root_path),
     }
 }


### PR DESCRIPTION
Part of #14 
This documents Info module
Also originally Info structure had instance method as 
```
#[derive(Clap, Debug)]
pub struct Info {}

impl Info {
    pub fn exec(&self) -> Result<()> {
        print_youki();
        print_kernel();
        print_os();
        print_hardware();
        print_cgroups();

        Ok(())
    }
}
```
But Info structure does not store any data, and all things we print are taken from the underlying system itself, so I don't think we will store anything in future as well. Also I think naming it `print` rather than `exec` would be more apt. So I have changed it to
```
impl Info {
    pub fn print() -> Result<()> {
        print_youki();
        print_kernel();
        print_os();
        print_hardware();
        print_cgroups();

        Ok(())
    }
}
```

Please take a look, @utam0k  and @Furisto 