### PR TITLE
Document Pause and Resume

### DIFF
--- a/docs/doc-draft.md
+++ b/docs/doc-draft.md
@@ -106,5 +106,13 @@ This has functions related to setting of namespaces to the calling process
 
 - [CLONE_NEWUSER flag](https://man7.org/linux/man-pages/man2/clone.2.html)
 
+## Pause and Resume
+
+This contains functionality regarding pausing and resuming container. Pausing a container indicates suspending all processes in it.
+This can be done with signals SIGSTOP and SIGCONT, but these can be intercepted. Using cgroups to suspend and resume processes without letting tasks know.
+
+- [cgroups man page](https://man7.org/linux/man-pages/man7/cgroups.7.html)
+- [freezer cgroup kernel documentation](https://www.kernel.org/doc/Documentation/cgroup-v1/freezer-subsystem.txt)
+
 [oci runtime specification]: https://github.com/opencontainers/runtime-spec/blob/master/runtime.md
 [runc man pages]: (https://github.com/opencontainers/runc/blob/master/man/runc.8.md)

--- a/src/commands/resume.rs
+++ b/src/commands/resume.rs
@@ -11,11 +11,17 @@ use crate::container::ContainerStatus;
 use crate::utils;
 use oci_spec::FreezerState;
 
+/// Structure to implement resume command
 #[derive(Clap, Debug)]
 pub struct Resume {
     pub container_id: String,
 }
 
+// Resuming a container indicates resuming all processes in given container from paused state
+// This uses Freezer cgroup to suspend and resume processes
+// For more information see :
+// https://man7.org/linux/man-pages/man7/cgroups.7.html
+// https://www.kernel.org/doc/Documentation/cgroup-v1/freezer-subsystem.txt
 impl Resume {
     pub fn exec(&self, root_path: PathBuf, systemd_cgroup: bool) -> Result<()> {
         log::debug!("start resuming container {}", self.container_id);
@@ -26,6 +32,8 @@ impl Resume {
         }
 
         let container = Container::load(container_root)?.refresh_status()?;
+        // check if container can be resumed :
+        // for example, a running process cannot be resumed
         if !container.can_resume() {
             bail!(
                 "{} could not be resumed because it was {:?}",
@@ -35,9 +43,15 @@ impl Resume {
         }
 
         let spec = container.spec()?;
-        let cgroups_path =
-            utils::get_cgroup_path(&spec.linux.unwrap().cgroups_path, &self.container_id);
+        // get cgroup path defined in spec
+        let path_in_spec = match spec.linux {
+            Some(linux) => linux.cgroups_path,
+            None => None,
+        };
+        let cgroups_path = utils::get_cgroup_path(&path_in_spec, &self.container_id);
+        // create cgroup manager structure from the config at the path
         let cmanager = cgroups::common::create_cgroup_manager(cgroups_path, systemd_cgroup)?;
+        // resume the frozen container
         cmanager.freeze(FreezerState::Thawed)?;
 
         log::debug!("saving running status");


### PR DESCRIPTION
Documents pause and resume commands, and add references for freezer cgroups in doc-draft.
@duduainankai I have changed an unwrap statement to a temp variable with match statement. It compiles correctly, can you verify that it does not do anything incorrect? I changed it to prevent potential panic due to unwrap. Also please verify the comments as well.