### PR TITLE
Fix alignment of cgroups info

### DIFF
--- a/src/commands/info.rs
+++ b/src/commands/info.rs
@@ -114,7 +114,7 @@ pub fn print_cgroups() {
     if let Ok(v1_mounts) = cgroups::v1::util::list_subsystem_mount_points() {
         let mut v1_mounts: Vec<String> = v1_mounts
             .iter()
-            .map(|kv| format!("  {:<16}{}", kv.0, kv.1.display()))
+            .map(|kv| format!("  {:<16}{}", kv.0.to_string(), kv.1.display()))
             .collect();
 
         v1_mounts.sort();


### PR DESCRIPTION
The format directive does not work when the type is not a string.
Before:
```
cgroup mounts
  blkio/sys/fs/cgroup/blkio
  cpu/sys/fs/cgroup/cpu,cpuacct
  cpuacct/sys/fs/cgroup/cpu,cpuacct
  cpuset/sys/fs/cgroup/cpuset
  devices/sys/fs/cgroup/devices
  freezer/sys/fs/cgroup/freezer
  hugetlb/sys/fs/cgroup/hugetlb
  memory/sys/fs/cgroup/memory
  net_cls/sys/fs/cgroup/net_cls,net_prio
  net_prio/sys/fs/cgroup/net_cls,net_prio
  pids/sys/fs/cgroup/pids
  unified         /sys/fs/cgroup/unified
```

After 

```
cgroup mounts
  blkio           /sys/fs/cgroup/blkio
  cpu             /sys/fs/cgroup/cpu,cpuacct
  cpuacct         /sys/fs/cgroup/cpu,cpuacct
  cpuset          /sys/fs/cgroup/cpuset
  devices         /sys/fs/cgroup/devices
  freezer         /sys/fs/cgroup/freezer
  hugetlb         /sys/fs/cgroup/hugetlb
  memory          /sys/fs/cgroup/memory
  net_cls         /sys/fs/cgroup/net_cls,net_prio
  net_prio        /sys/fs/cgroup/net_cls,net_prio
  pids            /sys/fs/cgroup/pids
  unified         /sys/fs/cgroup/unified
```

