### PR TITLE
Converted linux in spec from Option<Linux> to Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,10 +121,30 @@ Starting the docker daemon.
 $ dockerd --experimental --add-runtime="youki=$(pwd)/target/x86_64-unknown-linux-gnu/debug/youki"
 ```
 
+In case you get an error like :
+
+```
+failed to start daemon: pid file found, ensure docker is not running or delete /var/run/docker.pid
+```
+
+That means your normal Docker daemon is running, and it needs to be stopped. For that, open a new shell in same directory and run :
+
+```
+$ systemctl stop docker # might need root permission
+```
+
+Now in the same shell run the first command, which should start the docker daemon.
+
 You can use youki in a different terminal to start the container.
 
 ```
 $ docker run -it --rm --runtime youki busybox
+```
+
+Afterwards, you can close the docker daemon process in other the other terminal. To restart normal docker daemon (if you had stopped it before), run :
+
+```
+$ systemctl start docker # might need root permission
 ```
 
 ### Integration test
@@ -137,6 +157,7 @@ $ ./integration_test.sh
 ```
 
 ### Setting up Vagrant
+
 You can try youki on platforms other than linux by using the Vagrantfile we have prepared.
 
 ```

--- a/oci_spec/src/lib.rs
+++ b/oci_spec/src/lib.rs
@@ -37,7 +37,8 @@ pub struct Spec {
     #[serde(default)]
     pub annotations: HashMap<String, String>,
     // Platform specific config for Linux based containers
-    pub linux: Option<Linux>,
+    #[serde(default)]
+    pub linux: Linux,
 }
 
 // This gives a basic boilerplate for Spec that can be used calling Default::default().
@@ -56,7 +57,7 @@ impl Default for Spec {
             mounts: get_default_mounts(),
             // Defaults to empty metadata
             annotations: Default::default(),
-            linux: Some(Default::default()),
+            linux: Default::default(),
         }
     }
 }

--- a/src/commands/delete.rs
+++ b/src/commands/delete.rs
@@ -50,8 +50,7 @@ impl Delete {
                 log::debug!("remove dir {:?}", container.root);
                 fs::remove_dir_all(&container.root)?;
 
-                let cgroups_path =
-                    utils::get_cgroup_path(&spec.linux.unwrap().cgroups_path, container.id());
+                let cgroups_path = utils::get_cgroup_path(&spec.linux.cgroups_path, container.id());
 
                 // remove the cgroup created for the container
                 // check https://man7.org/linux/man-pages/man7/cgroups.7.html

--- a/src/commands/pause.rs
+++ b/src/commands/pause.rs
@@ -45,12 +45,7 @@ impl Pause {
         }
 
         let spec = container.spec()?;
-        // get cgroup path defined in spec
-        let path_in_spec = match spec.linux {
-            Some(linux) => linux.cgroups_path,
-            None => None,
-        };
-        let cgroups_path = utils::get_cgroup_path(&path_in_spec, &self.container_id);
+        let cgroups_path = utils::get_cgroup_path(&spec.linux.cgroups_path, &self.container_id);
         // create cgroup manager structure from the config at the path
         let cmanager = cgroups::common::create_cgroup_manager(cgroups_path, systemd_cgroup)?;
         // freeze the container

--- a/src/commands/resume.rs
+++ b/src/commands/resume.rs
@@ -43,12 +43,7 @@ impl Resume {
         }
 
         let spec = container.spec()?;
-        // get cgroup path defined in spec
-        let path_in_spec = match spec.linux {
-            Some(linux) => linux.cgroups_path,
-            None => None,
-        };
-        let cgroups_path = utils::get_cgroup_path(&path_in_spec, &self.container_id);
+        let cgroups_path = utils::get_cgroup_path(&spec.linux.cgroups_path, &self.container_id);
         // create cgroup manager structure from the config at the path
         let cmanager = cgroups::common::create_cgroup_manager(cgroups_path, systemd_cgroup)?;
         // resume the frozen container

--- a/src/container/builder_impl.rs
+++ b/src/container/builder_impl.rs
@@ -59,7 +59,7 @@ impl ContainerBuilderImpl {
     fn run_container(&mut self) -> Result<()> {
         prctl::set_dumpable(false).unwrap();
 
-        let linux = self.spec.linux.as_ref().unwrap();
+        let linux = &self.spec.linux;
         let cgroups_path = utils::get_cgroup_path(&linux.cgroups_path, &self.container_id);
         let cmanager = cgroups::common::create_cgroup_manager(&cgroups_path, self.use_systemd)?;
         let namespaces: Namespaces = linux.namespaces.clone().into();
@@ -124,7 +124,7 @@ fn container_init(
     notify_name: PathBuf,
     child: &mut child::ChildProcess,
 ) -> Result<()> {
-    let linux = spec.linux.as_ref().unwrap();
+    let linux = &spec.linux;
     let namespaces: Namespaces = linux.namespaces.clone().into();
     // need to create the notify socket before we pivot root, since the unix
     // domain socket used here is outside of the rootfs of container

--- a/src/container/tenant_builder.rs
+++ b/src/container/tenant_builder.rs
@@ -271,7 +271,7 @@ impl TenantContainerBuilder {
             }
         }
 
-        let mut linux = spec.linux.as_mut().unwrap();
+        let mut linux = &mut spec.linux;
         linux.namespaces = tenant_namespaces;
         Ok(())
     }

--- a/src/rootless.rs
+++ b/src/rootless.rs
@@ -30,16 +30,14 @@ impl From<&Linux> for Rootless {
 }
 
 pub fn detect_rootless(spec: &Spec) -> Result<Option<Rootless>> {
-    let linux = spec.linux.as_ref().unwrap();
-
     let rootless = if should_use_rootless() {
         log::debug!("rootless container should be created");
         log::warn!(
             "resource constraints and multi id mapping is unimplemented for rootless containers"
         );
         validate(spec)?;
-        let mut rootless = Rootless::from(linux);
-        if let Some((uid_binary, gid_binary)) = lookup_map_binaries(linux)? {
+        let mut rootless = Rootless::from(&spec.linux);
+        if let Some((uid_binary, gid_binary)) = lookup_map_binaries(&spec.linux)? {
             rootless.newuidmap = Some(uid_binary);
             rootless.newgidmap = Some(gid_binary);
         }
@@ -67,7 +65,7 @@ pub fn should_use_rootless() -> bool {
 /// Validates that the spec contains the required information for
 /// running in rootless mode
 pub fn validate(spec: &Spec) -> Result<()> {
-    let linux = spec.linux.as_ref().unwrap();
+    let linux = &spec.linux;
 
     if linux.uid_mappings.is_empty() {
         bail!("rootless containers require at least one uid mapping");


### PR DESCRIPTION
As Linux has Deafult trait, all occurrences of spec.linux would always unwrap it, and not having linux present is a fetal error in youki, there is no need to keep it in an Option wrapper.
This was discussed in https://github.com/containers/youki/pull/156#discussion_r675475868

I have checked that it successfully builds youki (No type errors), passes all unit tests, and ran it with docker in busybox container with shell. In the shell I ran ls,cd and ps, and they seemed to work fine.

I have ran this on Linux, it would be great if someone can verify that it also works on windows.

@utam0k @Furisto  please review.