### PR TITLE
Cleanup state file path construction

### DIFF
--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -10,7 +10,7 @@ use chrono::{DateTime, Local};
 use clap::Clap;
 use tabwriter::TabWriter;
 
-use crate::container::Container;
+use crate::container::{state::State, Container};
 
 /// Empty struct for list command
 #[derive(Clap, Debug)]
@@ -25,7 +25,7 @@ impl List {
         // so we iterate through each and print the various info
         for container_dir in fs::read_dir(root_path)? {
             let container_dir = container_dir?.path();
-            let state_file = container_dir.join("state.json");
+            let state_file = State::file_path(&container_dir);
             if !state_file.exists() {
                 continue;
             }

--- a/src/container/mod.rs
+++ b/src/container/mod.rs
@@ -9,7 +9,7 @@ mod builder_impl;
 #[allow(clippy::module_inception)]
 mod container;
 pub mod init_builder;
-mod state;
+pub mod state;
 pub mod tenant_builder;
 pub use container::Container;
 pub use state::{ContainerStatus, State};


### PR DESCRIPTION
#### Introduction

Hey folks, I started looking into this project, because I didn't even know that it exists since a couple of days. I'm Sascha and I'm already working on a couple of other container related topics. I can probably spent some time contributing to this project during my hack days if you're still looking for contributors. :upside_down_face: 

#### The change

This small cleanup creates a new static method `State::file_path()` which can be used to retrieve the state JSON file path. This makes the state module public and allows its usage from the `commands` module.