### PR TITLE
Use `remove_dir` instead of `remove_dir_all` because youki doesn't have permission to delete contents in cgroup directory.

### DIFF
--- a/src/cgroups/v2/manager.rs
+++ b/src/cgroups/v2/manager.rs
@@ -142,7 +142,7 @@ impl CgroupManager for Manager {
 
     fn remove(&self) -> Result<()> {
         log::debug!("remove cgroup {:?}", self.full_path);
-        fs::remove_dir_all(&self.full_path)?;
+        fs::remove_dir(&self.full_path)?;
 
         Ok(())
     }


### PR DESCRIPTION
I ran the delete in the tutorial and got an error.

https://doc.rust-lang.org/std/fs/fn.remove_dir_all.html
>  Removes a directory at this path, **after removing all its contents**. Use carefully!

https://www.kernel.org/doc/html/latest/admin-guide/cgroup-v2.html
> A cgroup which doesn’t have any children or live processes can be destroyed by removing the directory. Note that a cgroup which doesn’t have any children and is associated only with zombie processes is considered empty and can be removed:
> rmdir $CGROUP_NAME