### PR TITLE
Refactor clone(2) child stack creation.

### DIFF
--- a/oci_spec/Cargo.lock
+++ b/oci_spec/Cargo.lock
@@ -18,6 +18,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28b2cd92db5cbd74e8e5028f7e27dd7aa3090e89e4f2a197cc7c8dfb69c7063b"
 
 [[package]]
+name = "autocfg"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
+
+[[package]]
 name = "bitflags"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -102,9 +108,9 @@ checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
 
 [[package]]
 name = "libc"
-version = "0.2.95"
+version = "0.2.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "789da6d93f1b866ffe175afc5322a4d76c038605a1c3319bb57b06967ca98a36"
+checksum = "320cfe77175da3a483efed4bc0adc1968ca050b098ce4f2f1c13a56626128790"
 
 [[package]]
 name = "log"
@@ -122,15 +128,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b16bd47d9e329435e309c58469fe0791c2d0d1ba96ec0954152a5ae2b04387dc"
 
 [[package]]
-name = "nix"
-version = "0.19.1"
+name = "memoffset"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2ccba0cfe4fdf15982d1674c69b1fd80bad427d293849982668dfe454bd61f2"
+checksum = "59accc507f1338036a0477ef61afdae33cde60840f4dfe481319ce3ad116ddf9"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "nix"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf1e25ee6b412c2a1e3fcb6a4499a5c1bfe7f43e014bdce9a6b6666e5aa2d187"
 dependencies = [
  "bitflags",
  "cc",
  "cfg-if",
  "libc",
+ "memoffset",
 ]
 
 [[package]]

--- a/src/process/fork.rs
+++ b/src/process/fork.rs
@@ -1,15 +1,56 @@
 use anyhow::Result;
+use libc::c_int;
+use libc::c_void;
+use nix::errno::Errno;
 use nix::sched;
 use nix::unistd::Pid;
+use std::mem;
 
-pub fn clone(cb: sched::CloneCb, clone_flags: sched::CloneFlags) -> Result<Pid> {
-    // unlike fork, clone requires the caller to allocate the stack. here, we use the default
-    // 4KB for stack size, consistant with the runc implementation.
-    const STACK_SIZE: usize = 4096;
-    let stack: &mut [u8; STACK_SIZE] = &mut [0; STACK_SIZE];
-    // pass in the SIGCHID flag to mimic the effect of forking a process
-    let signal = nix::sys::signal::Signal::SIGCHLD;
-    let pid = sched::clone(cb, stack, clone_flags, Some(signal as i32))?;
+pub fn clone(mut cb: sched::CloneCb, clone_flags: sched::CloneFlags) -> Result<Pid> {
+    extern "C" fn callback(data: *mut sched::CloneCb) -> c_int {
+        let cb: &mut sched::CloneCb = unsafe { &mut *data };
+        (*cb)() as c_int
+    }
+
+    let child_stack_top = unsafe {
+        let page_size: usize = match libc::sysconf(libc::_SC_PAGE_SIZE) {
+            -1 => 4 * 1024, // default to 4K page size
+            x => x as usize,
+        };
+
+        let mut rlimit = libc::rlimit {
+            rlim_cur: 0,
+            rlim_max: 0,
+        };
+
+        Errno::result(libc::getrlimit(libc::RLIMIT_STACK, &mut rlimit))?;
+        let default_stack_size = rlimit.rlim_cur as usize;
+
+        let child_stack = libc::mmap(
+            libc::PT_NULL as *mut c_void,
+            default_stack_size,
+            libc::PROT_READ | libc::PROT_WRITE,
+            libc::MAP_PRIVATE | libc::MAP_ANONYMOUS | libc::MAP_STACK,
+            -1,
+            0,
+        );
+        Errno::result(libc::mprotect(child_stack, page_size, libc::PROT_NONE))?;
+        let child_stack_top = child_stack.add(default_stack_size);
+
+        child_stack_top
+    };
+
+    let res = unsafe {
+        let signal = nix::sys::signal::Signal::SIGCHLD;
+        let combined = clone_flags.bits() | signal as c_int;
+        libc::clone(
+            mem::transmute(callback as extern "C" fn(*mut Box<dyn FnMut() -> isize>) -> i32),
+            child_stack_top,
+            combined,
+            &mut cb as *mut _ as *mut c_void,
+        )
+    };
+    let pid = Errno::result(res).map(Pid::from_raw)?;
 
     Ok(pid)
 }
@@ -23,7 +64,7 @@ mod tests {
     #[test]
     fn test_fork_clone() -> Result<()> {
         let cb = || -> Result<()> {
-            // in a new pid namespace, pid of this process should be 1
+            // In a new pid namespace, pid of this process should be 1
             let pid = unistd::getpid();
             assert_eq!(unistd::Pid::from_raw(1), pid, "PID should set to 1");
 
@@ -38,6 +79,33 @@ mod tests {
                 if cb().is_err() {
                     return -1;
                 }
+
+                0
+            }),
+            flags,
+        )?;
+
+        let status = nix::sys::wait::waitpid(pid, None)?;
+        if let nix::sys::wait::WaitStatus::Exited(_, exit_code) = status {
+            assert_eq!(
+                0, exit_code,
+                "Process didn't exit correctly {:?}",
+                exit_code
+            );
+
+            return Ok(());
+        }
+
+        bail!("Process didn't exit correctly")
+    }
+
+    #[test]
+    fn test_clone_stack_allocation() -> Result<()> {
+        let flags = sched::CloneFlags::empty();
+        let pid = super::clone(
+            Box::new(|| {
+                let mut array_on_stack = [0u8; 4096];
+                array_on_stack.iter_mut().for_each(|x| *x = 0);
 
                 0
             }),


### PR DESCRIPTION
Fix #163 

After looking into more about how pthread_create and fork sets up child stack, refactored/fix how the child stack was created. Before this PR, as #163 indicates, LLVM with high optimization level will make memory behave not as we originally imagined. Therefore, we delved into lower APIs using `mmap` to create the child stack memory. This also gives us the benefit of reserving the max process/thread stack size on the system, without committing to actual physical memory. As a result, we don't have to hardcode a child's stack size or guess how much we need for the child process.