### PR TITLE
reduce the number of unnecessary clones and arguments by changing the order in which NotifyListeners are generated.

### DIFF
--- a/src/commands/start.rs
+++ b/src/commands/start.rs
@@ -16,8 +16,9 @@ pub struct Start {
 
 impl Start {
     pub fn new(container_id: String) -> Self {
-        return Self { container_id };
+        Self { container_id }
     }
+
     pub fn exec(&self, root_path: PathBuf) -> Result<()> {
         let container_root = root_path.join(&self.container_id);
         if !container_root.exists() {


### PR DESCRIPTION
fix lint warning
https://rust-lang.github.io/rust-clippy/master/index.html#too_many_arguments