### PR TITLE
implemented LISTEN_FDS

### DIFF
--- a/src/process/init.rs
+++ b/src/process/init.rs
@@ -210,12 +210,17 @@ pub fn container_init(args: ContainerInitArgs) -> Result<()> {
                 }
             };
 
-            // The LISTEN_FDS will have to be passed to container init process. The LISTEN_PID will
-            // be set to PID 1.
-            envs.append(&mut vec![
-                format!("LISTEN_FDS={}", listen_fds),
-                "LISTEN_PID=1".to_string(),
-            ]);
+            // The LISTEN_FDS will have to be passed to container init process.
+            // The LISTEN_PID will be set to PID 1. Based on the spec, if
+            // LISTEN_FDS is 0, the variable should be unset, so we just ignore
+            // it here, if it is 0.
+            if listen_fds > 0 {
+                envs.append(&mut vec![
+                    format!("LISTEN_FDS={}", listen_fds),
+                    "LISTEN_PID=1".to_string(),
+                ]);
+            }
+
             args.preserve_fds + listen_fds
         }
         Err(env::VarError::NotPresent) => args.preserve_fds,

--- a/src/process/init.rs
+++ b/src/process/init.rs
@@ -198,10 +198,13 @@ pub fn container_init(args: ContainerInitArgs) -> Result<()> {
     // environment variables.
     let preserve_fds: i32 = match env::var("LISTEN_FDS") {
         Ok(listen_fds_str) => {
-            let listen_fds = match listen_fds_str.parse::<i32>(){
+            let listen_fds = match listen_fds_str.parse::<i32>() {
                 Ok(v) => v,
                 Err(error) => {
-                    log::warn!("LISTEN_FDS entered is not a fd. Ignore the value. {:?}", error);
+                    log::warn!(
+                        "LISTEN_FDS entered is not a fd. Ignore the value. {:?}",
+                        error
+                    );
 
                     0
                 }
@@ -209,14 +212,18 @@ pub fn container_init(args: ContainerInitArgs) -> Result<()> {
 
             // The LISTEN_FDS will have to be passed to container init process. The LISTEN_PID will
             // be set to PID 1.
-            envs.append(&mut vec![format!("LISTEN_FDS={}", listen_fds), "LISTEN_PID=1".to_string()]);
+            envs.append(&mut vec![
+                format!("LISTEN_FDS={}", listen_fds),
+                "LISTEN_PID=1".to_string(),
+            ]);
             args.preserve_fds + listen_fds
-        },
-        Err(env::VarError::NotPresent) => {
-            args.preserve_fds
-        },
+        }
+        Err(env::VarError::NotPresent) => args.preserve_fds,
         Err(env::VarError::NotUnicode(value)) => {
-            log::warn!("LISTEN_FDS entered is malformed: {:?}. Ignore the value.", &value);
+            log::warn!(
+                "LISTEN_FDS entered is malformed: {:?}. Ignore the value.",
+                &value
+            );
             args.preserve_fds
         }
     };


### PR DESCRIPTION
Preserve LISTEN_FDS file descriptors in the container init process, and pass the correct environment variables. These are used for `systemd`. Ref: https://github.com/opencontainers/runc/blob/master/docs/terminals.md#other-file-descriptors

Note, I am not sure how to test this. I implement this based on the spec and runc code. But I couldn't find a way to use it in the wild. We can also choose not to merge this until someone in the future comes up with an use-case?