### PR TITLE
Add Windows, VM and Solaris types

### DIFF
--- a/oci_spec/src/solaris.rs
+++ b/oci_spec/src/solaris.rs
@@ -1,5 +1,107 @@
-use super::*;
+use serde::{Deserialize, Serialize};
 
-// TODO: implement me
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
-pub struct Solaris {}
+/// Solaris contains platform-specific configuration for Solaris application containers.
+pub struct Solaris {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    /// SMF FMRI which should go "online" before we start the container process.
+    pub milestone: Option<String>,
+
+    #[serde(default, skip_serializing_if = "Option::is_none", rename = "limitpriv")]
+    /// Maximum set of privileges any process in this container can obtain.
+    pub limit_priv: Option<String>,
+
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        rename = "maxShmMemory"
+    )]
+    /// The maximum amount of shared memory allowed for this container.
+    pub max_shm_memory: Option<String>,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    /// Specification for automatic creation of network resources for this container.
+    pub anet: Option<Vec<SolarisAnet>>,
+
+    #[serde(default, skip_serializing_if = "Option::is_none", rename = "cappedCPU")]
+    /// Set limit on the amount of CPU time that can be used by container.
+    pub capped_cpu: Option<SolarisCappedCPU>,
+
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        rename = "cappedMemory"
+    )]
+    /// The physical and swap caps on the memory that can be used by this container.
+    pub capped_memory: Option<SolarisCappedMemory>,
+}
+
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+/// SolarisAnet provides the specification for automatic creation of network resources for this
+/// container.
+pub struct SolarisAnet {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    /// Specify a name for the automatically created VNIC datalink.
+    pub linkname: Option<String>,
+
+    #[serde(default, skip_serializing_if = "Option::is_none", rename = "lowerLink")]
+    /// Specify the link over which the VNIC will be created.
+    pub lowerlink: Option<String>,
+
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        rename = "allowedAddress"
+    )]
+    /// The set of IP addresses that the container can use.
+    pub allowed_address: Option<String>,
+
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        rename = "configureAllowedAddress"
+    )]
+    /// Specifies whether allowedAddress limitation is to be applied to the VNIC.
+    pub configure_allowed_address: Option<String>,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    /// The value of the optional default router.
+    pub defrouter: Option<String>,
+
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        rename = "linkProtection"
+    )]
+    /// Enable one or more types of link protection.
+    pub link_protection: Option<String>,
+
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        rename = "macAddress"
+    )]
+    /// Set the VNIC's macAddress.
+    pub mac_address: Option<String>,
+}
+
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+/// SolarisCappedCPU allows users to set limit on the amount of CPU time that can be used by
+/// container.
+pub struct SolarisCappedCPU {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ncpus: Option<String>,
+}
+
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+/// SolarisCappedMemory allows users to set the physical and swap caps on the memory that can be
+/// used by this container.
+pub struct SolarisCappedMemory {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    /// The physical caps on the memory.
+    pub physical: Option<String>,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    /// The swap caps on the memory.
+    pub swap: Option<String>,
+}

--- a/oci_spec/src/vm.rs
+++ b/oci_spec/src/vm.rs
@@ -1,5 +1,53 @@
-use super::*;
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
 
-// TODO: implement me
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
-pub struct VM {}
+/// VM contains information for virtual-machine-based containers.
+pub struct VM {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    /// Hypervisor specifies hypervisor-related configuration for virtual-machine-based containers.
+    pub hypervisor: Option<VMHypervisor>,
+
+    /// Kernel specifies kernel-related configuration for virtual-machine-based containers.
+    pub kernel: VMKernel,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    /// Image specifies guest image related configuration for virtual-machine-based containers.
+    pub image: Option<VMImage>,
+}
+
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+/// VMHypervisor contains information about the hypervisor to use for a virtual machine.
+pub struct VMHypervisor {
+    /// Path is the host path to the hypervisor used to manage the virtual machine.
+    pub path: PathBuf,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    /// Parameters specifies parameters to pass to the hypervisor.
+    pub parameters: Option<Vec<String>>,
+}
+
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+/// VMKernel contains information about the kernel to use for a virtual machine.
+pub struct VMKernel {
+    /// Path is the host path to the kernel used to boot the virtual machine.
+    pub path: PathBuf,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    /// Parameters specifies parameters to pass to the kernel.
+    pub parameters: Option<Vec<String>>,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    /// InitRD is the host path to an initial ramdisk to be used by the kernel.
+    pub initrd: Option<String>,
+}
+
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+/// VMImage contains information about the virtual machine root image.
+pub struct VMImage {
+    /// Path is the host path to the root image that the VM kernel would boot into.
+    pub path: PathBuf,
+
+    /// Format is the root image format type (e.g. "qcow2", "raw", "vhd", etc).
+    pub format: String,
+}

--- a/oci_spec/src/windows.rs
+++ b/oci_spec/src/windows.rs
@@ -1,5 +1,177 @@
-use super::*;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 
-// TODO: implement me
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
-pub struct Windows {}
+/// Windows defines the runtime configuration for Windows based containers, including Hyper-V
+/// containers.
+pub struct Windows {
+    #[serde(rename = "layerFolders")]
+    /// LayerFolders contains a list of absolute paths to directories containing image layers.
+    pub layer_folders: Vec<String>,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    /// Devices are the list of devices to be mapped into the container.
+    pub devices: Option<Vec<WindowsDevice>>,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    /// Resources contains information for handling resource constraints for the container.
+    pub resources: Option<WindowsResources>,
+
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        rename = "credentialSpec"
+    )]
+    /// CredentialSpec contains a JSON object describing a group Managed Service Account (gMSA)
+    /// specification.
+    pub credential_spec: Option<HashMap<String, Option<serde_json::Value>>>,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    /// Servicing indicates if the container is being started in a mode to apply a Windows Update
+    /// servicing operation.
+    pub servicing: Option<bool>,
+
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        rename = "ignoreFlushesDuringBoot"
+    )]
+    /// IgnoreFlushesDuringBoot indicates if the container is being started in a mode where disk
+    /// writes are not flushed during its boot process.
+    pub ignore_flushes_during_boot: Option<bool>,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    /// HyperV contains information for running a container with Hyper-V isolation.
+    pub hyperv: Option<WindowsHyperV>,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    /// Network restriction configuration.
+    pub network: Option<WindowsNetwork>,
+}
+
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+/// WindowsDevice represents information about a host device to be mapped into the container.
+pub struct WindowsDevice {
+    /// Device identifier: interface class GUID, etc..
+    pub id: String,
+
+    #[serde(rename = "idType")]
+    /// Device identifier type: "class", etc..
+    pub id_type: String,
+}
+
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+pub struct WindowsResources {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    /// Memory restriction configuration.
+    pub memory: Option<WindowsMemoryResources>,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    /// CPU resource restriction configuration.
+    pub cpu: Option<WindowsCPUResources>,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    /// Storage restriction configuration.
+    pub storage: Option<WindowsStorageResources>,
+}
+
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+/// WindowsMemoryResources contains memory resource management settings.
+pub struct WindowsMemoryResources {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    /// Memory limit in bytes.
+    pub limit: Option<u64>,
+}
+
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+/// WindowsCPUResources contains CPU resource management settings.
+pub struct WindowsCPUResources {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    /// Number of CPUs available to the container.
+    pub count: Option<u64>,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    /// CPU shares (relative weight to other containers with cpu shares).
+    pub shares: Option<u16>,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    /// Specifies the portion of processor cycles that this container can use as a percentage times
+    /// 100.
+    pub maximum: Option<u16>,
+}
+
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+/// WindowsStorageResources contains storage resource management settings.
+pub struct WindowsStorageResources {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    /// Specifies maximum Iops for the system drive.
+    pub iops: Option<u64>,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    /// Specifies maximum bytes per second for the system drive.
+    pub bps: Option<u64>,
+
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        rename = "sandboxSize"
+    )]
+    /// Sandbox size specifies the minimum size of the system drive in bytes.
+    pub sandbox_size: Option<u64>,
+}
+
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+/// WindowsHyperV contains information for configuring a container to run with Hyper-V isolation.
+pub struct WindowsHyperV {
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        rename = "utilityVMPath"
+    )]
+    /// UtilityVMPath is an optional path to the image used for the Utility VM.
+    pub utility_vm_path: Option<String>,
+}
+
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+/// WindowsNetwork contains network settings for Windows containers.
+pub struct WindowsNetwork {
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        rename = "endpointList"
+    )]
+    /// List of HNS endpoints that the container should connect to.
+    pub endpoint_list: Option<Vec<String>>,
+
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        rename = "allowUnqualifiedDNSQuery"
+    )]
+    /// Specifies if unqualified DNS name resolution is allowed.
+    pub allow_unqualified_dns_query: Option<bool>,
+
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        rename = "DNSSearchList"
+    )]
+    /// Comma separated list of DNS suffixes to use for name resolution.
+    pub dns_search_list: Option<Vec<String>>,
+
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        rename = "networkSharedContainerName"
+    )]
+    /// Name (ID) of the container that we will share with the network stack.
+    pub network_shared_container_name: Option<String>,
+
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        rename = "networkNamespace"
+    )]
+    /// name (ID) of the network namespace that will be used for the container.
+    pub network_namespace: Option<String>,
+}


### PR DESCRIPTION
This resolves the missing `TODO`'s and adds the types.