### PR TITLE
Support unified resource section

### DIFF
--- a/cgroups/src/common.rs
+++ b/cgroups/src/common.rs
@@ -227,27 +227,3 @@ impl PathBufExt for PathBuf {
         Ok(PathBuf::from(format!("{}{}", self.display(), p.display())))
     }
 }
-
-pub(crate) trait StringExt {
-    // this should be replaced by split_once, when we switch to Rust 2021
-    fn split_one(&self, delimiter: &str) -> Option<(&str, &str)>;
-}
-
-impl StringExt for str {
-    fn split_one(&self, delimiter: &str) -> Option<(&str, &str)> {
-        let mut splits = self.splitn(2, delimiter);
-        let first = splits.next()?;
-        let second = splits.next()?;
-
-        Some((first, second))
-    }
-}
-
-#[macro_export]
-macro_rules! hashmap {
-    ($( $key: expr => $val: expr ),*) => {{
-         let mut map = ::std::collections::HashMap::new();
-         $( map.insert($key, $val); )*
-         map
-    }}
-}

--- a/cgroups/src/common.rs
+++ b/cgroups/src/common.rs
@@ -234,11 +234,20 @@ pub(crate) trait StringExt {
 }
 
 impl StringExt for str {
-    fn split_one(&self, delimiter: &str) ->Option<(&str, &str)> {
+    fn split_one(&self, delimiter: &str) -> Option<(&str, &str)> {
         let mut splits = self.splitn(2, delimiter);
         let first = splits.next()?;
         let second = splits.next()?;
 
         Some((first, second))
     }
+}
+
+#[macro_export]
+macro_rules! hashmap {
+    ($( $key: expr => $val: expr ),*) => {{
+         let mut map = ::std::collections::HashMap::new();
+         $( map.insert($key, $val); )*
+         map
+    }}
 }

--- a/cgroups/src/common.rs
+++ b/cgroups/src/common.rs
@@ -212,7 +212,7 @@ where
     Ok(())
 }
 
-pub trait PathBufExt {
+pub(crate) trait PathBufExt {
     fn join_safely(&self, p: &Path) -> Result<PathBuf>;
 }
 
@@ -225,5 +225,20 @@ impl PathBufExt for PathBuf {
             )
         }
         Ok(PathBuf::from(format!("{}{}", self.display(), p.display())))
+    }
+}
+
+pub(crate) trait StringExt {
+    // this should be replaced by split_once, when we switch to Rust 2021
+    fn split_one(&self, delimiter: &str) -> Option<(&str, &str)>;
+}
+
+impl StringExt for str {
+    fn split_one(&self, delimiter: &str) ->Option<(&str, &str)> {
+        let mut splits = self.splitn(2, delimiter);
+        let first = splits.next()?;
+        let second = splits.next()?;
+
+        Some((first, second))
     }
 }

--- a/cgroups/src/v1/cpu.rs
+++ b/cgroups/src/v1/cpu.rs
@@ -26,7 +26,7 @@ impl Controller for Cpu {
         log::debug!("Apply Cpu cgroup config");
 
         if let Some(cpu) = Self::needs_to_handle(linux_resources) {
-            Self::apply(cgroup_root, cpu)?;
+            Self::apply(cgroup_root, cpu).context("failed to apply cpu resource restrictions")?;
         }
 
         Ok(())

--- a/cgroups/src/v1/cpuset.rs
+++ b/cgroups/src/v1/cpuset.rs
@@ -1,6 +1,6 @@
 use std::{fs, path::Path};
 
-use anyhow::{Context, Result, bail};
+use anyhow::{bail, Context, Result};
 use nix::unistd;
 use oci_spec::{LinuxCpu, LinuxResources};
 use unistd::Pid;
@@ -31,7 +31,8 @@ impl Controller for CpuSet {
         log::debug!("Apply CpuSet cgroup config");
 
         if let Some(cpuset) = Self::needs_to_handle(linux_resources) {
-            Self::apply(cgroup_path, cpuset).context("failed to apply cpuset resource restrictions")?;
+            Self::apply(cgroup_path, cpuset)
+                .context("failed to apply cpuset resource restrictions")?;
         }
 
         Ok(())

--- a/cgroups/src/v1/cpuset.rs
+++ b/cgroups/src/v1/cpuset.rs
@@ -1,6 +1,6 @@
 use std::{fs, path::Path};
 
-use anyhow::{bail, Result};
+use anyhow::{Context, Result, bail};
 use nix::unistd;
 use oci_spec::{LinuxCpu, LinuxResources};
 use unistd::Pid;
@@ -31,7 +31,7 @@ impl Controller for CpuSet {
         log::debug!("Apply CpuSet cgroup config");
 
         if let Some(cpuset) = Self::needs_to_handle(linux_resources) {
-            Self::apply(cgroup_path, cpuset)?;
+            Self::apply(cgroup_path, cpuset).context("failed to apply cpuset resource restrictions")?;
         }
 
         Ok(())

--- a/cgroups/src/v1/freezer.rs
+++ b/cgroups/src/v1/freezer.rs
@@ -26,7 +26,7 @@ impl Controller for Freezer {
         create_dir_all(&cgroup_root)?;
 
         if let Some(freezer_state) = Self::needs_to_handle(linux_resources) {
-            Self::apply(freezer_state, cgroup_root)?;
+            Self::apply(freezer_state, cgroup_root).context("failed to appyl freezer")?;
         }
 
         Ok(())

--- a/cgroups/src/v1/hugetlb.rs
+++ b/cgroups/src/v1/hugetlb.rs
@@ -1,6 +1,6 @@
 use std::{collections::HashMap, path::Path};
 
-use anyhow::{Context, Result, bail};
+use anyhow::{bail, Context, Result};
 
 use crate::{
     common,
@@ -20,7 +20,8 @@ impl Controller for HugeTlb {
 
         if let Some(hugepage_limits) = Self::needs_to_handle(linux_resources) {
             for hugetlb in hugepage_limits {
-                Self::apply(cgroup_root, hugetlb).context("failed to apply hugetlb resource restrictions")?
+                Self::apply(cgroup_root, hugetlb)
+                    .context("failed to apply hugetlb resource restrictions")?
             }
         }
 

--- a/cgroups/src/v1/hugetlb.rs
+++ b/cgroups/src/v1/hugetlb.rs
@@ -1,6 +1,6 @@
 use std::{collections::HashMap, path::Path};
 
-use anyhow::{bail, Result};
+use anyhow::{Context, Result, bail};
 
 use crate::{
     common,
@@ -20,7 +20,7 @@ impl Controller for HugeTlb {
 
         if let Some(hugepage_limits) = Self::needs_to_handle(linux_resources) {
             for hugetlb in hugepage_limits {
-                Self::apply(cgroup_root, hugetlb)?
+                Self::apply(cgroup_root, hugetlb).context("failed to apply hugetlb resource restrictions")?
             }
         }
 

--- a/cgroups/src/v1/network_classifier.rs
+++ b/cgroups/src/v1/network_classifier.rs
@@ -1,6 +1,6 @@
 use std::path::Path;
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 
 use super::Controller;
 use crate::common;
@@ -15,7 +15,7 @@ impl Controller for NetworkClassifier {
         log::debug!("Apply NetworkClassifier cgroup config");
 
         if let Some(network) = Self::needs_to_handle(linux_resources) {
-            Self::apply(cgroup_root, network)?;
+            Self::apply(cgroup_root, network).context("failed to apply network classifier resource restrictions")?;
         }
 
         Ok(())

--- a/cgroups/src/v1/network_classifier.rs
+++ b/cgroups/src/v1/network_classifier.rs
@@ -15,7 +15,8 @@ impl Controller for NetworkClassifier {
         log::debug!("Apply NetworkClassifier cgroup config");
 
         if let Some(network) = Self::needs_to_handle(linux_resources) {
-            Self::apply(cgroup_root, network).context("failed to apply network classifier resource restrictions")?;
+            Self::apply(cgroup_root, network)
+                .context("failed to apply network classifier resource restrictions")?;
         }
 
         Ok(())

--- a/cgroups/src/v1/network_priority.rs
+++ b/cgroups/src/v1/network_priority.rs
@@ -1,6 +1,6 @@
 use std::path::Path;
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 
 use super::Controller;
 use crate::common;
@@ -15,7 +15,7 @@ impl Controller for NetworkPriority {
         log::debug!("Apply NetworkPriority cgroup config");
 
         if let Some(network) = Self::needs_to_handle(linux_resources) {
-            Self::apply(cgroup_root, network)?;
+            Self::apply(cgroup_root, network).context("failed to apply network priority resource restrictions")?;
         }
 
         Ok(())

--- a/cgroups/src/v1/network_priority.rs
+++ b/cgroups/src/v1/network_priority.rs
@@ -15,7 +15,8 @@ impl Controller for NetworkPriority {
         log::debug!("Apply NetworkPriority cgroup config");
 
         if let Some(network) = Self::needs_to_handle(linux_resources) {
-            Self::apply(cgroup_root, network).context("failed to apply network priority resource restrictions")?;
+            Self::apply(cgroup_root, network)
+                .context("failed to apply network priority resource restrictions")?;
         }
 
         Ok(())

--- a/cgroups/src/v1/pids.rs
+++ b/cgroups/src/v1/pids.rs
@@ -1,6 +1,6 @@
 use std::path::Path;
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 
 use super::Controller;
 use crate::{
@@ -21,7 +21,7 @@ impl Controller for Pids {
         log::debug!("Apply pids cgroup config");
 
         if let Some(pids) = &linux_resources.pids {
-            Self::apply(cgroup_root, pids)?;
+            Self::apply(cgroup_root, pids).context("failed to apply pids resource restrictions")?;
         }
 
         Ok(())

--- a/cgroups/src/v2/cpu.rs
+++ b/cgroups/src/v2/cpu.rs
@@ -1,4 +1,4 @@
-use anyhow::{bail, Result};
+use anyhow::{Context, Result, bail};
 use std::path::Path;
 
 use crate::{
@@ -22,7 +22,7 @@ pub struct Cpu {}
 impl Controller for Cpu {
     fn apply(linux_resources: &LinuxResources, path: &Path) -> Result<()> {
         if let Some(cpu) = &linux_resources.cpu {
-            Self::apply(path, cpu)?;
+            Self::apply(path, cpu).context("failed to apply cpu resource restrictions")?;
         }
 
         Ok(())

--- a/cgroups/src/v2/cpu.rs
+++ b/cgroups/src/v2/cpu.rs
@@ -1,4 +1,4 @@
-use anyhow::{Context, Result, bail};
+use anyhow::{bail, Context, Result};
 use std::path::Path;
 
 use crate::{

--- a/cgroups/src/v2/cpuset.rs
+++ b/cgroups/src/v2/cpuset.rs
@@ -14,7 +14,8 @@ pub struct CpuSet {}
 impl Controller for CpuSet {
     fn apply(linux_resources: &LinuxResources, cgroup_path: &Path) -> Result<()> {
         if let Some(cpuset) = &linux_resources.cpu {
-            Self::apply(cgroup_path, cpuset).context("failed to apply cpuset resource restrictions")?;
+            Self::apply(cgroup_path, cpuset)
+                .context("failed to apply cpuset resource restrictions")?;
         }
 
         Ok(())

--- a/cgroups/src/v2/cpuset.rs
+++ b/cgroups/src/v2/cpuset.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use anyhow::{Context, Result};
 use std::path::Path;
 
 use crate::common;
@@ -14,7 +14,7 @@ pub struct CpuSet {}
 impl Controller for CpuSet {
     fn apply(linux_resources: &LinuxResources, cgroup_path: &Path) -> Result<()> {
         if let Some(cpuset) = &linux_resources.cpu {
-            Self::apply(cgroup_path, cpuset)?;
+            Self::apply(cgroup_path, cpuset).context("failed to apply cpuset resource restrictions")?;
         }
 
         Ok(())

--- a/cgroups/src/v2/freezer.rs
+++ b/cgroups/src/v2/freezer.rs
@@ -1,4 +1,4 @@
-use anyhow::{Context, Result, bail};
+use anyhow::{bail, Context, Result};
 use std::{
     fs::OpenOptions,
     io::{BufRead, BufReader, Read, Seek, SeekFrom, Write},

--- a/cgroups/src/v2/freezer.rs
+++ b/cgroups/src/v2/freezer.rs
@@ -1,4 +1,4 @@
-use anyhow::{bail, Result};
+use anyhow::{Context, Result, bail};
 use std::{
     fs::OpenOptions,
     io::{BufRead, BufReader, Read, Seek, SeekFrom, Write},
@@ -19,7 +19,7 @@ pub struct Freezer {}
 impl Controller for Freezer {
     fn apply(linux_resources: &LinuxResources, cgroup_path: &Path) -> Result<()> {
         if let Some(freezer_state) = linux_resources.freezer {
-            Self::apply(freezer_state, cgroup_path)?;
+            Self::apply(freezer_state, cgroup_path).context("failed to apply freezer")?;
         }
 
         Ok(())

--- a/cgroups/src/v2/hugetlb.rs
+++ b/cgroups/src/v2/hugetlb.rs
@@ -16,7 +16,7 @@ impl Controller for HugeTlb {
         log::debug!("Apply hugetlb cgroup v2 config");
         if let Some(hugepage_limits) = linux_resources.hugepage_limits.as_ref() {
             for hugetlb in hugepage_limits {
-                Self::apply(cgroup_root, hugetlb)?
+                Self::apply(cgroup_root, hugetlb).context("failed to apply hugetlb resource restrictions")?
             }
         }
         Ok(())

--- a/cgroups/src/v2/hugetlb.rs
+++ b/cgroups/src/v2/hugetlb.rs
@@ -16,7 +16,8 @@ impl Controller for HugeTlb {
         log::debug!("Apply hugetlb cgroup v2 config");
         if let Some(hugepage_limits) = linux_resources.hugepage_limits.as_ref() {
             for hugetlb in hugepage_limits {
-                Self::apply(cgroup_root, hugetlb).context("failed to apply hugetlb resource restrictions")?
+                Self::apply(cgroup_root, hugetlb)
+                    .context("failed to apply hugetlb resource restrictions")?
             }
         }
         Ok(())

--- a/cgroups/src/v2/io.rs
+++ b/cgroups/src/v2/io.rs
@@ -1,6 +1,6 @@
 use std::path::{Path, PathBuf};
 
-use anyhow::{Context, Result, bail};
+use anyhow::{bail, Context, Result};
 
 use crate::{
     common,

--- a/cgroups/src/v2/io.rs
+++ b/cgroups/src/v2/io.rs
@@ -1,6 +1,6 @@
 use std::path::{Path, PathBuf};
 
-use anyhow::{bail, Result};
+use anyhow::{Context, Result, bail};
 
 use crate::{
     common,
@@ -20,7 +20,7 @@ impl Controller for Io {
     fn apply(linux_resource: &LinuxResources, cgroup_root: &Path) -> Result<()> {
         log::debug!("Apply io cgrup v2 config");
         if let Some(io) = &linux_resource.block_io {
-            Self::apply(cgroup_root, io)?;
+            Self::apply(cgroup_root, io).context("failed to apply io resource restrictions")?;
         }
         Ok(())
     }

--- a/cgroups/src/v2/io.rs
+++ b/cgroups/src/v2/io.rs
@@ -18,7 +18,7 @@ pub struct Io {}
 
 impl Controller for Io {
     fn apply(linux_resource: &LinuxResources, cgroup_root: &Path) -> Result<()> {
-        log::debug!("Apply io cgrup v2 config");
+        log::debug!("Apply io cgroup v2 config");
         if let Some(io) = &linux_resource.block_io {
             Self::apply(cgroup_root, io).context("failed to apply io resource restrictions")?;
         }

--- a/cgroups/src/v2/manager.rs
+++ b/cgroups/src/v2/manager.rs
@@ -1,18 +1,11 @@
-use std::{
-    fs::{self},
-    os::unix::fs::PermissionsExt,
-    path::{Path, PathBuf},
-};
+use std::{fs::{self}, os::unix::fs::PermissionsExt, path::{Path, PathBuf}};
 
 use anyhow::{bail, Result};
 
 use nix::unistd::Pid;
 use oci_spec::{FreezerState, LinuxResources};
 
-use super::{
-    controller::Controller, controller_type::ControllerType, cpu::Cpu, cpuset::CpuSet,
-    freezer::Freezer, hugetlb::HugeTlb, io::Io, memory::Memory, pids::Pids,
-};
+use super::{controller::Controller, controller_type::ControllerType, cpu::Cpu, cpuset::CpuSet, freezer::Freezer, hugetlb::HugeTlb, io::Io, memory::Memory, pids::Pids, unified::Unified};
 use crate::{
     common::{self, CgroupManager, PathBufExt, CGROUP_PROCS},
     stats::{Stats, StatsProvider},
@@ -133,6 +126,7 @@ impl CgroupManager for Manager {
             }
         }
 
+        Unified::apply(linux_resources, &self.full_path, self.get_available_controllers()?)?;
         Ok(())
     }
 

--- a/cgroups/src/v2/manager.rs
+++ b/cgroups/src/v2/manager.rs
@@ -1,11 +1,18 @@
-use std::{fs::{self}, os::unix::fs::PermissionsExt, path::{Path, PathBuf}};
+use std::{
+    fs::{self},
+    os::unix::fs::PermissionsExt,
+    path::{Path, PathBuf},
+};
 
 use anyhow::{bail, Result};
 
 use nix::unistd::Pid;
 use oci_spec::{FreezerState, LinuxResources};
 
-use super::{controller::Controller, controller_type::ControllerType, cpu::Cpu, cpuset::CpuSet, freezer::Freezer, hugetlb::HugeTlb, io::Io, memory::Memory, pids::Pids, unified::Unified};
+use super::{
+    controller::Controller, controller_type::ControllerType, cpu::Cpu, cpuset::CpuSet,
+    freezer::Freezer, hugetlb::HugeTlb, io::Io, memory::Memory, pids::Pids, unified::Unified,
+};
 use crate::{
     common::{self, CgroupManager, PathBufExt, CGROUP_PROCS},
     stats::{Stats, StatsProvider},
@@ -126,7 +133,11 @@ impl CgroupManager for Manager {
             }
         }
 
-        Unified::apply(linux_resources, &self.full_path, self.get_available_controllers()?)?;
+        Unified::apply(
+            linux_resources,
+            &self.full_path,
+            self.get_available_controllers()?,
+        )?;
         Ok(())
     }
 

--- a/cgroups/src/v2/memory.rs
+++ b/cgroups/src/v2/memory.rs
@@ -1,4 +1,4 @@
-use anyhow::{Context, Result, bail};
+use anyhow::{bail, Context, Result};
 use std::path::Path;
 
 use oci_spec::{LinuxMemory, LinuxResources};
@@ -20,7 +20,8 @@ pub struct Memory {}
 impl Controller for Memory {
     fn apply(linux_resources: &LinuxResources, cgroup_path: &Path) -> Result<()> {
         if let Some(memory) = &linux_resources.memory {
-            Self::apply(cgroup_path, memory).context("failed to apply memory resource restrictions")?;
+            Self::apply(cgroup_path, memory)
+                .context("failed to apply memory resource restrictions")?;
         }
 
         Ok(())

--- a/cgroups/src/v2/memory.rs
+++ b/cgroups/src/v2/memory.rs
@@ -1,4 +1,4 @@
-use anyhow::{bail, Result};
+use anyhow::{Context, Result, bail};
 use std::path::Path;
 
 use oci_spec::{LinuxMemory, LinuxResources};
@@ -20,7 +20,7 @@ pub struct Memory {}
 impl Controller for Memory {
     fn apply(linux_resources: &LinuxResources, cgroup_path: &Path) -> Result<()> {
         if let Some(memory) = &linux_resources.memory {
-            Self::apply(cgroup_path, memory)?;
+            Self::apply(cgroup_path, memory).context("failed to apply memory resource restrictions")?;
         }
 
         Ok(())

--- a/cgroups/src/v2/mod.rs
+++ b/cgroups/src/v2/mod.rs
@@ -10,4 +10,5 @@ mod memory;
 mod pids;
 pub mod systemd_manager;
 pub mod util;
+mod unified;
 pub use systemd_manager::SystemDCGroupManager;

--- a/cgroups/src/v2/mod.rs
+++ b/cgroups/src/v2/mod.rs
@@ -9,6 +9,6 @@ pub mod manager;
 mod memory;
 mod pids;
 pub mod systemd_manager;
-pub mod util;
 mod unified;
+pub mod util;
 pub use systemd_manager::SystemDCGroupManager;

--- a/cgroups/src/v2/pids.rs
+++ b/cgroups/src/v2/pids.rs
@@ -1,6 +1,6 @@
 use std::path::Path;
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 
 use crate::{
     common,
@@ -16,7 +16,7 @@ impl Controller for Pids {
     fn apply(linux_resource: &LinuxResources, cgroup_root: &std::path::Path) -> Result<()> {
         log::debug!("Apply pids cgroup v2 config");
         if let Some(pids) = &linux_resource.pids {
-            Self::apply(cgroup_root, pids)?;
+            Self::apply(cgroup_root, pids).context("failed to apply pids resource restrictions")?;
         }
         Ok(())
     }

--- a/cgroups/src/v2/unified.rs
+++ b/cgroups/src/v2/unified.rs
@@ -4,7 +4,7 @@ use anyhow::{Context, Result};
 use oci_spec::LinuxResources;
 
 use super::controller_type::ControllerType;
-use crate::common::{self, StringExt};
+use crate::common;
 
 pub struct Unified {}
 
@@ -20,7 +20,7 @@ impl Unified {
                 common::write_cgroup_file_str(cgroup_path.join(cgroup_file), value).map_err(
                     |e| {
                         let (subsystem, _) = cgroup_file
-                            .split_one(".")
+                            .split_once(".")
                             .with_context(|| {
                                 format!("failed to split {} with {}", cgroup_file, ".")
                             })
@@ -46,9 +46,11 @@ impl Unified {
 
 #[cfg(test)]
 mod tests {
+    use std::array::IntoIter;
+    use std::collections::HashMap;
     use std::fs;
+    use std::iter::FromIterator;
 
-    use crate::hashmap;
     use crate::test::{create_temp_dir, set_fixture};
     use crate::v2::controller_type::ControllerType;
 
@@ -62,9 +64,13 @@ mod tests {
         let cpu_weight_path = set_fixture(&tmp, "cpu.weight", "").unwrap();
 
         let resources = LinuxResources {
-            unified: Some(
-                hashmap!["hugetlb.1GB.limit_in_bytes".to_owned() => "72348034".to_owned() , "cpu.weight".to_owned()  => "5000".to_owned() ],
-            ),
+            unified: Some(HashMap::<_, _>::from_iter(IntoIter::new([
+                (
+                    "hugetlb.1GB.limit_in_bytes".to_owned(),
+                    "72348034".to_owned(),
+                ),
+                ("cpu.weight".to_owned(), "5000".to_owned()),
+            ]))),
             ..Default::default()
         };
 
@@ -85,9 +91,13 @@ mod tests {
             create_temp_dir("test_set_unified_failed_to_write_subsystem_not_enabled").unwrap();
 
         let resources = LinuxResources {
-            unified: Some(
-                hashmap!["hugetlb.1GB.limit_in_bytes".to_owned() => "72348034".to_owned() , "cpu.weight".to_owned()  => "5000".to_owned() ],
-            ),
+            unified: Some(HashMap::<_, _>::from_iter(IntoIter::new([
+                (
+                    "hugetlb.1GB.limit_in_bytes".to_owned(),
+                    "72348034".to_owned(),
+                ),
+                ("cpu.weight".to_owned(), "5000".to_owned()),
+            ]))),
             ..Default::default()
         };
 
@@ -104,9 +114,13 @@ mod tests {
         let tmp = create_temp_dir("test_set_unified_failed_to_write_subsystem_enabled").unwrap();
 
         let resources = LinuxResources {
-            unified: Some(
-                hashmap!["hugetlb.1GB.limit_in_bytes".to_owned() => "72348034".to_owned() , "cpu.weight".to_owned()  => "5000".to_owned() ],
-            ),
+            unified: Some(HashMap::<_, _>::from_iter(IntoIter::new([
+                (
+                    "hugetlb.1GB.limit_in_bytes".to_owned(),
+                    "72348034".to_owned(),
+                ),
+                ("cpu.weight".to_owned(), "5000".to_owned()),
+            ]))),
             ..Default::default()
         };
 

--- a/cgroups/src/v2/unified.rs
+++ b/cgroups/src/v2/unified.rs
@@ -1,0 +1,32 @@
+use std::{ path::Path};
+
+use anyhow::{Context, Result};
+use oci_spec::LinuxResources;
+
+use super::{controller_type::ControllerType};
+use crate::common::{self, StringExt};
+
+pub struct Unified{}
+
+impl Unified {
+    pub fn apply(linux_resources: &LinuxResources, cgroup_path: &Path, controllers: Vec<ControllerType>) -> Result<()> {
+        if let Some(unified) = &linux_resources.unified {
+            log::debug!("Apply unified cgroup config");
+            for (cgroup_file, value) in unified {
+                common::write_cgroup_file_str(cgroup_path.join(cgroup_file), value)
+                .map_err(|e| {
+                    let (subsystem, _) = cgroup_file.split_one(".").with_context(|| format!("failed to split {} with {}", cgroup_file, ".")).unwrap();
+                    let context = if !controllers.iter().any(|c| c.to_string() == subsystem) {
+                        format!("failed to set {} to {}: subsystem {} is not available", cgroup_file, value, subsystem)
+                        } else {
+                        format!("failed to set {} to {}: {}", cgroup_file, value, e)
+                        };
+
+                        e.context(context)                      
+                })?; 
+            }            
+        }
+
+        Ok(())
+    }
+}

--- a/cgroups/src/v2/unified.rs
+++ b/cgroups/src/v2/unified.rs
@@ -1,32 +1,123 @@
-use std::{ path::Path};
+use std::path::Path;
 
 use anyhow::{Context, Result};
 use oci_spec::LinuxResources;
 
-use super::{controller_type::ControllerType};
+use super::controller_type::ControllerType;
 use crate::common::{self, StringExt};
 
-pub struct Unified{}
+pub struct Unified {}
 
 impl Unified {
-    pub fn apply(linux_resources: &LinuxResources, cgroup_path: &Path, controllers: Vec<ControllerType>) -> Result<()> {
+    pub fn apply(
+        linux_resources: &LinuxResources,
+        cgroup_path: &Path,
+        controllers: Vec<ControllerType>,
+    ) -> Result<()> {
         if let Some(unified) = &linux_resources.unified {
             log::debug!("Apply unified cgroup config");
             for (cgroup_file, value) in unified {
-                common::write_cgroup_file_str(cgroup_path.join(cgroup_file), value)
-                .map_err(|e| {
-                    let (subsystem, _) = cgroup_file.split_one(".").with_context(|| format!("failed to split {} with {}", cgroup_file, ".")).unwrap();
-                    let context = if !controllers.iter().any(|c| c.to_string() == subsystem) {
-                        format!("failed to set {} to {}: subsystem {} is not available", cgroup_file, value, subsystem)
+                common::write_cgroup_file_str(cgroup_path.join(cgroup_file), value).map_err(
+                    |e| {
+                        let (subsystem, _) = cgroup_file
+                            .split_one(".")
+                            .with_context(|| {
+                                format!("failed to split {} with {}", cgroup_file, ".")
+                            })
+                            .unwrap();
+                        let context = if !controllers.iter().any(|c| c.to_string() == subsystem) {
+                            format!(
+                                "failed to set {} to {}: subsystem {} is not available",
+                                cgroup_file, value, subsystem
+                            )
                         } else {
-                        format!("failed to set {} to {}: {}", cgroup_file, value, e)
+                            format!("failed to set {} to {}: {}", cgroup_file, value, e)
                         };
 
-                        e.context(context)                      
-                })?; 
-            }            
+                        e.context(context)
+                    },
+                )?;
+            }
         }
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use crate::hashmap;
+    use crate::test::{create_temp_dir, set_fixture};
+    use crate::v2::controller_type::ControllerType;
+
+    use super::*;
+
+    #[test]
+    fn test_set_unified() {
+        // arrange
+        let tmp = create_temp_dir("test_set_unified").unwrap();
+        let hugetlb_limit_path = set_fixture(&tmp, "hugetlb.1GB.limit_in_bytes", "").unwrap();
+        let cpu_weight_path = set_fixture(&tmp, "cpu.weight", "").unwrap();
+
+        let resources = LinuxResources {
+            unified: Some(
+                hashmap!["hugetlb.1GB.limit_in_bytes".to_owned() => "72348034".to_owned() , "cpu.weight".to_owned()  => "5000".to_owned() ],
+            ),
+            ..Default::default()
+        };
+
+        // act
+        Unified::apply(&resources, &tmp, vec![]).expect("apply unified");
+
+        // assert
+        let hugetlb_limit = fs::read_to_string(hugetlb_limit_path).expect("read hugetlb limit");
+        let cpu_weight = fs::read_to_string(cpu_weight_path).expect("read cpu weight");
+        assert_eq!(hugetlb_limit, "72348034");
+        assert_eq!(cpu_weight, "5000");
+    }
+
+    #[test]
+    fn test_set_unified_failed_to_write_subsystem_not_enabled() {
+        // arrange
+        let tmp =
+            create_temp_dir("test_set_unified_failed_to_write_subsystem_not_enabled").unwrap();
+
+        let resources = LinuxResources {
+            unified: Some(
+                hashmap!["hugetlb.1GB.limit_in_bytes".to_owned() => "72348034".to_owned() , "cpu.weight".to_owned()  => "5000".to_owned() ],
+            ),
+            ..Default::default()
+        };
+
+        // act
+        let result = Unified::apply(&resources, &tmp, vec![]);
+
+        // assert
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_set_unified_failed_to_write_subsystem_enabled() {
+        // arrange
+        let tmp = create_temp_dir("test_set_unified_failed_to_write_subsystem_enabled").unwrap();
+
+        let resources = LinuxResources {
+            unified: Some(
+                hashmap!["hugetlb.1GB.limit_in_bytes".to_owned() => "72348034".to_owned() , "cpu.weight".to_owned()  => "5000".to_owned() ],
+            ),
+            ..Default::default()
+        };
+
+        // act
+        let result = Unified::apply(
+            &resources,
+            &tmp,
+            vec![ControllerType::HugeTlb, ControllerType::Cpu],
+        );
+
+        // assert
+        assert!(result.is_err());
     }
 }


### PR DESCRIPTION
Adds support for the [unified](https://github.com/opencontainers/runtime-spec/blob/master/config-linux.md#unified) section of the oci runtime spec. This does not map to a controller, so I decided not to implement it as one either. Once we have another one of these "pseudo" controllers (like devices) it probably makes sense to introduce a PseudoControllerType but for now I wanted to keep it simple.

While I was at it, I also added some additional context in case of errors occurring while applying resource restrictions. 