### PR TITLE
[WIP] Async cgroups using Rio

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,9 +19,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.40"
+version = "1.0.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28b2cd92db5cbd74e8e5028f7e27dd7aa3090e89e4f2a197cc7c8dfb69c7063b"
+checksum = "595d3cfa7a60d4555cb5067b99f07142a08ea778de5cf993f7b75c7d8fabc486"
 
 [[package]]
 name = "async-trait"
@@ -71,9 +71,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.68"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a72c244c1ff497a746a7e1fb3d14bd08420ecda70c8f25c7112f2781652d787"
+checksum = "e70cc2f62c6ce1868963827bd677764c62d07c3d9a3e1fb1177ee1a9ab199eb2"
 
 [[package]]
 name = "cfg-if"
@@ -152,19 +152,20 @@ dependencies = [
 
 [[package]]
 name = "dbus"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f597e08dfa79b593f23bbfc7840b23b2c5aa2e3a98d8e68b67b5b9ff800dc0db"
+checksum = "c8862bb50aa3b2a2db5bfd2c875c73b3038aa931c411087e335ca8ca0ed430b9"
 dependencies = [
  "libc",
  "libdbus-sys",
+ "winapi",
 ]
 
 [[package]]
 name = "env_logger"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17392a012ea30ef05a610aa97dfb49496e71c9f676b27879922ea5bdf60d9d3f"
+checksum = "a19187fea3ac7e84da7dacf48de0c45d63c6a76f9490dae389aead16c243fce3"
 dependencies = [
  "log",
  "regex",
@@ -344,9 +345,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.9.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
+checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
 
 [[package]]
 name = "heck"
@@ -359,9 +360,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "322f4de77956e22ed0e5032c359a0f1273f1f7f0d79bfa3b8ffbc730d7fbcc5c"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
  "libc",
 ]
@@ -374,9 +375,9 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "indexmap"
-version = "1.6.2"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "824845a0bf897a9042383849b02c1bc219c2383772efcd5c6f9766fa4b81aef3"
+checksum = "bc633605454125dec4b66843673f01c7df2b89479b32e0ed634e43a91cff62a5"
 dependencies = [
  "autocfg",
  "hashbrown",
@@ -384,9 +385,9 @@ dependencies = [
 
 [[package]]
 name = "instant"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61124eeebbd69b8190558df225adf7e4caafce0d743919e5d6b19652314ec5ec"
+checksum = "bee0328b1209d157ef001c94dd85b4f8f64139adb0eac2659f4b08382b2f474d"
 dependencies = [
  "cfg-if 1.0.0",
 ]
@@ -405,9 +406,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.95"
+version = "0.2.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "789da6d93f1b866ffe175afc5322a4d76c038605a1c3319bb57b06967ca98a36"
+checksum = "320cfe77175da3a483efed4bc0adc1968ca050b098ce4f2f1c13a56626128790"
 
 [[package]]
 name = "libdbus-sys"
@@ -474,9 +475,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.7.11"
+version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf80d3e903b34e0bd7282b218398aec54e082c840d9baf8339e0080a0c542956"
+checksum = "8c2bdb6314ec10835cd3293dd268473a835c02b7b352e788be788b3c6ca6bb16"
 dependencies = [
  "libc",
  "log",
@@ -508,9 +509,9 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.21.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c3728fec49d363a50a8828a190b379a446cc5cf085c06259bbbeb34447e4ec7"
+checksum = "cf1e25ee6b412c2a1e3fcb6a4499a5c1bfe7f43e014bdce9a6b6666e5aa2d187"
 dependencies = [
  "bitflags",
  "cc",
@@ -571,9 +572,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.7.2"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af8b08b04175473088b46763e51ee54da5f9a164bc162f615b91bc179dbf15a3"
+checksum = "692fcb63b64b1758029e0a96ee63e049ce8c5948587f2f7208df04625e5f6b56"
 
 [[package]]
 name = "os_str_bytes"
@@ -608,9 +609,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc0e1f259c92177c30a4c9d177246edd0a3568b25756a977d0632cf8fa37e905"
+checksum = "8d31d11c69a6b52a174b42bdc0c30e5e11670f90788b2c471c31c1d17d449443"
 
 [[package]]
 name = "pin-utils"
@@ -631,7 +632,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "059a34f111a9dee2ce1ac2826a68b24601c4298cfeb1a587c3cb493d5ab46f52"
 dependencies = [
  "libc",
- "nix 0.21.0",
+ "nix 0.22.0",
 ]
 
 [[package]]
@@ -716,18 +717,18 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ef9e7e66b4468674bfcb0c81af8b7fa0bb154fa9f28eb840da5c447baeb8d7e"
+checksum = "2e7573632e6454cf6b99d7aac4ccca54be06da05aca2ef7423d22d27d4d4bcd8"
 dependencies = [
  "rand_core",
 ]
 
 [[package]]
 name = "rand_core"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34cf66eb183df1c5876e2dcf6b13d57340741e8dc255b48e40a26de954d06ae7"
+checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
 dependencies = [
  "getrandom",
 ]
@@ -852,9 +853,9 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
-version = "1.0.72"
+version = "1.0.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1e8cdbefb79a9a5a65e0db8b47b723ee907b7c7f8496c76a1770b5c310bab82"
+checksum = "f71489ff30030d2ae598524f61326b902466f72a0fb1a8564c001cc63425bcc7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -896,18 +897,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.25"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa6f76457f59514c7eeb4e59d891395fab0b2fd1d40723ae737d64153392e9c6"
+checksum = "93119e4feac1cbe6c798c34d3a53ea0026b0b1de6a120deef895137c0529bfe2"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.25"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a36768c0fbf1bb15eca10defa29526bda730a2376c2ab4393ccfa16fb1a318d"
+checksum = "060d69a0afe7796bf42e9e2ff91f5ee691fb15c53d38b4b62a9a53eb23164745"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -926,9 +927,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.7.1"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0d2e7be6ae3a5fa87eed5fb451aff96f2573d2694942e40543ae0bbe19c796"
+checksum = "8895849a949e7845e06bd6dc1aa51731a103c42707010a5b591c0038fb73385b"
 
 [[package]]
 name = "unicode-width"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,6 +24,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28b2cd92db5cbd74e8e5028f7e27dd7aa3090e89e4f2a197cc7c8dfb69c7063b"
 
 [[package]]
+name = "async-trait"
+version = "0.1.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b98e84bbb4cbcdd97da190ba0c58a1bb0de2c1fdf67d159e192ed766aeca722"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -748,6 +759,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
 
 [[package]]
+name = "rio"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e98c25665909853c07874301124482754434520ab572ac6a22e90366de6685b"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -973,6 +993,7 @@ name = "youki"
 version = "0.0.1"
 dependencies = [
  "anyhow",
+ "async-trait",
  "caps",
  "chrono",
  "clap",
@@ -987,6 +1008,7 @@ dependencies = [
  "prctl",
  "procfs",
  "quickcheck",
+ "rio",
  "serde",
  "serde_json",
  "serial_test",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,8 @@ oci_spec = { version = "0.1.0", path = "./oci_spec" }
 systemd = { version = "0.8", default-features = false, optional = true }
 dbus = "0.9.2"
 tabwriter = "1"
+rio = "0.9.4"
+async-trait = "0.1.50"
 
 [dev-dependencies]
 oci_spec = { version = "0.1.0", path = "./oci_spec", features = ["proptests"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2018"
 description = "A container runtime written in Rust"
 
 [features]
-default = ["systemd_cgroups"]
 systemd_cgroups = ["systemd"]
 
 [dependencies.clap]
@@ -27,7 +26,7 @@ anyhow = "1.0"
 mio = { version = "0.7", features = ["os-ext", "os-poll"] }
 chrono = { version="0.4", features = ["serde"] }
 once_cell = "1.6.0"
-futures = { version = "0.3", features = ["thread-pool"] }
+futures = { version = "0.3", features = ["thread-pool", "executor"] }
 oci_spec = { version = "0.1.0", path = "./oci_spec" }
 systemd = { version = "0.8", default-features = false, optional = true }
 dbus = "0.9.2"

--- a/]
+++ b/]
@@ -120,7 +120,7 @@ pub async fn async_write_cgroup_file_str(ring: &Rio, file: &fs::File, data: &str
         Ordering::Link,
     ).await?;
 
-    // ring.fdatasync_ordered(file, Ordering::Link).await?;
+    ring.fdatasync_ordered(file, Ordering::Link).await?;
 
     Ok(())
 }

--- a/src/cgroups/common.rs
+++ b/src/cgroups/common.rs
@@ -89,7 +89,7 @@ pub fn open_cgroup_file<P: AsRef<Path>>(path: P) -> Result<File> {
 }
 
 #[inline]
-pub async fn async_write_cgroup_file_str(ring: &Rio, file: &File, data: &str) -> Result<Completion> {
+pub async fn async_write_cgroup_file_str(ring: &Rio, file: &File, data: &str) -> Result<()> {
     ring.write_at_ordered(
         &file,
         &data,
@@ -97,7 +97,9 @@ pub async fn async_write_cgroup_file_str(ring: &Rio, file: &File, data: &str) ->
         // Maybe we pass this control to the caller, but for now this is gives use some
         // notion of ordering to keep writes in sequence
         Ordering::Link,
-    )
+    ).await?;
+
+    Ok(())
 }
 
 #[inline]

--- a/src/cgroups/test.rs
+++ b/src/cgroups/test.rs
@@ -10,6 +10,14 @@ use oci_spec::LinuxCpu;
 
 use crate::utils::{create_temp_dir, TempDir};
 
+// helper macro for testing the result of async operations
+macro_rules! aw {
+    ($e:expr) => {
+        futures::executor::block_on($e)
+    };
+}
+pub(crate) use aw;
+
 pub fn setup(testname: &str, cgroup_file: &str) -> (TempDir, PathBuf) {
     let tmp = create_temp_dir(testname).expect("create temp directory for test");
     let cgroup_file = set_fixture(&tmp, cgroup_file, "")

--- a/src/cgroups/v1/blkio.rs
+++ b/src/cgroups/v1/blkio.rs
@@ -38,36 +38,36 @@ impl Controller for Blkio {
 
 impl Blkio {
     async fn apply(ring: &Rio, root_path: &Path, blkio: &LinuxBlockIo) -> Result<()> {
-        let trbd_file = common::open_cgroup_file(&root_path.join(CGROUP_BLKIO_THROTTLE_READ_BPS));
+        let trbd_file = common::open_cgroup_file(&root_path.join(CGROUP_BLKIO_THROTTLE_READ_BPS))?;
         for trbd in &blkio.blkio_throttle_read_bps_device {
-            common::async_write_cgroup_file(
+            common::async_write_cgroup_file_str(
                 ring,
                 &trbd_file,
                 &format!("{}:{} {}", trbd.major, trbd.minor, trbd.rate),
             ).await?;
         }
 
-        let twbd_file = common::open_cgroup_file(&root_path.join(CGROUP_BLKIO_THROTTLE_WRITE_BPS));
+        let twbd_file = common::open_cgroup_file(&root_path.join(CGROUP_BLKIO_THROTTLE_WRITE_BPS))?;
         for twbd in &blkio.blkio_throttle_write_bps_device {
-            common::async_write_cgroup_file(
+            common::async_write_cgroup_file_str(
                 ring,
                 &twbd_file,
                 &format!("{}:{} {}", twbd.major, twbd.minor, twbd.rate),
             ).await?;
         }
 
-        let trid_file = common::open_cgroup_file(&root_path.join(CGROUP_BLKIO_THROTTLE_READ_IOPS));
+        let trid_file = common::open_cgroup_file(&root_path.join(CGROUP_BLKIO_THROTTLE_READ_IOPS))?;
         for trid in &blkio.blkio_throttle_read_iops_device {
-            common::async_write_cgroup_file(
+            common::async_write_cgroup_file_str(
                 ring,
                 &trid_file,
                 &format!("{}:{} {}", trid.major, trid.minor, trid.rate),
             ).await?;
         }
 
-        let twid_file = common::open_cgroup_file(&root_path.join(CGROUP_BLKIO_THROTTLE_WRITE_IOPS));
+        let twid_file = common::open_cgroup_file(&root_path.join(CGROUP_BLKIO_THROTTLE_WRITE_IOPS))?;
         for twid in &blkio.blkio_throttle_write_iops_device {
-            common::async_write_cgroup_file(
+            common::async_write_cgroup_file_str(
                 ring,
                 &twid_file,
                 &format!("{}:{} {}", twid.major, twid.minor, twid.rate),

--- a/src/cgroups/v1/controller.rs
+++ b/src/cgroups/v1/controller.rs
@@ -1,12 +1,14 @@
 use std::{fs, path::Path};
 
 use anyhow::Result;
+use async_trait::async_trait;
 use nix::unistd::Pid;
 
 use oci_spec::LinuxResources;
 
 use crate::cgroups::common::{self, CGROUP_PROCS};
 
+#[async_trait]
 pub trait Controller {
     type Resource;
 
@@ -18,7 +20,7 @@ pub trait Controller {
     }
 
     /// Applies resource restrictions to the cgroup
-    fn apply(linux_resources: &LinuxResources, cgroup_root: &Path) -> Result<()>;
+    async fn apply(linux_resources: &LinuxResources, ring: &rio::Rio, cgroup_root: &Path) -> Result<()>;
 
     /// Checks if the controller needs to handle this request
     fn needs_to_handle(linux_resources: &LinuxResources) -> Option<&Self::Resource>;

--- a/src/cgroups/v1/controller.rs
+++ b/src/cgroups/v1/controller.rs
@@ -14,6 +14,9 @@ pub trait Controller {
 
     /// Adds a new task specified by its pid to the cgroup
     fn add_task(pid: Pid, cgroup_path: &Path) -> Result<()> {
+        // NOTE: it might be worth making this async. I'll leave it as is until I get some
+        // benchmarks finished, and then determine if there's any worthwhile performance gains
+        // to be had.
         fs::create_dir_all(cgroup_path)?;
         common::write_cgroup_file(cgroup_path.join(CGROUP_PROCS), pid)?;
         Ok(())

--- a/src/cgroups/v1/controller.rs
+++ b/src/cgroups/v1/controller.rs
@@ -20,7 +20,7 @@ pub trait Controller {
     }
 
     /// Applies resource restrictions to the cgroup
-    async fn apply(linux_resources: &LinuxResources, ring: &rio::Rio, cgroup_root: &Path) -> Result<()>;
+    async fn apply(ring: &rio::Rio, linux_resources: &LinuxResources, cgroup_root: &Path) -> Result<()>;
 
     /// Checks if the controller needs to handle this request
     fn needs_to_handle(linux_resources: &LinuxResources) -> Option<&Self::Resource>;

--- a/src/cgroups/v1/cpu.rs
+++ b/src/cgroups/v1/cpu.rs
@@ -55,26 +55,29 @@ impl Cpu {
 
         if let Some(cpu_period) = cpu.period {
             if cpu_period != 0 {
-                let period_file = common::open_cgroup_file(root_path.join(CGROUP_PERIOD))?;
+                let period_file = common::open_cgroup_file(root_path.join(CGROUP_CPU_PERIOD))?;
                 await common::async_write_cgroup_file(ring, &shares_file, cpu_period)?;
             }
         }
 
         if let Some(cpu_quota) = cpu.quota {
             if cpu_quota != 0 {
-                common::write_cgroup_file(root_path.join(CGROUP_CPU_QUOTA), cpu_quota)?;
+                let quota_file = common::open_cgroup_file(root_path.join(CGROUP_CPU_QUOTA))?;
+                await common::async_write_cgroup_file(ring, &quota_file, cpu_quota)?;
             }
         }
 
         if let Some(rt_runtime) = cpu.realtime_runtime {
             if rt_runtime != 0 {
-                common::write_cgroup_file(root_path.join(CGROUP_CPU_RT_RUNTIME), rt_runtime)?;
+                let rt_runtime_file = common::open_cgroup_file(root_path.join(CGROUP_CPU_RT_RUNTIME))?;
+                await common::async_write_cgroup_file(ring, &rt_runtime_file, rt_runtime)?;
             }
         }
 
         if let Some(rt_period) = cpu.realtime_period {
             if rt_period != 0 {
-                common::write_cgroup_file(root_path.join(CGROUP_CPU_RT_PERIOD), rt_period)?;
+                let rt_period_file = common::open_cgroup_file(root_path.join(CGROUP_CPU_RT_PERIOD));
+                await common::async_write_cgroup_file(ring, &rt_period_file, rt_period)?;
             }
         }
 

--- a/src/cgroups/v1/cpu.rs
+++ b/src/cgroups/v1/cpu.rs
@@ -80,7 +80,7 @@ impl Cpu {
 
         if let Some(rt_period) = cpu.realtime_period {
             if rt_period != 0 {
-                let rt_period_file = common::open_cgroup_file(root_path.join(CGROUP_CPU_RT_PERIOD));
+                let rt_period_file = common::open_cgroup_file(root_path.join(CGROUP_CPU_RT_PERIOD))?;
                 common::async_write_cgroup_file(ring, &rt_period_file, rt_period).await?;
             }
         }

--- a/src/cgroups/v1/cpuacct.rs
+++ b/src/cgroups/v1/cpuacct.rs
@@ -1,16 +1,19 @@
 use std::path::Path;
 
 use anyhow::Result;
+use async_trait::async_trait;
 use oci_spec::LinuxResources;
+use rio::Rio;
 
 use super::Controller;
 
 pub struct CpuAcct {}
 
+#[async_trait]
 impl Controller for CpuAcct {
     type Resource = ();
 
-    fn apply(_linux_resources: &LinuxResources, _cgroup_path: &Path) -> Result<()> {
+    async fn apply(_ring: &Rio, _linux_resources: &LinuxResources, _cgroup_path: &Path) -> Result<()> {
         Ok(())
     }
 

--- a/src/cgroups/v1/devices.rs
+++ b/src/cgroups/v1/devices.rs
@@ -1,6 +1,9 @@
 use std::path::Path;
+use std::fs::File;
 
 use anyhow::Result;
+use async_trait::async_trait;
+use rio::Rio;
 
 use crate::cgroups::common;
 use crate::{cgroups::v1::Controller, rootfs::default_devices};
@@ -8,24 +11,30 @@ use oci_spec::{LinuxDeviceCgroup, LinuxDeviceType, LinuxResources};
 
 pub struct Devices {}
 
+#[async_trait]
 impl Controller for Devices {
     type Resource = ();
 
-    fn apply(linux_resources: &LinuxResources, cgroup_root: &Path) -> Result<()> {
+    async fn apply(ring: &Rio, linux_resources: &LinuxResources, cgroup_root: &Path) -> Result<()> {
         log::debug!("Apply Devices cgroup config");
 
-        for d in &linux_resources.devices {
-            Self::apply_device(d, cgroup_root)?;
-        }
-
-        for d in [
+        // concat an array of default devices
+        let defaults = [
             default_devices().iter().map(|d| d.into()).collect(),
             Self::default_allow_devices(),
-        ]
-        .concat()
-        {
-            Self::apply_device(&d, &cgroup_root)?;
-        }
+        ].concat();
+
+        // combine iterators for default and specified devices
+        let devices_iter = linux_resources.devices.into_iter().chain(defaults.into_iter());
+
+        // partition all devices into a allowed and denied device sets
+        let (allowed, denied): (Vec<LinuxDeviceCgroup>, Vec<LinuxDeviceCgroup>) = devices_iter.into_iter().partition(|d| d.allow);
+        
+        // apply the allowed devices all at once
+        Self::apply_allowed_devices(ring, &allowed, cgroup_root).await?;
+
+        // apply the denied devices all at once
+        Self::apply_denied_devices(ring, &denied, cgroup_root).await?;
 
         Ok(())
     }
@@ -37,14 +46,22 @@ impl Controller for Devices {
 }
 
 impl Devices {
-    fn apply_device(device: &LinuxDeviceCgroup, cgroup_root: &Path) -> Result<()> {
-        let path = if device.allow {
-            cgroup_root.join("devices.allow")
-        } else {
-            cgroup_root.join("devices.deny")
-        };
+    async fn apply_allowed_devices(ring: &Rio, devices: &[LinuxDeviceCgroup], cgroup_root: &Path) -> Result<()> {
+        let file = common::open_cgroup_file(cgroup_root.join("devices.allow"))?;
+        Self::apply_devices(ring, devices, &file).await
+    }
 
-        common::write_cgroup_file_str(path, &device.to_string())?;
+    async fn apply_denied_devices(ring: &Rio, devices: &[LinuxDeviceCgroup], cgroup_root: &Path) -> Result<()> {
+        let file = common::open_cgroup_file(cgroup_root.join("device.deny"))?;
+        Self::apply_devices(ring, devices, &file).await
+    }
+
+    async fn apply_devices(ring: &Rio, devices: &[LinuxDeviceCgroup], file: &File) -> Result<()> {
+        // combine all device entries into a single string
+        let contents = devices.iter().map(|d| d.to_string()).fold(String::new(), |a, b| a + &b + "\n");
+
+        // apply all of the devices in one write
+        common::async_write_cgroup_file_str(ring, file, &contents).await?;
         Ok(())
     }
 
@@ -102,42 +119,15 @@ impl Devices {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::cgroups::test::set_fixture;
+    use crate::cgroups::test::{set_fixture, aw};
     use crate::utils::create_temp_dir;
     use oci_spec::{LinuxDeviceCgroup, LinuxDeviceType};
     use std::fs::read_to_string;
 
     #[test]
-    fn test_set_default_devices() {
-        let tmp =
-            create_temp_dir("test_set_default_devices").expect("create temp directory for test");
-
-        Devices::default_allow_devices().iter().for_each(|d| {
-            // NOTE: We reset the fixtures every iteration because files aren't appended
-            // so what happens in the tests is you get strange overwrites which can contain
-            // remaining bytes from the last iteration. Resetting the files more appropriately
-            // mocks the behavior of cgroup files.
-            set_fixture(&tmp, "devices.allow", "").expect("create allowed devices list");
-            set_fixture(&tmp, "devices.deny", "").expect("create denied devices list");
-
-            Devices::apply_device(&d, &tmp).expect("Apply default device");
-            println!("Device: {}", d.to_string());
-            if d.allow {
-                let allowed_content =
-                    read_to_string(tmp.join("devices.allow")).expect("read to string");
-                assert_eq!(allowed_content, d.to_string());
-            } else {
-                let denied_content =
-                    read_to_string(tmp.join("devices.deny")).expect("read to string");
-                assert_eq!(denied_content, d.to_string());
-            }
-        });
-    }
-
-    #[test]
-    fn test_set_mock_devices() {
-        let tmp = create_temp_dir("test_set_mock_devices").expect("create temp directory for test");
-        [
+    fn test_set_allowed_devices() {
+        let tmp = create_temp_dir("test_set_allowed_devices").expect("create temp directory for test");
+        let devices = [
             LinuxDeviceCgroup {
                 allow: true,
                 typ: LinuxDeviceType::C,
@@ -147,6 +137,48 @@ mod tests {
             },
             LinuxDeviceCgroup {
                 allow: true,
+                typ: LinuxDeviceType::A,
+                major: None,
+                minor: Some(200),
+                access: "rwm".to_string(),
+            },
+            LinuxDeviceCgroup {
+                allow: true,
+                typ: LinuxDeviceType::P,
+                major: Some(10),
+                minor: Some(200),
+                access: "m".to_string(),
+            },
+            LinuxDeviceCgroup {
+                allow: true,
+                typ: LinuxDeviceType::U,
+                major: None,
+                minor: None,
+                access: "rw".to_string(),
+            },
+        ];
+            set_fixture(&tmp, "devices.allow", "").expect("create allowed devices list");
+
+            let ring = rio::new().expect("start io_uring");
+            aw!(Devices::apply_allowed_devices(&ring, &devices, &tmp)).expect("Apply allowed device");
+            let expected = devices.iter().map(|d| d.to_string()).fold(String::new(), |a, b| a + &b + "\n");
+            let content = read_to_string(tmp.join("devices.allow")).expect("read file contents");
+            assert_eq!(content, expected);
+    }
+
+    #[test]
+    fn test_set_denied_devices() {
+        let tmp = create_temp_dir("test_set_denied_devices").expect("create temp directory for test");
+        let devices = [
+            LinuxDeviceCgroup {
+                allow: false,
+                typ: LinuxDeviceType::C,
+                major: Some(10),
+                minor: None,
+                access: "rwm".to_string(),
+            },
+            LinuxDeviceCgroup {
+                allow: false,
                 typ: LinuxDeviceType::A,
                 major: None,
                 minor: Some(200),
@@ -166,24 +198,14 @@ mod tests {
                 minor: None,
                 access: "rw".to_string(),
             },
-        ]
-        .iter()
-        .for_each(|d| {
-            set_fixture(&tmp, "devices.allow", "").expect("create allowed devices list");
+        ];
             set_fixture(&tmp, "devices.deny", "").expect("create denied devices list");
 
-            Devices::apply_device(&d, &tmp).expect("Apply default device");
-            println!("Device: {}", d.to_string());
-            if d.allow {
-                let allowed_content =
-                    read_to_string(tmp.join("devices.allow")).expect("read to string");
-                assert_eq!(allowed_content, d.to_string());
-            } else {
-                let denied_content =
-                    read_to_string(tmp.join("devices.deny")).expect("read to string");
-                assert_eq!(denied_content, d.to_string());
-            }
-        });
+            let ring = rio::new().expect("start io_uring");
+            aw!(Devices::apply_allowed_devices(&ring, &devices, &tmp)).expect("Apply denied device");
+            let expected = devices.iter().map(|d| d.to_string()).fold(String::new(), |a, b| a + &b + "\n");
+            let content = read_to_string(tmp.join("devices.denied")).expect("read file contents");
+            assert_eq!(content, expected);
     }
 
     quickcheck! {
@@ -191,36 +213,18 @@ mod tests {
             let tmp = create_temp_dir("property_test_apply_device").expect("create temp directory for test");
             set_fixture(&tmp, "devices.allow", "").expect("create allowed devices list");
             set_fixture(&tmp, "devices.deny", "").expect("create denied devices list");
-            Devices::apply_device(&device, &tmp).expect("Apply default device");
+            let ring = rio::new().expect("start io_uring");
             if device.allow {
+                aw!(Devices::apply_allowed_devices(&ring, &[device], &tmp)).expect("Apply default device");
                 let allowed_content =
                     read_to_string(tmp.join("devices.allow")).expect("read to string");
                 allowed_content == device.to_string()
             } else {
+                aw!(Devices::apply_denied_devices(&ring, &[device], &tmp)).expect("Apply default device");
                 let denied_content =
                     read_to_string(tmp.join("devices.deny")).expect("read to string");
                 denied_content == device.to_string()
             }
-        }
-
-        fn property_test_apply_multiple_devices(devices: Vec<LinuxDeviceCgroup>) -> bool {
-            let tmp = create_temp_dir("property_test_apply_multiple_devices").expect("create temp directory for test");
-            devices.iter()
-                .map(|device| {
-                    set_fixture(&tmp, "devices.allow", "").expect("create allowed devices list");
-                    set_fixture(&tmp, "devices.deny", "").expect("create denied devices list");
-                    Devices::apply_device(&device, &tmp).expect("Apply default device");
-                    if device.allow {
-                        let allowed_content =
-                            read_to_string(tmp.join("devices.allow")).expect("read to string");
-                        allowed_content == device.to_string()
-                    } else {
-                        let denied_content =
-                            read_to_string(tmp.join("devices.deny")).expect("read to string");
-                        denied_content == device.to_string()
-                    }
-                })
-                .all(|is_ok| is_ok)
         }
     }
 }


### PR DESCRIPTION
I'd like to explore using tokio's new uring implementation they released late last month, but I had been slowly working on this for a bit now. I've made some major progress lately. Do note not all tests are passing yet. I'm still working through some issues. While Rio brings a reasonable amount of safety to the table you always have to make sure you're written buffers live until you get a completion back from the kernel or you get a use after free. Also you need to make sure your process holds the file open long enough, which leads to some very weird code currently. I think possibly I will open all files needed right away in the top level `apply` when I do a pass to clean up the code. However I do worry about readability and maintainability with this approach. It's unfortunately an annoying approach. I'd like to consider tokio-uring because I believe it will more closely resemble the File access patterns we previously had. I figured I'd post this for curiosity sake, to get some feedback, and generally to show some of the progress. It is even possible that if tokio-uring is a quick implementation that we could compare all 3 solutions current synchronous approach vs Rio vs tokio-uring.

Let me know if you have any questions or concerns.