### PR TITLE
[WIP] cgroups v2: PoC of devices controller

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,7 +56,7 @@ jobs:
         with:
           toolchain: ${{ matrix.rust }}
       - run: sudo apt-get -y update
-      - run: sudo apt-get install -y pkg-config libsystemd-dev libdbus-glib-1-dev
+      - run: sudo apt-get install -y pkg-config libsystemd-dev libdbus-glib-1-dev libelf-dev
       - name: Build
         run: ./build.sh --release
       - name: Run tests
@@ -89,7 +89,7 @@ jobs:
         with:
           toolchain: ${{ matrix.rust }}
       - run: sudo apt-get -y update
-      - run: sudo apt-get install -y pkg-config libsystemd-dev libdbus-glib-1-dev
+      - run: sudo apt-get install -y pkg-config libsystemd-dev libdbus-glib-1-dev libelf-dev
       - name: Build
         run: ./build.sh --release
       - uses: actions/setup-go@v2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,6 +24,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28b2cd92db5cbd74e8e5028f7e27dd7aa3090e89e4f2a197cc7c8dfb69c7063b"
 
 [[package]]
+name = "ascii"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae7d751998c189c1d4468cf0a39bb2eae052a9c58d50ebb3b9591ee3813ad50"
+
+[[package]]
 name = "autocfg"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -82,10 +88,14 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "dbus",
+ "errno",
+ "libbpf-sys",
+ "libc",
  "log",
  "nix",
  "oci_spec",
  "procfs",
+ "rbpf",
  "serde",
  "systemd",
 ]
@@ -132,6 +142,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "combine"
+version = "2.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1645a65a99c7c8d345761f4b75a6ffe5be3b3b27a93ee731fccc5050ba6be97c"
+dependencies = [
+ "ascii",
+ "byteorder",
 ]
 
 [[package]]
@@ -434,6 +454,16 @@ name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+
+[[package]]
+name = "libbpf-sys"
+version = "0.4.0-2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cb2a66e5ddf38dbe9ba76f32d5ac337cf03ce18d042cde35988522cf6c0f6d2"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
 
 [[package]]
 name = "libc"
@@ -780,6 +810,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d51e9f596de227fda2ea6c84607f5558e196eeaf43c986b724ba4fb8fdf497e7"
 dependencies = [
  "rand_core",
+]
+
+[[package]]
+name = "rbpf"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c9c11162e7a92d2ede17ea2e5ef83025fd3e252638e43bf92294ea61791d1c4"
+dependencies = [
+ "byteorder",
+ "combine",
+ "libc",
+ "time",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,12 +24,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28b2cd92db5cbd74e8e5028f7e27dd7aa3090e89e4f2a197cc7c8dfb69c7063b"
 
 [[package]]
-name = "ascii"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ae7d751998c189c1d4468cf0a39bb2eae052a9c58d50ebb3b9591ee3813ad50"
-
-[[package]]
 name = "autocfg"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -88,14 +82,10 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "dbus",
- "errno",
- "libbpf-sys",
- "libc",
  "log",
  "nix",
  "oci_spec",
  "procfs",
- "rbpf",
  "serde",
  "systemd",
 ]
@@ -142,16 +132,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "combine"
-version = "2.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1645a65a99c7c8d345761f4b75a6ffe5be3b3b27a93ee731fccc5050ba6be97c"
-dependencies = [
- "ascii",
- "byteorder",
 ]
 
 [[package]]
@@ -454,16 +434,6 @@ name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
-
-[[package]]
-name = "libbpf-sys"
-version = "0.4.0-2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cb2a66e5ddf38dbe9ba76f32d5ac337cf03ce18d042cde35988522cf6c0f6d2"
-dependencies = [
- "cc",
- "pkg-config",
-]
 
 [[package]]
 name = "libc"
@@ -810,18 +780,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d51e9f596de227fda2ea6c84607f5558e196eeaf43c986b724ba4fb8fdf497e7"
 dependencies = [
  "rand_core",
-]
-
-[[package]]
-name = "rbpf"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c9c11162e7a92d2ede17ea2e5ef83025fd3e252638e43bf92294ea61791d1c4"
-dependencies = [
- "byteorder",
- "combine",
- "libc",
- "time",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -73,7 +73,8 @@ $ sudo apt-get install   \
       pkg-config         \
       libsystemd-dev     \
       libdbus-glib-1-dev \
-      build-essential
+      build-essential    \
+      libelf-dev
 ```
 
 ### Fedora, Centos, RHEL and related distributions
@@ -82,7 +83,8 @@ $ sudo apt-get install   \
 $ sudo dnf install   \
       pkg-config     \
       systemd-devel  \
-      dbus-devel
+      dbus-devel     \
+      elfutils-libelf-devel \
 ```
 
 ## Build

--- a/cgroups/Cargo.lock
+++ b/cgroups/Cargo.lock
@@ -18,10 +18,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "ansi_term"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "595d3cfa7a60d4555cb5067b99f07142a08ea778de5cf993f7b75c7d8fabc486"
+
+[[package]]
+name = "ascii"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae7d751998c189c1d4468cf0a39bb2eae052a9c58d50ebb3b9591ee3813ad50"
+
+[[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "winapi",
+]
 
 [[package]]
 name = "autocfg"
@@ -81,13 +107,20 @@ name = "cgroups"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "clap",
  "dbus",
+ "env_logger 0.9.0",
+ "errno",
+ "libbpf-sys",
+ "libc",
  "log",
  "nix",
  "oci_spec",
  "procfs",
  "quickcheck",
+ "rbpf",
  "serde",
+ "serde_json",
  "systemd",
 ]
 
@@ -102,6 +135,31 @@ dependencies = [
  "num-traits",
  "time",
  "winapi",
+]
+
+[[package]]
+name = "clap"
+version = "2.33.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002"
+dependencies = [
+ "ansi_term",
+ "atty",
+ "bitflags",
+ "strsim",
+ "textwrap",
+ "unicode-width",
+ "vec_map",
+]
+
+[[package]]
+name = "combine"
+version = "2.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1645a65a99c7c8d345761f4b75a6ffe5be3b3b27a93ee731fccc5050ba6be97c"
+dependencies = [
+ "ascii",
+ "byteorder",
 ]
 
 [[package]]
@@ -142,6 +200,19 @@ checksum = "a19187fea3ac7e84da7dacf48de0c45d63c6a76f9490dae389aead16c243fce3"
 dependencies = [
  "log",
  "regex",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b2cf0344971ee6c64c31be0d530793fba457d322dfec2810c453d0ef228f9c3"
+dependencies = [
+ "atty",
+ "humantime",
+ "log",
+ "regex",
+ "termcolor",
 ]
 
 [[package]]
@@ -222,10 +293,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "hermit-abi"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "itoa"
@@ -238,6 +324,16 @@ name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+
+[[package]]
+name = "libbpf-sys"
+version = "0.4.0-2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cb2a66e5ddf38dbe9ba76f32d5ac337cf03ce18d042cde35988522cf6c0f6d2"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
 
 [[package]]
 name = "libc"
@@ -387,7 +483,7 @@ version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "588f6378e4dd99458b60ec275b4477add41ce4fa9f64dcba6f15adccb19b50d6"
 dependencies = [
- "env_logger",
+ "env_logger 0.8.4",
  "log",
  "rand",
 ]
@@ -439,6 +535,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d51e9f596de227fda2ea6c84607f5558e196eeaf43c986b724ba4fb8fdf497e7"
 dependencies = [
  "rand_core",
+]
+
+[[package]]
+name = "rbpf"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c9c11162e7a92d2ede17ea2e5ef83025fd3e252638e43bf92294ea61791d1c4"
+dependencies = [
+ "byteorder",
+ "combine",
+ "libc",
+ "time",
 ]
 
 [[package]]
@@ -514,6 +622,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "strsim"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
+
+[[package]]
 name = "syn"
 version = "1.0.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -554,6 +668,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "termcolor"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
+dependencies = [
+ "unicode-width",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -584,6 +716,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-width"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -594,6 +732,12 @@ name = "utf8-cstr"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55bcbb425141152b10d5693095950b51c3745d019363fc2929ffd8f61449b628"
+
+[[package]]
+name = "vec_map"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "wasi"
@@ -616,6 +760,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/cgroups/Cargo.toml
+++ b/cgroups/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2018"
 
 [features]
-default = ["systemd_cgroups", "cgroupsv2_devices"]
+default = ["systemd_cgroups"]
 systemd_cgroups = ["systemd"]
 cgroupsv2_devices = ["rbpf", "libbpf-sys", "errno", "libc"]
 

--- a/cgroups/Cargo.toml
+++ b/cgroups/Cargo.toml
@@ -4,8 +4,9 @@ version = "0.1.0"
 edition = "2018"
 
 [features]
-default = ["systemd_cgroups"]
+default = ["systemd_cgroups", "cgroupsv2_devices"]
 systemd_cgroups = ["systemd"]
+cgroupsv2_devices = []
 
 [dependencies]
 nix = "0.22.0"
@@ -16,7 +17,15 @@ oci_spec = { git = "https://github.com/containers/oci-spec-rs", rev = "e0de21b89
 systemd = { version = "0.8", default-features = false, optional = true }
 dbus = "0.9.2"
 serde = { version = "1.0", features = ["derive"] }
+rbpf = "0.1.0"
+libbpf-sys = "0.4.0-2"
+errno = "0.2.7"
+libc = "0.2.84"
 
 [dev-dependencies]
 oci_spec = { git = "https://github.com/containers/oci-spec-rs", rev = "e0de21b89dc1e65f69a5f45a08bbe426787c7fa1", features = ["proptests"]}
 quickcheck = "1"
+clap = "2"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+env_logger = "0.9"

--- a/cgroups/Cargo.toml
+++ b/cgroups/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 [features]
 default = ["systemd_cgroups", "cgroupsv2_devices"]
 systemd_cgroups = ["systemd"]
-cgroupsv2_devices = []
+cgroupsv2_devices = ["rbpf", "libbpf-sys", "errno", "libc"]
 
 [dependencies]
 nix = "0.22.0"
@@ -17,10 +17,10 @@ oci_spec = { git = "https://github.com/containers/oci-spec-rs", rev = "e0de21b89
 systemd = { version = "0.8", default-features = false, optional = true }
 dbus = "0.9.2"
 serde = { version = "1.0", features = ["derive"] }
-rbpf = "0.1.0"
-libbpf-sys = "0.4.0-2"
-errno = "0.2.7"
-libc = "0.2.84"
+rbpf = {version = "0.1.0", optional = true }
+libbpf-sys = { version = "0.4.0-2", optional = true }
+errno = { version = "0.2.7", optional = true }
+libc = { version = "0.2.84", optional = true }
 
 [dev-dependencies]
 oci_spec = { git = "https://github.com/containers/oci-spec-rs", rev = "e0de21b89dc1e65f69a5f45a08bbe426787c7fa1", features = ["proptests"]}

--- a/cgroups/Cargo.toml
+++ b/cgroups/Cargo.toml
@@ -2,6 +2,7 @@
 name = "cgroups"
 version = "0.1.0"
 edition = "2018"
+autoexamples = false
 
 [features]
 default = ["systemd_cgroups"]

--- a/cgroups/examples/bpf.rs
+++ b/cgroups/examples/bpf.rs
@@ -1,0 +1,100 @@
+use anyhow::{bail, Result};
+use clap::{Arg, SubCommand};
+use std::os::unix::io::AsRawFd;
+use std::path::Path;
+
+use nix::fcntl::OFlag;
+use nix::sys::stat::Mode;
+
+use cgroups::v2::devices::bpf;
+use cgroups::v2::devices::emulator;
+use cgroups::v2::devices::program;
+use oci_spec::*;
+
+const LICENSE: &'static str = &"Apache";
+
+fn main() -> Result<()> {
+    env_logger::init();
+
+    let matches = clap::App::new("bpf")
+        .version("0.1")
+        .about("tools to test BPF program for cgroups v2 devices")
+        .arg(
+            Arg::with_name("cgroup_dir")
+                .short("c")
+                .value_name("CGROUP_DIR"),
+        )
+        .subcommand(
+            SubCommand::with_name("query")
+                .help("query list of BPF programs attached to cgroup dir"),
+        )
+        .subcommand(
+            SubCommand::with_name("detach")
+                .help("detach BPF program by id")
+                .arg(
+                    Arg::with_name("id")
+                        .value_name("PROG_ID")
+                        .required(true)
+                        .help("ID of BPF program returned by query command"),
+                ),
+        )
+        .subcommand(
+            SubCommand::with_name("attach")
+                .help("compile rules to BPF and attach to cgroup dir")
+                .arg(
+                    Arg::with_name("input_file")
+                        .value_name("INPUT_FILE")
+                        .required(true)
+                        .help("File contains Vec<LinuxDeviceCgroup> in json format"),
+                ),
+        )
+        .get_matches_safe()?;
+
+    let cgroup_dir = matches.value_of("cgroup_dir").unwrap();
+
+    let cgroup_fd = nix::dir::Dir::open(
+        cgroup_dir,
+        OFlag::O_RDONLY | OFlag::O_DIRECTORY,
+        Mode::from_bits(0o600).unwrap(),
+    )?;
+
+    match matches.subcommand() {
+        ("query", Some(_)) => {
+            let progs = bpf::prog_query(cgroup_fd.as_raw_fd())?;
+            for prog in &progs {
+                println!("prog: id={}, fd={}", prog.id, prog.fd);
+            }
+        }
+        ("detach", Some(submatch)) => {
+            let prog_id = submatch.value_of("id").unwrap().parse::<u32>()?;
+            let progs = bpf::prog_query(cgroup_fd.as_raw_fd())?;
+            let prog = progs.iter().find(|v| v.id == prog_id);
+            if prog.is_none() {
+                bail!("can't get prog fd by prog id");
+            }
+
+            bpf::prog_detach2(prog.unwrap().fd, cgroup_fd.as_raw_fd())?;
+            println!("detach ok");
+        }
+        ("attach", Some(submatch)) => {
+            let input_file = submatch.value_of("input_file").unwrap();
+            let rules = parse_cgroupv1_device_rules(&input_file)?;
+            let mut emulator = emulator::Emulator::with_default_allow(false);
+            emulator.add_rules(&rules)?;
+            let prog = program::Program::from_rules(&emulator.rules, emulator.default_allow)?;
+            let prog_fd = bpf::prog_load(LICENSE, prog.bytecodes())?;
+            bpf::prog_attach(prog_fd, cgroup_fd.as_raw_fd())?;
+            println!("attach ok");
+        }
+
+        (_, _) => {}
+    };
+
+    Ok(())
+}
+
+fn parse_cgroupv1_device_rules<P: AsRef<Path>>(path: P) -> Result<Vec<LinuxDeviceCgroup>> {
+    let content = std::fs::read_to_string(path)?;
+    let devices = serde_json::from_str(&content)?;
+    Ok(devices)
+}

--- a/cgroups/examples/rules.json
+++ b/cgroups/examples/rules.json
@@ -1,0 +1,17 @@
+[
+    {
+        "allow": false,
+        "access": "rwm"
+    },
+    {
+        "allow": true,
+        "type": "c",
+        "access": "rwm"
+    },
+    {
+        "allow": true,
+        "type": "b",
+        "major": 8,
+        "access": "rm"
+    }
+]

--- a/cgroups/src/common.rs
+++ b/cgroups/src/common.rs
@@ -8,7 +8,7 @@ use std::{
 
 use anyhow::{bail, Context, Result};
 use nix::unistd::Pid;
-use oci_spec::{FreezerState, LinuxResources};
+use oci_spec::{FreezerState, LinuxDevice, LinuxDeviceCgroup, LinuxDeviceType, LinuxResources};
 use procfs::process::Process;
 #[cfg(feature = "systemd_cgroups")]
 use systemd::daemon::booted;
@@ -226,4 +226,113 @@ impl PathBufExt for PathBuf {
         }
         Ok(PathBuf::from(format!("{}{}", self.display(), p.display())))
     }
+}
+
+pub(crate) fn default_allow_devices() -> Vec<LinuxDeviceCgroup> {
+    vec![
+        LinuxDeviceCgroup {
+            allow: true,
+            typ: Some(LinuxDeviceType::C),
+            major: None,
+            minor: None,
+            access: "m".to_string().into(),
+        },
+        LinuxDeviceCgroup {
+            allow: true,
+            typ: Some(LinuxDeviceType::B),
+            major: None,
+            minor: None,
+            access: "m".to_string().into(),
+        },
+        // /dev/console
+        LinuxDeviceCgroup {
+            allow: true,
+            typ: Some(LinuxDeviceType::C),
+            major: Some(5),
+            minor: Some(1),
+            access: "rwm".to_string().into(),
+        },
+        // /dev/pts
+        LinuxDeviceCgroup {
+            allow: true,
+            typ: Some(LinuxDeviceType::C),
+            major: Some(136),
+            minor: None,
+            access: "rwm".to_string().into(),
+        },
+        LinuxDeviceCgroup {
+            allow: true,
+            typ: Some(LinuxDeviceType::C),
+            major: Some(5),
+            minor: Some(2),
+            access: "rwm".to_string().into(),
+        },
+        // tun/tap
+        LinuxDeviceCgroup {
+            allow: true,
+            typ: Some(LinuxDeviceType::C),
+            major: Some(10),
+            minor: Some(200),
+            access: "rwm".to_string().into(),
+        },
+    ]
+}
+
+pub(crate) fn default_devices() -> Vec<LinuxDevice> {
+    vec![
+        LinuxDevice {
+            path: PathBuf::from("/dev/null"),
+            typ: LinuxDeviceType::C,
+            major: 1,
+            minor: 3,
+            file_mode: Some(0o066),
+            uid: None,
+            gid: None,
+        },
+        LinuxDevice {
+            path: PathBuf::from("/dev/zero"),
+            typ: LinuxDeviceType::C,
+            major: 1,
+            minor: 5,
+            file_mode: Some(0o066),
+            uid: None,
+            gid: None,
+        },
+        LinuxDevice {
+            path: PathBuf::from("/dev/full"),
+            typ: LinuxDeviceType::C,
+            major: 1,
+            minor: 7,
+            file_mode: Some(0o066),
+            uid: None,
+            gid: None,
+        },
+        LinuxDevice {
+            path: PathBuf::from("/dev/tty"),
+            typ: LinuxDeviceType::C,
+            major: 5,
+            minor: 0,
+            file_mode: Some(0o066),
+            uid: None,
+            gid: None,
+        },
+        LinuxDevice {
+            path: PathBuf::from("/dev/urandom"),
+            typ: LinuxDeviceType::C,
+            major: 1,
+            minor: 9,
+            file_mode: Some(0o066),
+            uid: None,
+            gid: None,
+        },
+        LinuxDevice {
+            path: PathBuf::from("/dev/random"),
+            typ: LinuxDeviceType::C,
+            major: 1,
+            minor: 8,
+            file_mode: Some(0o066),
+            uid: None,
+            gid: None,
+        },
+    ]
 }

--- a/cgroups/src/v2/controller_type.rs
+++ b/cgroups/src/v2/controller_type.rs
@@ -1,3 +1,5 @@
+use std::fmt::Display;
+
 pub enum ControllerType {
     Cpu,
     CpuSet,
@@ -6,20 +8,51 @@ pub enum ControllerType {
     HugeTlb,
     Pids,
     Freezer,
-    Devices,
 }
 
-impl ToString for ControllerType {
-    fn to_string(&self) -> String {
-        match self {
-            Self::Cpu => "cpu".into(),
-            Self::CpuSet => "cpuset".into(),
-            Self::Io => "io".into(),
-            Self::Memory => "memory".into(),
-            Self::HugeTlb => "hugetlb".into(),
-            Self::Pids => "pids".into(),
-            Self::Freezer => "freezer".into(),
-            Self::Devices => "devices".into(),
-        }
+impl Display for ControllerType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let print = match self {
+            Self::Cpu => "cpu",
+            Self::CpuSet => "cpuset",
+            Self::Io => "io",
+            Self::Memory => "memory",
+            Self::HugeTlb => "hugetlb",
+            Self::Pids => "pids",
+            Self::Freezer => "freezer",
+        };
+
+        write!(f, "{}", print)
     }
 }
+
+pub const CONTROLLER_TYPES: &[ControllerType] = &[
+    ControllerType::Cpu,
+    ControllerType::CpuSet,
+    ControllerType::HugeTlb,
+    ControllerType::Io,
+    ControllerType::Memory,
+    ControllerType::Pids,
+    ControllerType::Freezer,
+];
+
+pub enum PseudoControllerType {
+    Devices,
+    Unified,
+}
+
+impl Display for PseudoControllerType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let print = match self {
+            Self::Devices => "devices",
+            Self::Unified => "unified",
+        };
+
+        write!(f, "{}", print)
+    }
+}
+
+pub const PSEUDO_CONTROLLER_TYPES: &[PseudoControllerType] = &[
+    PseudoControllerType::Devices,
+    PseudoControllerType::Unified,
+];

--- a/cgroups/src/v2/controller_type.rs
+++ b/cgroups/src/v2/controller_type.rs
@@ -52,7 +52,5 @@ impl Display for PseudoControllerType {
     }
 }
 
-pub const PSEUDO_CONTROLLER_TYPES: &[PseudoControllerType] = &[
-    PseudoControllerType::Devices,
-    PseudoControllerType::Unified,
-];
+pub const PSEUDO_CONTROLLER_TYPES: &[PseudoControllerType] =
+    &[PseudoControllerType::Devices, PseudoControllerType::Unified];

--- a/cgroups/src/v2/controller_type.rs
+++ b/cgroups/src/v2/controller_type.rs
@@ -6,6 +6,7 @@ pub enum ControllerType {
     HugeTlb,
     Pids,
     Freezer,
+    Devices,
 }
 
 impl ToString for ControllerType {
@@ -18,6 +19,7 @@ impl ToString for ControllerType {
             Self::HugeTlb => "hugetlb".into(),
             Self::Pids => "pids".into(),
             Self::Freezer => "freezer".into(),
+            Self::Devices => "devices".into(),
         }
     }
 }

--- a/cgroups/src/v2/devices/bpf.rs
+++ b/cgroups/src/v2/devices/bpf.rs
@@ -1,0 +1,116 @@
+use anyhow::{bail, Result};
+use std::os::unix::io::RawFd;
+
+// FIXME: add tests
+
+pub fn prog_load(license: &str, insns: &[u8]) -> Result<RawFd> {
+    let insns_cnt = insns.len() / std::mem::size_of::<libbpf_sys::bpf_insn>();
+    let insns = insns as *const _ as *const libbpf_sys::bpf_insn;
+
+    let prog_fd = unsafe {
+        libbpf_sys::bpf_load_program(
+            libbpf_sys::BPF_PROG_TYPE_CGROUP_DEVICE,
+            insns,
+            insns_cnt as u64,
+            license as *const _ as *const i8,
+            0,
+            0 as *mut i8,
+            0,
+        )
+    };
+
+    if prog_fd < 0 {
+        return Err(errno::errno().into());
+    }
+    Ok(prog_fd)
+}
+
+pub struct ProgramInfo {
+    pub id: u32,
+    pub fd: i32,
+}
+
+pub fn prog_query(cgroup_fd: RawFd) -> Result<Vec<ProgramInfo>> {
+    let mut prog_ids: Vec<u32> = vec![0_u32; 64];
+    let mut attach_flags = 0_u32;
+    for _ in 0..10 {
+        let mut prog_cnt = prog_ids.len() as u32;
+        let ret = unsafe {
+            libbpf_sys::bpf_prog_query(
+                cgroup_fd,
+                libbpf_sys::BPF_CGROUP_DEVICE,
+                0,
+                &mut attach_flags,
+                &prog_ids[0] as *const u32 as *mut u32,
+                &mut prog_cnt,
+            )
+        };
+        if ret != 0 {
+            let err = errno::errno();
+            if err.0 == libc::ENOSPC {
+                assert!(prog_cnt as usize > prog_ids.len());
+
+                // allocate more space and try again
+                prog_ids.resize(prog_cnt as usize, 0);
+                continue;
+            }
+
+            return Err(err.into());
+        }
+
+        prog_ids.resize(prog_cnt as usize, 0);
+        break;
+    }
+
+    let mut prog_fds = Vec::with_capacity(prog_ids.len());
+    for prog_id in &prog_ids {
+        let prog_fd = unsafe { libbpf_sys::bpf_prog_get_fd_by_id(*prog_id) };
+        if prog_fd < 0 {
+            log::debug!("bpf_prog_get_fd_by_id failed: {}", errno::errno());
+            continue;
+        }
+        prog_fds.push(ProgramInfo {
+            id: *prog_id,
+            fd: prog_fd,
+        });
+    }
+    Ok(prog_fds)
+}
+
+pub fn prog_detach2(prog_fd: RawFd, cgroup_fd: RawFd) -> Result<()> {
+    let ret =
+        unsafe { libbpf_sys::bpf_prog_detach2(prog_fd, cgroup_fd, libbpf_sys::BPF_CGROUP_DEVICE) };
+    if ret != 0 {
+        return Err(errno::errno().into());
+    }
+    Ok(())
+}
+
+pub fn prog_attach(prog_fd: RawFd, cgroup_fd: RawFd) -> Result<()> {
+    let ret = unsafe {
+        libbpf_sys::bpf_prog_attach(
+            prog_fd,
+            cgroup_fd,
+            libbpf_sys::BPF_CGROUP_DEVICE,
+            libbpf_sys::BPF_F_ALLOW_MULTI,
+        )
+    };
+
+    if ret != 0 {
+        return Err(errno::errno().into());
+    }
+    Ok(())
+}
+
+pub fn bump_memlock_rlimit() -> Result<()> {
+    let rlimit = libc::rlimit {
+        rlim_cur: 128 << 20,
+        rlim_max: 128 << 20,
+    };
+
+    if unsafe { libc::setrlimit(libc::RLIMIT_MEMLOCK, &rlimit) } != 0 {
+        bail!("Failed to increase rlimit");
+    }
+
+    Ok(())
+}

--- a/cgroups/src/v2/devices/controller.rs
+++ b/cgroups/src/v2/devices/controller.rs
@@ -10,7 +10,6 @@ use oci_spec::{LinuxDevice, LinuxDeviceCgroup, LinuxDeviceType, LinuxResources};
 
 pub struct Devices {}
 
-// FIXME: which license?
 const LICENSE: &'static str = &"Apache";
 
 impl Devices {

--- a/cgroups/src/v2/devices/controller.rs
+++ b/cgroups/src/v2/devices/controller.rs
@@ -1,0 +1,186 @@
+use std::os::unix::io::AsRawFd;
+use std::path::{Path, PathBuf};
+
+use anyhow::Result;
+
+use super::*;
+use nix::fcntl::OFlag;
+use nix::sys::stat::Mode;
+use oci_spec::{LinuxDevice, LinuxDeviceCgroup, LinuxDeviceType, LinuxResources};
+
+pub struct Devices {}
+
+// FIXME: which license?
+const LICENSE: &'static str = &"Apache";
+
+impl Devices {
+    pub fn apply(linux_resources: &LinuxResources, cgroup_root: &Path) -> Result<()> {
+        log::debug!("Apply Devices cgroup config");
+
+        // FIXME: should we start as "deny all"?
+        let mut emulator = emulator::Emulator::with_default_allow(false);
+
+        // FIXME: apply user-defined and default rules in which order?
+        if let Some(devices) = linux_resources.devices.as_ref() {
+            for d in devices {
+                log::debug!("apply user defined rule: {:?}", d);
+                emulator.add_rule(d)?;
+            }
+        }
+
+        for d in [
+            Self::default_devices().iter().map(|d| d.into()).collect(),
+            Self::default_allow_devices(),
+        ]
+        .concat()
+        {
+            log::debug!("apply default rule: {:?}", d);
+            emulator.add_rule(&d)?;
+        }
+
+        let prog = program::Program::from_rules(&emulator.rules, emulator.default_allow)?;
+
+        // Increase `ulimit -l` limit to avoid BPF_PROG_LOAD error (#2167).
+        // This limit is not inherited into the container.
+        bpf::bump_memlock_rlimit()?;
+        let prog_fd = bpf::prog_load(LICENSE, prog.bytecodes())?;
+
+        // FIXME: simple way to attach BPF program
+        //  1. get list of existing attached programs
+        //  2. attach this program (not use BPF_F_REPLACE, see below)
+        //  3. detach all programs of 1
+        //
+        // runc will use BPF_F_REPLACE to replace currently attached progam if:
+        //   1. BPF_F_REPLACE is supported by kernel
+        //   2. there is exactly one attached program
+        // https://github.com/opencontainers/runc/blob/8e6871a3b14bb74e0ef358aca3b9f8f9cb80f041/libcontainer/cgroups/ebpf/ebpf_linux.go#L165
+        //
+        // IMHO, this is too complicated, and in most cases, we just attach program once without
+        // already attached programs.
+
+        let fd = nix::dir::Dir::open(
+            cgroup_root.as_os_str(),
+            OFlag::O_RDONLY | OFlag::O_DIRECTORY,
+            Mode::from_bits(0o600).unwrap(),
+        )?;
+
+        let old_progs = bpf::prog_query(fd.as_raw_fd())?;
+        bpf::prog_attach(prog_fd, fd.as_raw_fd())?;
+        for old_prog in old_progs {
+            bpf::prog_detach2(old_prog.fd, fd.as_raw_fd())?;
+        }
+
+        Ok(())
+    }
+    // FIXME: move to common
+    fn default_allow_devices() -> Vec<LinuxDeviceCgroup> {
+        vec![
+            LinuxDeviceCgroup {
+                allow: true,
+                typ: Some(LinuxDeviceType::C),
+                major: None,
+                minor: None,
+                access: "m".to_string().into(),
+            },
+            LinuxDeviceCgroup {
+                allow: true,
+                typ: Some(LinuxDeviceType::B),
+                major: None,
+                minor: None,
+                access: "m".to_string().into(),
+            },
+            // /dev/console
+            LinuxDeviceCgroup {
+                allow: true,
+                typ: Some(LinuxDeviceType::C),
+                major: Some(5),
+                minor: Some(1),
+                access: "rwm".to_string().into(),
+            },
+            // /dev/pts
+            LinuxDeviceCgroup {
+                allow: true,
+                typ: Some(LinuxDeviceType::C),
+                major: Some(136),
+                minor: None,
+                access: "rwm".to_string().into(),
+            },
+            LinuxDeviceCgroup {
+                allow: true,
+                typ: Some(LinuxDeviceType::C),
+                major: Some(5),
+                minor: Some(2),
+                access: "rwm".to_string().into(),
+            },
+            // tun/tap
+            LinuxDeviceCgroup {
+                allow: true,
+                typ: Some(LinuxDeviceType::C),
+                major: Some(10),
+                minor: Some(200),
+                access: "rwm".to_string().into(),
+            },
+        ]
+    }
+
+    pub fn default_devices() -> Vec<LinuxDevice> {
+        vec![
+            LinuxDevice {
+                path: PathBuf::from("/dev/null"),
+                typ: LinuxDeviceType::C,
+                major: 1,
+                minor: 3,
+                file_mode: Some(0o066),
+                uid: None,
+                gid: None,
+            },
+            LinuxDevice {
+                path: PathBuf::from("/dev/zero"),
+                typ: LinuxDeviceType::C,
+                major: 1,
+                minor: 5,
+                file_mode: Some(0o066),
+                uid: None,
+                gid: None,
+            },
+            LinuxDevice {
+                path: PathBuf::from("/dev/full"),
+                typ: LinuxDeviceType::C,
+                major: 1,
+                minor: 7,
+                file_mode: Some(0o066),
+                uid: None,
+                gid: None,
+            },
+            LinuxDevice {
+                path: PathBuf::from("/dev/tty"),
+                typ: LinuxDeviceType::C,
+                major: 5,
+                minor: 0,
+                file_mode: Some(0o066),
+                uid: None,
+                gid: None,
+            },
+            LinuxDevice {
+                path: PathBuf::from("/dev/urandom"),
+                typ: LinuxDeviceType::C,
+                major: 1,
+                minor: 9,
+                file_mode: Some(0o066),
+                uid: None,
+                gid: None,
+            },
+            LinuxDevice {
+                path: PathBuf::from("/dev/random"),
+                typ: LinuxDeviceType::C,
+                major: 1,
+                minor: 8,
+                file_mode: Some(0o066),
+                uid: None,
+                gid: None,
+            },
+        ]
+    }
+}
+
+// FIXME: add tests, but how to?

--- a/cgroups/src/v2/devices/controller.rs
+++ b/cgroups/src/v2/devices/controller.rs
@@ -1,13 +1,14 @@
 use std::os::unix::io::AsRawFd;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use anyhow::Result;
 
 use super::*;
 use nix::fcntl::OFlag;
 use nix::sys::stat::Mode;
-use oci_spec::{LinuxDevice, LinuxDeviceCgroup, LinuxDeviceType, LinuxResources};
+use oci_spec::{LinuxDeviceCgroup, LinuxResources};
 
+use crate::common::{default_allow_devices, default_devices};
 use crate::v2::controller::Controller;
 
 const LICENSE: &'static str = &"Apache";
@@ -20,19 +21,22 @@ impl Controller for Devices {
         return Ok(());
 
         #[cfg(feature = "cgroupsv2_devices")]
-        return controller::Devices::apply(linux_resources, cgroup_root);
+        return Self::apply_devices(cgroup_root, &linux_resources.devices);
     }
 }
 
 impl Devices {
-    pub fn apply(linux_resources: &LinuxResources, cgroup_root: &Path) -> Result<()> {
+    pub fn apply_devices(
+        cgroup_root: &Path,
+        linux_devices: &Option<Vec<LinuxDeviceCgroup>>,
+    ) -> Result<()> {
         log::debug!("Apply Devices cgroup config");
 
         // FIXME: should we start as "deny all"?
         let mut emulator = emulator::Emulator::with_default_allow(false);
 
         // FIXME: apply user-defined and default rules in which order?
-        if let Some(devices) = linux_resources.devices.as_ref() {
+        if let Some(devices) = linux_devices {
             for d in devices {
                 log::debug!("apply user defined rule: {:?}", d);
                 emulator.add_rule(d)?;
@@ -40,8 +44,8 @@ impl Devices {
         }
 
         for d in [
-            Self::default_devices().iter().map(|d| d.into()).collect(),
-            Self::default_allow_devices(),
+            default_devices().iter().map(|d| d.into()).collect(),
+            default_allow_devices(),
         ]
         .concat()
         {
@@ -82,115 +86,6 @@ impl Devices {
         }
 
         Ok(())
-    }
-    // FIXME: move to common
-    fn default_allow_devices() -> Vec<LinuxDeviceCgroup> {
-        vec![
-            LinuxDeviceCgroup {
-                allow: true,
-                typ: Some(LinuxDeviceType::C),
-                major: None,
-                minor: None,
-                access: "m".to_string().into(),
-            },
-            LinuxDeviceCgroup {
-                allow: true,
-                typ: Some(LinuxDeviceType::B),
-                major: None,
-                minor: None,
-                access: "m".to_string().into(),
-            },
-            // /dev/console
-            LinuxDeviceCgroup {
-                allow: true,
-                typ: Some(LinuxDeviceType::C),
-                major: Some(5),
-                minor: Some(1),
-                access: "rwm".to_string().into(),
-            },
-            // /dev/pts
-            LinuxDeviceCgroup {
-                allow: true,
-                typ: Some(LinuxDeviceType::C),
-                major: Some(136),
-                minor: None,
-                access: "rwm".to_string().into(),
-            },
-            LinuxDeviceCgroup {
-                allow: true,
-                typ: Some(LinuxDeviceType::C),
-                major: Some(5),
-                minor: Some(2),
-                access: "rwm".to_string().into(),
-            },
-            // tun/tap
-            LinuxDeviceCgroup {
-                allow: true,
-                typ: Some(LinuxDeviceType::C),
-                major: Some(10),
-                minor: Some(200),
-                access: "rwm".to_string().into(),
-            },
-        ]
-    }
-
-    pub fn default_devices() -> Vec<LinuxDevice> {
-        vec![
-            LinuxDevice {
-                path: PathBuf::from("/dev/null"),
-                typ: LinuxDeviceType::C,
-                major: 1,
-                minor: 3,
-                file_mode: Some(0o066),
-                uid: None,
-                gid: None,
-            },
-            LinuxDevice {
-                path: PathBuf::from("/dev/zero"),
-                typ: LinuxDeviceType::C,
-                major: 1,
-                minor: 5,
-                file_mode: Some(0o066),
-                uid: None,
-                gid: None,
-            },
-            LinuxDevice {
-                path: PathBuf::from("/dev/full"),
-                typ: LinuxDeviceType::C,
-                major: 1,
-                minor: 7,
-                file_mode: Some(0o066),
-                uid: None,
-                gid: None,
-            },
-            LinuxDevice {
-                path: PathBuf::from("/dev/tty"),
-                typ: LinuxDeviceType::C,
-                major: 5,
-                minor: 0,
-                file_mode: Some(0o066),
-                uid: None,
-                gid: None,
-            },
-            LinuxDevice {
-                path: PathBuf::from("/dev/urandom"),
-                typ: LinuxDeviceType::C,
-                major: 1,
-                minor: 9,
-                file_mode: Some(0o066),
-                uid: None,
-                gid: None,
-            },
-            LinuxDevice {
-                path: PathBuf::from("/dev/random"),
-                typ: LinuxDeviceType::C,
-                major: 1,
-                minor: 8,
-                file_mode: Some(0o066),
-                uid: None,
-                gid: None,
-            },
-        ]
     }
 }
 

--- a/cgroups/src/v2/devices/controller.rs
+++ b/cgroups/src/v2/devices/controller.rs
@@ -8,9 +8,21 @@ use nix::fcntl::OFlag;
 use nix::sys::stat::Mode;
 use oci_spec::{LinuxDevice, LinuxDeviceCgroup, LinuxDeviceType, LinuxResources};
 
-pub struct Devices {}
+use crate::v2::controller::Controller;
 
 const LICENSE: &'static str = &"Apache";
+
+pub struct Devices {}
+
+impl Controller for Devices {
+    fn apply(linux_resources: &LinuxResources, cgroup_root: &Path) -> Result<()> {
+        #[cfg(not(feature = "cgroupsv2_devices"))]
+        return Ok(());
+
+        #[cfg(feature = "cgroupsv2_devices")]
+        return controller::Devices::apply(linux_resources, cgroup_root);
+    }
+}
 
 impl Devices {
     pub fn apply(linux_resources: &LinuxResources, cgroup_root: &Path) -> Result<()> {

--- a/cgroups/src/v2/devices/emulator.rs
+++ b/cgroups/src/v2/devices/emulator.rs
@@ -1,0 +1,57 @@
+use anyhow::Result;
+use oci_spec::*;
+
+// For cgroup v1 compatiblity, runc implements a device emulator to caculate the final rules given
+// a list of user-defined rules.
+// https://github.com/opencontainers/runc/commit/2353ffec2bb670a200009dc7a54a56b93145f141
+//
+// I chose to implement a very simple algorithm, which will just work in most cases, but with
+// diversion from cgroupv1 in some cases:
+//  1. just add used-defined rules one by one
+//  2. discard existing rules when encountering a rule with type='a', and change to deny/allow all
+//     list according the 'allow' of the rule
+//  3. bpf program will check rule one by one in *reversed* order, return action of first rule
+//     which matches device access operation
+//
+
+// FIXME: should we use runc's implementation?
+pub struct Emulator {
+    pub default_allow: bool,
+    pub rules: Vec<LinuxDeviceCgroup>,
+}
+
+impl Emulator {
+    pub fn with_default_allow(default_allow: bool) -> Self {
+        Emulator {
+            default_allow,
+            rules: Vec::new(),
+        }
+    }
+
+    pub fn add_rules(&mut self, rules: &Vec<oci_spec::LinuxDeviceCgroup>) -> Result<()> {
+        for rule in rules {
+            self.add_rule(rule)?;
+        }
+        Ok(())
+    }
+
+    pub fn add_rule(&mut self, rule: &oci_spec::LinuxDeviceCgroup) -> Result<()> {
+        // special case, switch to blacklist or whitelist and clear all existing rules
+        // NOTE: we ignore other fields when type='a', this is same as cgroup v1 and runc
+        if rule.typ.clone().unwrap_or_default() == oci_spec::LinuxDeviceType::A {
+            self.default_allow = rule.allow;
+            self.rules.clear();
+            return Ok(());
+        }
+
+        // empty access match nothing, just discard this rule
+        if rule.access.is_none() {
+            return Ok(());
+        }
+
+        self.rules.push(rule.clone());
+        Ok(())
+    }
+}
+
+// FIXME: add some tests

--- a/cgroups/src/v2/devices/mod.rs
+++ b/cgroups/src/v2/devices/mod.rs
@@ -4,6 +4,3 @@ pub mod emulator;
 pub mod program;
 
 pub use controller::Devices;
-
-
-

--- a/cgroups/src/v2/devices/mod.rs
+++ b/cgroups/src/v2/devices/mod.rs
@@ -1,21 +1,9 @@
 pub mod bpf;
-mod controller;
+pub mod controller;
 pub mod emulator;
 pub mod program;
 
-use crate::v2::controller::Controller;
-use anyhow::Result;
-use oci_spec::LinuxResources;
-use std::path::Path;
+pub use controller::Devices;
 
-pub struct Devices {}
 
-impl Controller for Devices {
-    fn apply(linux_resources: &LinuxResources, cgroup_root: &Path) -> Result<()> {
-        #[cfg(not(feature = "cgroupsv2_devices"))]
-        return Ok(());
 
-        #[cfg(feature = "cgroupsv2_devices")]
-        return controller::Devices::apply(linux_resources, cgroup_root);
-    }
-}

--- a/cgroups/src/v2/devices/mod.rs
+++ b/cgroups/src/v2/devices/mod.rs
@@ -1,0 +1,21 @@
+pub mod bpf;
+mod controller;
+pub mod emulator;
+pub mod program;
+
+use crate::v2::controller::Controller;
+use anyhow::Result;
+use oci_spec::LinuxResources;
+use std::path::Path;
+
+pub struct Devices {}
+
+impl Controller for Devices {
+    fn apply(linux_resources: &LinuxResources, cgroup_root: &Path) -> Result<()> {
+        #[cfg(not(feature = "cgroupsv2_devices"))]
+        return Ok(());
+
+        #[cfg(feature = "cgroupsv2_devices")]
+        return controller::Devices::apply(linux_resources, cgroup_root);
+    }
+}

--- a/cgroups/src/v2/devices/program.rs
+++ b/cgroups/src/v2/devices/program.rs
@@ -248,7 +248,7 @@ fn bpf_cgroup_dev_ctx(
 mod tests {
     use super::*;
 
-    pub fn build_bpf_program(rules: &Option<Vec<oci_spec::LinuxDeviceCgroup>>) -> Result<Program> {
+    fn build_bpf_program(rules: &Option<Vec<oci_spec::LinuxDeviceCgroup>>) -> Result<Program> {
         let mut em = crate::v2::devices::emulator::Emulator::with_default_allow(false);
         if let Some(rules) = rules {
             em.add_rules(rules)?;

--- a/cgroups/src/v2/devices/program.rs
+++ b/cgroups/src/v2/devices/program.rs
@@ -1,0 +1,468 @@
+use anyhow::{bail, Result};
+use oci_spec::*;
+
+use rbpf::disassembler::disassemble;
+use rbpf::insn_builder::Arch as RbpfArch;
+use rbpf::insn_builder::*;
+
+pub struct Program {
+    prog: BpfCode,
+}
+
+impl Program {
+    pub fn from_rules(rules: &Vec<LinuxDeviceCgroup>, default_allow: bool) -> Result<Self> {
+        let mut prog = Program {
+            prog: BpfCode::new(),
+        };
+        prog.init();
+
+        for rule in rules.iter().rev() {
+            prog.add_rule(rule)?;
+        }
+        prog.finalize(default_allow);
+        Ok(prog)
+    }
+
+    pub fn bytecodes(&self) -> &[u8] {
+        self.prog.into_bytes()
+    }
+
+    fn finalize(&mut self, default_allow: bool) {
+        self.prog
+            .mov(Source::Imm, RbpfArch::X32)
+            .set_dst(0)
+            .set_imm(default_allow as i32)
+            .push();
+
+        self.prog.exit().push();
+    }
+
+    // struct bpf_cgroup_dev_ctx: https://elixir.bootlin.com/linux/v5.3.6/source/include/uapi/linux/bpf.h#L3423
+    /*
+    u32 access_type
+    u32 major
+    u32 minor
+    */
+    // R2 <- type (lower 16 bit of u32 access_type at R1[0])
+    // R3 <- access (upper 16 bit of u32 access_type at R1[0])
+    // R4 <- major (u32 major at R1[4])
+    // R5 <- minor (u32 minor at R1[8])
+    fn init(&mut self) {
+        self.prog
+            .load_x(MemSize::Word)
+            .set_src(1)
+            .set_off(0)
+            .set_dst(2)
+            .push();
+
+        self.prog
+            .bit_and(Source::Imm, RbpfArch::X32)
+            .set_dst(2)
+            .set_imm(0xFFFF)
+            .push();
+
+        self.prog
+            .load_x(MemSize::Word)
+            .set_src(1)
+            .set_off(0)
+            .set_dst(3)
+            .push();
+
+        self.prog
+            .right_shift(Source::Imm, RbpfArch::X32)
+            .set_imm(16)
+            .set_dst(3)
+            .push();
+
+        self.prog
+            .load_x(MemSize::Word)
+            .set_src(1)
+            .set_off(4)
+            .set_dst(4)
+            .push();
+
+        self.prog
+            .load_x(MemSize::Word)
+            .set_src(1)
+            .set_off(8)
+            .set_dst(5)
+            .push();
+    }
+
+    fn add_rule(&mut self, rule: &LinuxDeviceCgroup) -> Result<()> {
+        let dev_type = bpf_dev_type(rule.typ.clone().unwrap_or_default())?;
+        let access = bpf_access(rule.access.clone().unwrap_or_default())?;
+        let has_access = access
+            != (libbpf_sys::BPF_DEVCG_ACC_READ
+                | libbpf_sys::BPF_DEVCG_ACC_WRITE
+                | libbpf_sys::BPF_DEVCG_ACC_MKNOD);
+
+        let has_major = rule.major.is_some() && rule.major.unwrap() >= 0;
+        let has_minor = rule.minor.is_some() && rule.minor.unwrap() >= 0;
+
+        // count of instructions of this rule
+        let mut instruction_count = 1; // execute dev_type
+        if has_access {
+            instruction_count += 3;
+        }
+        if has_major {
+            instruction_count += 1;
+        }
+        if has_minor {
+            instruction_count += 1;
+        }
+        instruction_count += 2;
+
+        // if (R2 != dev_type) goto next rule
+        let mut next_rule_offset = instruction_count - 1;
+        self.prog
+            .jump_conditional(Cond::NotEquals, Source::Imm)
+            .set_dst(2)
+            .set_imm(dev_type as i32)
+            .set_off(next_rule_offset)
+            .push();
+
+        if has_access {
+            next_rule_offset -= 3;
+            // if (R3 & access != R3 /* use R1 as a temp var */) goto next rule
+            self.prog
+                .mov(Source::Reg, RbpfArch::X32)
+                .set_dst(1)
+                .set_src(3)
+                .push();
+
+            self.prog
+                .bit_and(Source::Imm, RbpfArch::X32)
+                .set_dst(1)
+                .set_imm(access as i32)
+                .push();
+
+            self.prog
+                .jump_conditional(Cond::NotEquals, Source::Reg)
+                .set_dst(1)
+                .set_src(3)
+                .set_off(next_rule_offset)
+                .push();
+        }
+
+        if has_major {
+            next_rule_offset -= 1;
+            // if (R4 != major) goto next rule
+            self.prog
+                .jump_conditional(Cond::NotEquals, Source::Imm)
+                .set_dst(4)
+                .set_imm(rule.major.unwrap() as i32)
+                .set_off(next_rule_offset)
+                .push();
+        }
+
+        if has_minor {
+            next_rule_offset -= 1;
+            // if (R5 != minor) goto next rule
+            self.prog
+                .jump_conditional(Cond::NotEquals, Source::Imm)
+                .set_dst(5)
+                .set_imm(rule.minor.unwrap() as i32)
+                .set_off(next_rule_offset)
+                .push();
+        }
+
+        // matched, return rule.allow
+        self.prog
+            .mov(Source::Imm, RbpfArch::X32)
+            .set_dst(0)
+            .set_imm(rule.allow as i32)
+            .push();
+        self.prog.exit().push();
+
+        Ok(())
+    }
+
+    pub fn dump(&self) {
+        disassemble(self.prog.into_bytes());
+    }
+
+    pub fn execute(
+        &self,
+        typ: LinuxDeviceType,
+        major: u32,
+        minor: u32,
+        access: String,
+    ) -> Result<u64> {
+        let mut mem = bpf_cgroup_dev_ctx(typ, major, minor, access)?;
+        let vm = rbpf::EbpfVmRaw::new(Some(self.prog.into_bytes()))?;
+        let result = vm.execute_program(&mut mem[..])?;
+        Ok(result)
+    }
+}
+
+fn bpf_dev_type(typ: LinuxDeviceType) -> Result<u32> {
+    let dev_type: u32 = match typ {
+        LinuxDeviceType::C => libbpf_sys::BPF_DEVCG_DEV_CHAR,
+        LinuxDeviceType::U => bail!("unbuffered char device not supported"),
+        LinuxDeviceType::B => libbpf_sys::BPF_DEVCG_DEV_BLOCK,
+        LinuxDeviceType::P => bail!("pipe device not supported"),
+        LinuxDeviceType::A => {
+            bail!("wildcard device type should be removed when cleaning rules")
+        }
+    };
+    Ok(dev_type)
+}
+
+fn bpf_access(access: String) -> Result<u32> {
+    let mut v = 0_u32;
+    for c in access.chars() {
+        let cur_access = match c {
+            'r' => libbpf_sys::BPF_DEVCG_ACC_READ,
+            'w' => libbpf_sys::BPF_DEVCG_ACC_WRITE,
+            'm' => libbpf_sys::BPF_DEVCG_ACC_MKNOD,
+            _ => bail!("invalid access: {}", c),
+        };
+        v |= cur_access;
+    }
+    Ok(v)
+}
+
+fn bpf_cgroup_dev_ctx(
+    typ: LinuxDeviceType,
+    major: u32,
+    minor: u32,
+    access: String,
+) -> Result<Vec<u8>> {
+    let mut mem = Vec::with_capacity(12);
+
+    let mut type_access = 0_u32;
+    if let Ok(t) = bpf_dev_type(typ) {
+        type_access = t & 0xFFFF;
+    }
+
+    type_access |= bpf_access(access)? << 16;
+
+    mem.extend_from_slice(&type_access.to_ne_bytes());
+    mem.extend_from_slice(&major.to_ne_bytes());
+    mem.extend_from_slice(&minor.to_ne_bytes());
+
+    Ok(mem)
+}
+
+mod tests {
+    use super::*;
+
+    pub fn build_bpf_program(rules: &Option<Vec<oci_spec::LinuxDeviceCgroup>>) -> Result<Program> {
+        let mut em = crate::v2::devices::emulator::Emulator::with_default_allow(false);
+        if let Some(rules) = rules {
+            em.add_rules(rules)?;
+        }
+
+        Program::from_rules(&em.rules, em.default_allow)
+    }
+
+    #[test]
+    fn test_devices_allow_single() {
+        let rules = vec![LinuxDeviceCgroup {
+            allow: true,
+            typ: Some(LinuxDeviceType::C),
+            major: Some(10),
+            minor: Some(20),
+            access: "r".to_string().into(),
+        }];
+
+        let prog = build_bpf_program(&Some(rules)).unwrap();
+        let ty_list = vec![
+            LinuxDeviceType::C,
+            LinuxDeviceType::U,
+            LinuxDeviceType::P,
+            LinuxDeviceType::B,
+        ];
+        let major_list = vec![10_u32, 99_u32];
+        let minor_list = vec![20_u32, 00_u32];
+        let access_list = vec!["r", "w", "m"];
+        for ty in &ty_list {
+            for major in &major_list {
+                for minor in &minor_list {
+                    for access in &access_list {
+                        let ret = prog.execute(*ty, *major, *minor, access.to_string());
+                        assert!(ret.is_ok());
+
+                        println!(
+                            "execute {:?} {} {} {} -> {:?}",
+                            ty, major, minor, access, ret
+                        );
+                        if *ty == LinuxDeviceType::C  // only this is allowed
+                            && *major == 10
+                                && *minor == 20
+                                && access.eq(&"r")
+                        {
+                            assert_eq!(ret.unwrap(), 1);
+                        } else {
+                            assert_eq!(ret.unwrap(), 0);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn test_devices_deny_all() {
+        let rules = vec![];
+
+        let prog = build_bpf_program(&Some(rules)).unwrap();
+        let ty_list = vec![
+            LinuxDeviceType::C,
+            LinuxDeviceType::U,
+            LinuxDeviceType::P,
+            LinuxDeviceType::B,
+        ];
+        let major_list = vec![10_u32, 99_u32];
+        let minor_list = vec![20_u32, 00_u32];
+        let access_list = vec!["r", "w", "m"];
+        for ty in &ty_list {
+            for major in &major_list {
+                for minor in &minor_list {
+                    for access in &access_list {
+                        let ret = prog.execute(*ty, *major, *minor, access.to_string());
+                        assert!(ret.is_ok());
+                        assert_eq!(ret.unwrap(), 0);
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn test_devices_allow_all() {
+        let rules = vec![LinuxDeviceCgroup {
+            allow: true,
+            typ: Some(LinuxDeviceType::A),
+            major: None,
+            minor: None,
+            access: None,
+        }];
+
+        let prog = build_bpf_program(&Some(rules)).unwrap();
+        let ty_list = vec![
+            LinuxDeviceType::C,
+            LinuxDeviceType::U,
+            LinuxDeviceType::P,
+            LinuxDeviceType::B,
+        ];
+        let major_list = vec![10_u32, 99_u32];
+        let minor_list = vec![20_u32, 00_u32];
+        let access_list = vec!["r", "w", "m"];
+        for ty in &ty_list {
+            for major in &major_list {
+                for minor in &minor_list {
+                    for access in &access_list {
+                        let ret = prog.execute(*ty, *major, *minor, access.to_string());
+                        assert!(ret.is_ok());
+
+                        println!(
+                            "execute {:?} {} {} {} -> {:?}",
+                            ty, major, minor, access, ret
+                        );
+                        assert_eq!(ret.unwrap(), 1);
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn test_devices_allow_wildcard() {
+        let rules = vec![LinuxDeviceCgroup {
+            allow: true,
+            typ: Some(LinuxDeviceType::C),
+            major: None,
+            minor: Some(20),
+            access: "r".to_string().into(),
+        }];
+
+        let prog = build_bpf_program(&Some(rules)).unwrap();
+        let ty_list = vec![
+            LinuxDeviceType::C,
+            LinuxDeviceType::U,
+            LinuxDeviceType::P,
+            LinuxDeviceType::B,
+        ];
+        let major_list = vec![10_u32, 99_u32];
+        let minor_list = vec![20_u32, 00_u32];
+        let access_list = vec!["r", "w", "m"];
+        for ty in &ty_list {
+            for major in &major_list {
+                for minor in &minor_list {
+                    for access in &access_list {
+                        let ret = prog.execute(*ty, *major, *minor, access.to_string());
+                        assert!(ret.is_ok());
+
+                        println!(
+                            "execute {:?} {} {} {} -> {:?}",
+                            ty, major, minor, access, ret
+                        );
+                        if *ty == LinuxDeviceType::C && *minor == 20 && access.eq(&"r") {
+                            assert_eq!(ret.unwrap(), 1);
+                        } else {
+                            assert_eq!(ret.unwrap(), 0);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn test_devices_allow_and_deny() {
+        let rules = vec![
+            LinuxDeviceCgroup {
+                allow: true,
+                typ: Some(LinuxDeviceType::C),
+                major: None,
+                minor: Some(20),
+                access: "rw".to_string().into(),
+            },
+            LinuxDeviceCgroup {
+                allow: false,
+                typ: Some(LinuxDeviceType::C),
+                major: Some(10),
+                minor: None,
+                access: "r".to_string().into(),
+            },
+        ];
+
+        let prog = build_bpf_program(&Some(rules)).unwrap();
+        let ty_list = vec![
+            LinuxDeviceType::C,
+            LinuxDeviceType::U,
+            LinuxDeviceType::P,
+            LinuxDeviceType::B,
+        ];
+        let major_list = vec![10_u32, 99_u32];
+        let minor_list = vec![20_u32, 00_u32];
+        let access_list = vec!["r", "w", "m"];
+        for ty in &ty_list {
+            for major in &major_list {
+                for minor in &minor_list {
+                    for access in &access_list {
+                        let ret = prog.execute(*ty, *major, *minor, access.to_string());
+                        assert!(ret.is_ok());
+
+                        println!(
+                            "execute {:?} {} {} {} -> {:?}",
+                            ty, major, minor, access, ret
+                        );
+                        if *ty == LinuxDeviceType::C && *major == 10 && access.eq(&"r") {
+                            assert_eq!(ret.unwrap(), 0);
+                        } else if *ty == LinuxDeviceType::C
+                            && *minor == 20
+                            && (access.eq(&"r") || access.eq(&"w"))
+                        {
+                            assert_eq!(ret.unwrap(), 1);
+                        } else {
+                            assert_eq!(ret.unwrap(), 0);
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/cgroups/src/v2/manager.rs
+++ b/cgroups/src/v2/manager.rs
@@ -11,7 +11,8 @@ use oci_spec::{FreezerState, LinuxResources};
 
 use super::{
     controller::Controller, controller_type::ControllerType, cpu::Cpu, cpuset::CpuSet,
-    freezer::Freezer, hugetlb::HugeTlb, io::Io, memory::Memory, pids::Pids, unified::Unified,
+    devices::Devices, freezer::Freezer, hugetlb::HugeTlb, io::Io, memory::Memory, pids::Pids,
+    unified::Unified,
 };
 use crate::{
     common::{self, CgroupManager, PathBufExt, CGROUP_PROCS},
@@ -29,6 +30,7 @@ const CONTROLLER_TYPES: &[ControllerType] = &[
     ControllerType::Memory,
     ControllerType::Pids,
     ControllerType::Freezer,
+    ControllerType::Devices,
 ];
 
 pub struct Manager {
@@ -98,6 +100,7 @@ impl Manager {
                 "memory" => controllers.push(ControllerType::Memory),
                 "pids" => controllers.push(ControllerType::Pids),
                 "freezer" => controllers.push(ControllerType::Freezer),
+                "devices" => controllers.push(ControllerType::Devices),
                 tpe => log::warn!("Controller {} is not yet implemented.", tpe),
             }
         }
@@ -130,6 +133,7 @@ impl CgroupManager for Manager {
                 ControllerType::Memory => Memory::apply(linux_resources, &self.full_path)?,
                 ControllerType::Pids => Pids::apply(linux_resources, &self.full_path)?,
                 ControllerType::Freezer => Freezer::apply(linux_resources, &self.full_path)?,
+                ControllerType::Devices => Devices::apply(linux_resources, &self.full_path)?,
             }
         }
 

--- a/cgroups/src/v2/manager.rs
+++ b/cgroups/src/v2/manager.rs
@@ -9,7 +9,21 @@ use anyhow::{bail, Result};
 use nix::unistd::Pid;
 use oci_spec::{FreezerState, LinuxResources};
 
-use super::{controller::Controller, controller_type::{ControllerType, PseudoControllerType, CONTROLLER_TYPES, PSEUDO_CONTROLLER_TYPES}, cpu::Cpu, cpuset::CpuSet, devices::Devices, freezer::Freezer, hugetlb::HugeTlb, io::Io, memory::Memory, pids::Pids, unified::Unified};
+use super::{
+    controller::Controller,
+    controller_type::{
+        ControllerType, PseudoControllerType, CONTROLLER_TYPES, PSEUDO_CONTROLLER_TYPES,
+    },
+    cpu::Cpu,
+    cpuset::CpuSet,
+    devices::Devices,
+    freezer::Freezer,
+    hugetlb::HugeTlb,
+    io::Io,
+    memory::Memory,
+    pids::Pids,
+    unified::Unified,
+};
 use crate::{
     common::{self, CgroupManager, PathBufExt, CGROUP_PROCS},
     stats::{Stats, StatsProvider},
@@ -122,9 +136,15 @@ impl CgroupManager for Manager {
 
         for pseudoctlr in PSEUDO_CONTROLLER_TYPES {
             match pseudoctlr {
-                PseudoControllerType::Devices => Devices::apply(linux_resources, &self.full_path)?,
-                PseudoControllerType::Unified => Unified::apply(linux_resources, &self.cgroup_path, self.get_available_controllers()?)?,
-            }         
+                PseudoControllerType::Devices => {
+                    Devices::apply(linux_resources, &self.cgroup_path)?
+                }
+                PseudoControllerType::Unified => Unified::apply(
+                    linux_resources,
+                    &self.cgroup_path,
+                    self.get_available_controllers()?,
+                )?,
+            }
         }
 
         Ok(())

--- a/cgroups/src/v2/mod.rs
+++ b/cgroups/src/v2/mod.rs
@@ -12,4 +12,5 @@ pub mod systemd_manager;
 mod unified;
 pub mod util;
 pub use systemd_manager::SystemDCGroupManager;
+#[cfg(feature = "cgroupsv2_devices")]
 pub mod devices;

--- a/cgroups/src/v2/mod.rs
+++ b/cgroups/src/v2/mod.rs
@@ -12,3 +12,4 @@ pub mod systemd_manager;
 mod unified;
 pub mod util;
 pub use systemd_manager::SystemDCGroupManager;
+pub mod devices;

--- a/cgroups/src/v2/systemd_manager.rs
+++ b/cgroups/src/v2/systemd_manager.rs
@@ -8,10 +8,7 @@ use nix::unistd::Pid;
 use oci_spec::{FreezerState, LinuxResources};
 use std::path::{Path, PathBuf};
 
-use super::{
-    controller::Controller, controller_type::ControllerType, cpu::Cpu, cpuset::CpuSet,
-    devices::Devices, freezer::Freezer, hugetlb::HugeTlb, io::Io, memory::Memory, pids::Pids,
-};
+use super::{controller::Controller, controller_type::{ControllerType, PseudoControllerType}, cpu::Cpu, cpuset::CpuSet, devices::Devices, freezer::Freezer, hugetlb::HugeTlb, io::Io, memory::Memory, pids::Pids, unified::Unified};
 use crate::common::{self, CgroupManager, PathBufExt};
 use crate::stats::Stats;
 
@@ -235,10 +232,10 @@ impl CgroupManager for SystemDCGroupManager {
                 ControllerType::Memory => Memory::apply(linux_resources, &self.full_path)?,
                 ControllerType::Pids => Pids::apply(linux_resources, &self.full_path)?,
                 ControllerType::Freezer => Freezer::apply(linux_resources, &self.full_path)?,
-                ControllerType::Devices => Devices::apply(linux_resources, &self.full_path)?,
             }
         }
 
+        Devices::apply(linux_resources, &self.full_path)?;
         Ok(())
     }
 

--- a/cgroups/src/v2/systemd_manager.rs
+++ b/cgroups/src/v2/systemd_manager.rs
@@ -10,7 +10,7 @@ use std::path::{Path, PathBuf};
 
 use super::{
     controller::Controller, controller_type::ControllerType, cpu::Cpu, cpuset::CpuSet,
-    freezer::Freezer, hugetlb::HugeTlb, io::Io, memory::Memory, pids::Pids,
+    devices::Devices, freezer::Freezer, hugetlb::HugeTlb, io::Io, memory::Memory, pids::Pids,
 };
 use crate::common::{self, CgroupManager, PathBufExt};
 use crate::stats::Stats;
@@ -235,6 +235,7 @@ impl CgroupManager for SystemDCGroupManager {
                 ControllerType::Memory => Memory::apply(linux_resources, &self.full_path)?,
                 ControllerType::Pids => Pids::apply(linux_resources, &self.full_path)?,
                 ControllerType::Freezer => Freezer::apply(linux_resources, &self.full_path)?,
+                ControllerType::Devices => Devices::apply(linux_resources, &self.full_path)?,
             }
         }
 

--- a/cgroups/src/v2/systemd_manager.rs
+++ b/cgroups/src/v2/systemd_manager.rs
@@ -8,7 +8,10 @@ use nix::unistd::Pid;
 use oci_spec::{FreezerState, LinuxResources};
 use std::path::{Path, PathBuf};
 
-use super::{controller::Controller, controller_type::{ControllerType, PseudoControllerType}, cpu::Cpu, cpuset::CpuSet, devices::Devices, freezer::Freezer, hugetlb::HugeTlb, io::Io, memory::Memory, pids::Pids, unified::Unified};
+use super::{
+    controller::Controller, controller_type::ControllerType, cpu::Cpu, cpuset::CpuSet,
+    devices::Devices, freezer::Freezer, hugetlb::HugeTlb, io::Io, memory::Memory, pids::Pids,
+};
 use crate::common::{self, CgroupManager, PathBufExt};
 use crate::stats::Stats;
 

--- a/cgroups/src/v2/systemd_manager.rs
+++ b/cgroups/src/v2/systemd_manager.rs
@@ -8,9 +8,11 @@ use nix::unistd::Pid;
 use oci_spec::{FreezerState, LinuxResources};
 use std::path::{Path, PathBuf};
 
+#[cfg(feature = "cgroupsv2_devices")]
+use super::devices::Devices;
 use super::{
     controller::Controller, controller_type::ControllerType, cpu::Cpu, cpuset::CpuSet,
-    devices::Devices, freezer::Freezer, hugetlb::HugeTlb, io::Io, memory::Memory, pids::Pids,
+    freezer::Freezer, hugetlb::HugeTlb, io::Io, memory::Memory, pids::Pids,
 };
 use crate::common::{self, CgroupManager, PathBufExt};
 use crate::stats::Stats;
@@ -238,6 +240,7 @@ impl CgroupManager for SystemDCGroupManager {
             }
         }
 
+        #[cfg(feature = "cgroupsv2_devices")]
         Devices::apply(linux_resources, &self.full_path)?;
         Ok(())
     }


### PR DESCRIPTION
This a PoC of cgroup v2 BPF devices controller, based on the implementation of runc.

It works but with many FIXMEs and TODOs:
1. build BPF bytecode instruction by instruction using ebpf
2. attach/detach using libbpf-sys,  always attach new program and detach old programs, no BF_F_REPLACE
3. use naive algorithm to check rules, runc's device emulator is not implemented
4. there is a simple binary in cgroups/examples/bpf.rs, used to query/attach/detach BPF program, should help testing
5. toggled on by feature "cgroupsv2_devices", which is enabled by default in Cargo.toml
