### PR TITLE
ensure theat read only paths work properly.

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ youki is not at the practical stage yet. However, it is getting closer to practi
 |    Seccomp     |             Filtering system calls              |                     WIP on [#25](https://github.com/containers/youki/issues/25)                     |
 |     Hooks      | Add custom processing during container creation |                                                  ✅                                                  |
 |    Rootless    |   Running a container without root privileges   | It works, but cgroups isn't supported. WIP on [#77](https://github.com/containers/youki/issues/77)  |
-| OCI Compliance |        Compliance with OCI Runtime Spec         |                                   37 out of 57 test cases passing                                   |
+| OCI Compliance |        Compliance with OCI Runtime Spec         |                                   38 out of 57 test cases passing                                   |
 
 # Getting Started
 

--- a/integration_test.sh
+++ b/integration_test.sh
@@ -39,7 +39,7 @@ test_cases=(
   # "linux_ns_path/linux_ns_path.t"
   # "linux_ns_path_type/linux_ns_path_type.t"
   # "linux_process_apparmor_profile/linux_process_apparmor_profile.t"
-  # "linux_readonly_paths/linux_readonly_paths.t"
+  "linux_readonly_paths/linux_readonly_paths.t"
   # "linux_rootfs_propagation/linux_rootfs_propagation.t"
   # "linux_seccomp/linux_seccomp.t"
   "linux_sysctl/linux_sysctl.t"


### PR DESCRIPTION
In the case of read-only, the flags are ignored on the first bind mount, so it has to be mounted twice.

https://man7.org/linux/man-pages/man2/mount.2.html
> Creating a bind mount
> ....
>       The filesystemtype and data arguments are ignored.
>       The remaining bits (other than MS_REC, described below) in the
>       mountflags argument are also ignored.  (The bind mount has the
>       same mount options as the underlying mount point.)  However, see
>       the discussion of remounting above, for a method of making an
>       existing bind mount read-only.
