### PR TITLE
Chdir to process.cwd before starting container to pass integration test

### DIFF
--- a/integration_test.sh
+++ b/integration_test.sh
@@ -53,7 +53,7 @@ test_cases=(
   "poststop_fail/poststop_fail.t"
   "prestart/prestart.t"
   "prestart_fail/prestart_fail.t"
-  # "process/process.t"
+  "process/process.t"
   "process_capabilities/process_capabilities.t"
   "process_capabilities_fail/process_capabilities_fail.t"
   # "process_oom_score_adj/process_oom_score_adj.t"

--- a/src/process/init.rs
+++ b/src/process/init.rs
@@ -213,7 +213,6 @@ pub fn container_init(args: ContainerInitArgs) -> Result<()> {
         }
     }
 
-
     let mut do_chdir = !proc.cwd.is_empty();
     // change directory to process.cwd if process.cwd is not empty
     if do_chdir {
@@ -224,7 +223,7 @@ pub fn container_init(args: ContainerInitArgs) -> Result<()> {
         match unistd::chdir(&*proc.cwd) {
             Ok(_) => do_chdir = false,
             Err(nix::Error::EPERM) => {}
-            Err(e) => return Err(anyhow::anyhow!("Failed to chdir: {}", e))
+            Err(e) => return Err(anyhow::anyhow!("Failed to chdir: {}", e)),
         };
     }
 

--- a/src/process/init.rs
+++ b/src/process/init.rs
@@ -216,7 +216,6 @@ pub fn container_init(args: ContainerInitArgs) -> Result<()> {
     let mut do_chdir = !proc.cwd.is_empty();
     // change directory to process.cwd if process.cwd is not empty
     if do_chdir {
-        do_chdir = false;
         // This chdir must run before setting up the user.
         // This may allow the user running youki to access directories
         // that the container user cannot access.

--- a/src/process/init.rs
+++ b/src/process/init.rs
@@ -213,7 +213,7 @@ pub fn container_init(args: ContainerInitArgs) -> Result<()> {
         }
     }
 
-   let do_chdir = if proc.cwd.is_empty() {
+    let do_chdir = if proc.cwd.is_empty() {
         false
     } else {
         // This chdir must run before setting up the user.
@@ -223,6 +223,7 @@ pub fn container_init(args: ContainerInitArgs) -> Result<()> {
             Ok(_) => false,
             Err(nix::Error::EPERM) => true,
             Err(e) => bail!("Failed to chdir: {}", e),
+        }
     };
 
     command.set_id(Uid::from_raw(proc.user.uid), Gid::from_raw(proc.user.gid))?;


### PR DESCRIPTION
ref: #207

Integration Test case: `process/process.t`
This test case is failed because youki does not change directory to `proecss.cwd` before starting container.
I tried fix this.