### PR TITLE
Fix integration_test script for go env

### DIFF
--- a/integration_test.sh
+++ b/integration_test.sh
@@ -77,7 +77,7 @@ check_enviroment() {
 
 for case in "${test_cases[@]}"; do
   if [[ ! -e "${ROOT}/integration_test/src/github.com/opencontainers/runtime-tools/validation/$case" ]]; then
-    GOPATH=${ROOT}/integration_test make runtimetest validation-executables
+    GO111MODULE=auto GOPATH=${ROOT}/integration_test make runtimetest validation-executables
     break
   fi
 done


### PR DESCRIPTION
For those who upgraded Go but without setting the right go env (just like me). 
Run script will get this error: 

```bash 
yukang@mango:~/youki$  ./integration_test.sh
CGO_ENABLED=0 go build -installsuffix cgo -tags "" -ldflags "-X main.gitCommit=59cdde06764be8d761db120664020f0415f36045 -X main.version=0.9.0" -o runtimetest ./cmd/runtimetest
go: cannot find main module, but found Godeps/Godeps.json in /home/yukang/youki/integration_test/src/github.com/opencontainers/runtime-tools
        to create a module there, run:
        go mod init
make: *** [Makefile:18: runtimetest] Error 1

```
This PR will fix it.