### PR TITLE
Use chroot when not entering into mount namespace

### DIFF
--- a/integration_test.sh
+++ b/integration_test.sh
@@ -39,7 +39,7 @@ test_cases=(
   "linux_devices/linux_devices.t"
   # "linux_masked_paths/linux_masked_paths.t"
   "linux_mount_label/linux_mount_label.t"
-  # "linux_ns_itype/linux_ns_itype.t"
+  "linux_ns_itype/linux_ns_itype.t"
   "linux_ns_nopath/linux_ns_nopath.t"
   "linux_ns_path/linux_ns_path.t"
   "linux_ns_path_type/linux_ns_path_type.t"

--- a/integration_test.sh
+++ b/integration_test.sh
@@ -39,7 +39,9 @@ test_cases=(
   "linux_devices/linux_devices.t"
   # "linux_masked_paths/linux_masked_paths.t"
   "linux_mount_label/linux_mount_label.t"
-  "linux_ns_itype/linux_ns_itype.t"
+  # This test case hangs on the Github Action. Runtime-tools has an issue filed from 2019 that the clean up step hangs. Otherwise, the test case passes.
+  # Ref: https://github.com/opencontainers/runtime-tools/issues/698
+  # "linux_ns_itype/linux_ns_itype.t"
   "linux_ns_nopath/linux_ns_nopath.t"
   "linux_ns_path/linux_ns_path.t"
   "linux_ns_path_type/linux_ns_path_type.t"

--- a/src/process/init.rs
+++ b/src/process/init.rs
@@ -323,10 +323,20 @@ pub fn container_init(
         rootfs::prepare_rootfs(spec, rootfs, bind_service)
             .with_context(|| "Failed to prepare rootfs")?;
 
-        // change the root of filesystem of the process to the rootfs
-        command
-            .pivot_rootfs(rootfs)
-            .with_context(|| format!("Failed to pivot root to {:?}", rootfs))?;
+        // Entering into the rootfs jail. If mount namespace is specified, then
+        // we use pivot_root, but if we are on the host mount namespace, we will
+        // use simple chroot. Scary things will happen if you try to pivot_root
+        // in the host mount namespace...
+        if namespaces.get(LinuxNamespaceType::Mount).is_some() {
+            // change the root of filesystem of the process to the rootfs
+            command
+                .pivot_rootfs(rootfs)
+                .with_context(|| format!("Failed to pivot root to {:?}", rootfs))?;
+        } else {
+            command
+                .chroot(rootfs)
+                .with_context(|| format!("Failed to chroot to {:?}", rootfs))?;
+        }
 
         if let Some(kernel_params) = &linux.sysctl {
             sysctl(kernel_params)

--- a/src/syscall/linux.rs
+++ b/src/syscall/linux.rs
@@ -195,4 +195,10 @@ impl Syscall for LinuxSyscall {
         let user = unsafe { Self::passwd_to_user(result.read()) };
         Some(user)
     }
+
+    fn chroot(&self, path: &Path) -> Result<()> {
+        unistd::chroot(path)?;
+
+        Ok(())
+    }
 }

--- a/src/syscall/syscall.rs
+++ b/src/syscall/syscall.rs
@@ -19,6 +19,7 @@ use crate::syscall::{linux::LinuxSyscall, test::TestHelperSyscall};
 pub trait Syscall {
     fn as_any(&self) -> &dyn Any;
     fn pivot_rootfs(&self, path: &Path) -> Result<()>;
+    fn chroot(&self, path: &Path) -> Result<()>;
     fn set_ns(&self, rawfd: i32, nstype: CloneFlags) -> Result<()>;
     fn set_id(&self, uid: Uid, gid: Gid) -> Result<()>;
     fn unshare(&self, flags: CloneFlags) -> Result<()>;

--- a/src/syscall/test.rs
+++ b/src/syscall/test.rs
@@ -64,6 +64,10 @@ impl Syscall for TestHelperSyscall {
     fn get_pwuid(&self, _: u32) -> Option<Arc<OsStr>> {
         todo!()
     }
+
+    fn chroot(&self, _: &std::path::Path) -> anyhow::Result<()> {
+        todo!()
+    }
 }
 
 impl TestHelperSyscall {


### PR DESCRIPTION
Do not pivot_root when under the host mount namespace. Chroot instead.

Fix #240

Also passes "linux_ns_itype/linux_ns_itype.t" test.