### PR TITLE
Pass process user integration test

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ youki is not at the practical stage yet. However, it is getting closer to practi
 |    Seccomp     |             Filtering system calls              |                     WIP on [#25](https://github.com/containers/youki/issues/25)                     |
 |     Hooks      | Add custom processing during container creation |                                                  ✅                                                  |
 |    Rootless    |   Running a container without root privileges   | It works, but cgroups isn't supported. WIP on [#77](https://github.com/containers/youki/issues/77)  |
-| OCI Compliance |        Compliance with OCI Runtime Spec         |                                   44 out of 55 test cases passing                                   |
+| OCI Compliance |        Compliance with OCI Runtime Spec         |                                   45 out of 55 test cases passing                                   |
 
 # Design and implementation of youki
 ![sequence diagram of youki](docs/.drawio.svg)

--- a/integration_test.sh
+++ b/integration_test.sh
@@ -66,7 +66,7 @@ test_cases=(
   "process_oom_score_adj/process_oom_score_adj.t"
   "process_rlimits/process_rlimits.t"
   "process_rlimits_fail/process_rlimits_fail.t"
-  # "process_user/process_user.t"
+  "process_user/process_user.t"
   "root_readonly_true/root_readonly_true.t"
   # Record the tests that runc also fails to pass below, maybe we will fix this by origin integration test, issue: https://github.com/containers/youki/issues/56
   # "start/start.t"

--- a/src/container/builder_impl.rs
+++ b/src/container/builder_impl.rs
@@ -152,10 +152,11 @@ impl<'a> ContainerBuilderImpl<'a> {
         let init_pid = receiver_from_intermediate.wait_for_intermediate_ready()?;
         log::debug!("init pid is {:?}", init_pid);
 
-        cmanager
-            .add_task(init_pid)
-            .context("Failed to add tasks to cgroup manager")?;
         if self.rootless.is_none() && linux.resources.is_some() && self.init {
+            cmanager
+                .add_task(init_pid)
+                .context("Failed to add tasks to cgroup manager")?;
+
             cmanager
                 .apply(linux.resources.as_ref().unwrap())
                 .context("Failed to apply resource limits through cgroup")?;

--- a/src/container/builder_impl.rs
+++ b/src/container/builder_impl.rs
@@ -139,8 +139,8 @@ impl<'a> ContainerBuilderImpl<'a> {
             receiver_from_intermediate.wait_for_mapping_request()?;
             log::debug!("write mapping for pid {:?}", intermediate_pid);
             let rootless = self.rootless.as_ref().unwrap();
-            if !rootless.priviledged {
-                // The main process is running as an unpriviledged user and cannot write the mapping
+            if !rootless.privileged {
+                // The main process is running as an unprivileged user and cannot write the mapping
                 // until "deny" has been written to setgroups. See CVE-2014-8989.
                 utils::write_file(format!("/proc/{}/setgroups", intermediate_pid), "deny")?;
             }

--- a/src/container/builder_impl.rs
+++ b/src/container/builder_impl.rs
@@ -121,7 +121,7 @@ impl<'a> ContainerBuilderImpl<'a> {
                 .close()
                 .context("Failed to close unused receiver")?;
 
-            init::container_intermidiate(init_args, receiver_from_main, sender_to_main)
+            init::container_intermediate(init_args, receiver_from_main, sender_to_main)
         })?;
         // Close down unused fds. The corresponding fds are duplicated to the
         // child process during fork.

--- a/src/container/init_builder.rs
+++ b/src/container/init_builder.rs
@@ -1,7 +1,7 @@
 use anyhow::{bail, Context, Result};
 use nix::unistd;
 use oci_spec::Spec;
-use rootless::detect_rootless;
+use rootless::Rootless;
 use std::{
     fs,
     path::{Path, PathBuf},
@@ -65,7 +65,7 @@ impl InitContainerBuilder {
             None
         };
 
-        let rootless = detect_rootless(&spec)?;
+        let rootless = Rootless::new(&spec)?;
         let mut builder_impl = ContainerBuilderImpl {
             init: true,
             syscall: self.base.syscall,

--- a/src/container/tenant_builder.rs
+++ b/src/container/tenant_builder.rs
@@ -13,7 +13,7 @@ use std::{
     str::FromStr,
 };
 
-use crate::{notify_socket::NotifySocket, rootless::detect_rootless, tty, utils};
+use crate::{notify_socket::NotifySocket, rootless::Rootless, tty, utils};
 
 use super::{builder::ContainerBuilder, builder_impl::ContainerBuilderImpl, Container};
 
@@ -100,7 +100,7 @@ impl TenantContainerBuilder {
         let csocketfd = self.setup_tty_socket(&container_dir)?;
 
         let use_systemd = self.should_use_systemd(&container);
-        let rootless = detect_rootless(&spec)?;
+        let rootless = Rootless::new(&spec)?;
 
         let mut builder_impl = ContainerBuilderImpl {
             init: false,

--- a/src/main.rs
+++ b/src/main.rs
@@ -88,7 +88,7 @@ enum SubCommand {
 fn main() -> Result<()> {
     let opts = Opts::parse();
 
-    if let Err(e) = youki::logger::init(PathBuf::from("/tmp/youki/container").into()) {
+    if let Err(e) = youki::logger::init(opts.log) {
         eprintln!("log init failed: {:?}", e);
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,7 +25,7 @@ use youki::commands::run;
 use youki::commands::spec_json;
 use youki::commands::start;
 use youki::commands::state;
-use youki::rootless::should_use_rootless;
+use youki::rootless::rootless_required;
 use youki::utils::{self, create_dir_all_with_mode};
 
 // High-level commandline option definition
@@ -88,7 +88,7 @@ enum SubCommand {
 fn main() -> Result<()> {
     let opts = Opts::parse();
 
-    if let Err(e) = youki::logger::init(opts.log) {
+    if let Err(e) = youki::logger::init(PathBuf::from("/tmp/youki/container").into()) {
         eprintln!("log init failed: {:?}", e);
     }
 
@@ -118,7 +118,7 @@ fn determine_root_path(root_path: Option<PathBuf>) -> Result<PathBuf> {
         return Ok(path);
     }
 
-    if !should_use_rootless() {
+    if !rootless_required() {
         let default = PathBuf::from("/run/youki");
         utils::create_dir_all(&default)?;
         return Ok(default);

--- a/src/process/init.rs
+++ b/src/process/init.rs
@@ -480,7 +480,7 @@ fn set_supplementary_gids(user: &User, rootless: &Option<Rootless>) -> Result<()
             .collect();
 
         match rootless {
-            Some(r) if r.priviledged => {
+            Some(r) if r.privileged => {
                 nix::unistd::setgroups(&gids).context("failed to set supplementary gids")?;
             }
             None => {
@@ -488,7 +488,7 @@ fn set_supplementary_gids(user: &User, rootless: &Option<Rootless>) -> Result<()
             }
             // this should have been detected during validation
             _ => unreachable!(
-                "unpriviledged users cannot set supplementary gids in rootless container"
+                "unprivileged users cannot set supplementary gids in rootless container"
             ),
         }
     }

--- a/src/process/init.rs
+++ b/src/process/init.rs
@@ -7,6 +7,7 @@ use nix::{
     sys::statfs,
     unistd::{self, Gid, Uid},
 };
+use oci_spec::User;
 use oci_spec::{LinuxNamespaceType, Spec};
 use std::collections::HashMap;
 use std::{
@@ -15,6 +16,7 @@ use std::{
 };
 use std::{fs, path::Path, path::PathBuf};
 
+use crate::rootless::Rootless;
 use crate::{
     capabilities,
     container::Container,
@@ -146,7 +148,7 @@ fn readonly_path(path: &str) -> Result<()> {
     Ok(())
 }
 
-pub struct ContainerInitArgs {
+pub struct ContainerInitArgs<'a> {
     /// Flag indicating if an init or a tenant container should be created
     pub init: bool,
     /// Interface to operating system primitives
@@ -163,6 +165,8 @@ pub struct ContainerInitArgs {
     pub preserve_fds: i32,
     /// Container state
     pub container: Option<Container>,
+    /// Options for rootless containers
+    pub rootless: Option<Rootless<'a>>,
 }
 
 pub fn container_intermidiate(
@@ -364,6 +368,8 @@ pub fn container_init(
         }
     };
 
+    set_supplementary_gids(&proc.user, &args.rootless)?;
+
     command
         .set_id(Uid::from_raw(proc.user.uid), Gid::from_raw(proc.user.gid))
         .context("Failed to configure uid and gid")?;
@@ -454,6 +460,40 @@ pub fn container_init(
     // After do_exec is called, the process is replaced with the container
     // payload through execvp, so it should never reach here.
     unreachable!();
+}
+
+fn set_supplementary_gids(user: &User, rootless: &Option<Rootless>) -> Result<()> {
+    if let Some(additional_gids) = &user.additional_gids {
+        if additional_gids.is_empty() {
+            return Ok(());
+        }
+
+        let setgroups =
+            fs::read_to_string("/proc/self/setgroups").context("failed to read setgroups")?;
+        if setgroups.trim() == "deny" {
+            bail!("cannot set supplementary gids, setgroup is disabled");
+        }
+
+        let gids: Vec<Gid> = additional_gids
+            .iter()
+            .map(|gid| Gid::from_raw(*gid))
+            .collect();
+
+        match rootless {
+            Some(r) if r.priviledged => {
+                nix::unistd::setgroups(&gids).context("failed to set supplementary gids")?;
+            }
+            None => {
+                nix::unistd::setgroups(&gids).context("failed to set supplementary gids")?;
+            }
+            // this should have been detected during validation
+            _ => unreachable!(
+                "unpriviledged users cannot set supplementary gids in rootless container"
+            ),
+        }
+    }
+
+    Ok(())
 }
 
 #[cfg(test)]

--- a/src/process/init.rs
+++ b/src/process/init.rs
@@ -169,7 +169,7 @@ pub struct ContainerInitArgs<'a> {
     pub rootless: Option<Rootless<'a>>,
 }
 
-pub fn container_intermidiate(
+pub fn container_intermediate(
     args: ContainerInitArgs,
     receiver_from_main: &mut channel::ReceiverFromMain,
     sender_to_main: &mut channel::SenderIntermediateToMain,

--- a/src/rootfs.rs
+++ b/src/rootfs.rs
@@ -68,17 +68,15 @@ pub fn prepare_rootfs(spec: &Spec, rootfs: &Path, bind_devices: bool) -> Result<
         }
     }
 
-    let olddir = getcwd()?;
-    chdir(rootfs)?;
+    chdir(rootfs).context("failed to set current directory to rootfs")?;
     setup_default_symlinks(rootfs).context("Failed to setup default symlinks")?;
     if let Some(added_devices) = linux.devices.as_ref() {
         create_devices(default_devices().iter().chain(added_devices), bind_devices)
     } else {
         create_devices(default_devices().iter(), bind_devices)
     }?;
-    setup_ptmx(rootfs)?;
-    chdir(&olddir)?;
 
+    setup_ptmx(rootfs)?;
     Ok(())
 }
 

--- a/src/rootfs.rs
+++ b/src/rootfs.rs
@@ -9,7 +9,7 @@ use nix::mount::mount as nix_mount;
 use nix::mount::MsFlags;
 use nix::sys::stat::Mode;
 use nix::sys::stat::{mknod, umask};
-use nix::unistd::{chdir, chown, close};
+use nix::unistd::{chown, close};
 use nix::unistd::{Gid, Uid};
 use oci_spec::{LinuxDevice, LinuxDeviceType, Mount, Spec};
 use std::fs::OpenOptions;
@@ -68,12 +68,15 @@ pub fn prepare_rootfs(spec: &Spec, rootfs: &Path, bind_devices: bool) -> Result<
         }
     }
 
-    chdir(rootfs).context("failed to set current directory to rootfs")?;
     setup_default_symlinks(rootfs).context("Failed to setup default symlinks")?;
     if let Some(added_devices) = linux.devices.as_ref() {
-        create_devices(default_devices().iter().chain(added_devices), bind_devices)
+        create_devices(
+            rootfs,
+            default_devices().iter().chain(added_devices),
+            bind_devices,
+        )
     } else {
-        create_devices(default_devices().iter(), bind_devices)
+        create_devices(rootfs, default_devices().iter(), bind_devices)
     }?;
 
     setup_ptmx(rootfs)?;
@@ -87,8 +90,7 @@ fn setup_ptmx(rootfs: &Path) -> Result<()> {
         }
     }
 
-    symlink("pts/ptmx", "dev/ptmx").context("Failed to symlink ptmx")?;
-
+    symlink("pts/ptmx", rootfs.join("dev/ptmx")).context("failed to symlink ptmx")?;
     Ok(())
 }
 
@@ -169,7 +171,7 @@ pub fn default_devices() -> Vec<LinuxDevice> {
     ]
 }
 
-fn create_devices<'a, I>(devices: I, bind: bool) -> Result<()>
+fn create_devices<'a, I>(rootfs: &Path, devices: I, bind: bool) -> Result<()>
 where
     I: Iterator<Item = &'a LinuxDevice>,
 {
@@ -181,7 +183,7 @@ where
                     panic!("{} is not a valid device path", dev.path.display());
                 }
 
-                bind_dev(dev)
+                bind_dev(rootfs, dev)
             })
             .collect::<Result<Vec<_>>>()?;
     } else {
@@ -191,7 +193,7 @@ where
                     panic!("{} is not a valid device path", dev.path.display());
                 }
 
-                mknod_dev(dev)
+                mknod_dev(rootfs, dev)
             })
             .collect::<Result<Vec<_>>>()?;
     }
@@ -200,15 +202,17 @@ where
     Ok(())
 }
 
-fn bind_dev(dev: &LinuxDevice) -> Result<()> {
+fn bind_dev(rootfs: &Path, dev: &LinuxDevice) -> Result<()> {
+    let full_container_path = rootfs.join(dev.path.as_in_container()?);
+
     let fd = open(
-        &dev.path.as_in_container()?,
+        &full_container_path,
         OFlag::O_RDWR | OFlag::O_CREAT,
         Mode::from_bits_truncate(0o644),
     )?;
     close(fd)?;
     nix_mount(
-        Some(&*dev.path.as_in_container()?),
+        Some(&full_container_path),
         &dev.path,
         None::<&str>,
         MsFlags::MS_BIND,
@@ -218,21 +222,23 @@ fn bind_dev(dev: &LinuxDevice) -> Result<()> {
     Ok(())
 }
 
-fn mknod_dev(dev: &LinuxDevice) -> Result<()> {
+fn mknod_dev(rootfs: &Path, dev: &LinuxDevice) -> Result<()> {
     fn makedev(major: i64, minor: i64) -> u64 {
         ((minor & 0xff)
             | ((major & 0xfff) << 8)
             | ((minor & !0xff) << 12)
             | ((major & !0xfff) << 32)) as u64
     }
+
+    let full_container_path = rootfs.join(dev.path.as_in_container()?);
     mknod(
-        &dev.path.as_in_container()?,
+        &full_container_path,
         dev.typ.to_sflag()?,
         Mode::from_bits_truncate(dev.file_mode.unwrap_or(0)),
         makedev(dev.major, dev.minor),
     )?;
     chown(
-        &dev.path.as_in_container()?,
+        &full_container_path,
         dev.uid.map(Uid::from_raw),
         dev.gid.map(Gid::from_raw),
     )?;

--- a/src/rootfs.rs
+++ b/src/rootfs.rs
@@ -9,7 +9,7 @@ use nix::mount::mount as nix_mount;
 use nix::mount::MsFlags;
 use nix::sys::stat::Mode;
 use nix::sys::stat::{mknod, umask};
-use nix::unistd::{chdir, chown, close, getcwd};
+use nix::unistd::{chdir, chown, close};
 use nix::unistd::{Gid, Uid};
 use oci_spec::{LinuxDevice, LinuxDeviceType, Mount, Spec};
 use std::fs::OpenOptions;

--- a/src/rootless.rs
+++ b/src/rootless.rs
@@ -18,9 +18,9 @@ pub struct Rootless<'a> {
     pub gid_mappings: Option<&'a Vec<LinuxIdMapping>>,
     /// Info on the user namespaces
     user_namespace: Option<LinuxNamespace>,
-    /// Is rootless container requested by a priviledged
+    /// Is rootless container requested by a privileged
     /// user
-    pub priviledged: bool,
+    pub privileged: bool,
 }
 
 impl<'a> Rootless<'a> {
@@ -66,7 +66,7 @@ impl<'a> From<&'a Linux> for Rootless<'a> {
             uid_mappings: linux.uid_mappings.as_ref(),
             gid_mappings: linux.gid_mappings.as_ref(),
             user_namespace: user_namespace.cloned(),
-            priviledged: nix::unistd::geteuid().is_root(),
+            privileged: nix::unistd::geteuid().is_root(),
         }
     }
 }
@@ -118,19 +118,19 @@ fn validate(spec: &Spec) -> Result<()> {
 
     if let Some(process) = &spec.process {
         if let Some(additional_gids) = &process.user.additional_gids {
-            let priviledged = nix::unistd::geteuid().is_root();
+            let privileged = nix::unistd::geteuid().is_root();
 
-            match (priviledged, additional_gids.is_empty()) {
+            match (privileged, additional_gids.is_empty()) {
                 (true, false) => {
                     for gid in additional_gids {
-                        if !is_id_mapped(*gid, &gid_mappings) {
+                        if !is_id_mapped(*gid, gid_mappings) {
                             bail!("gid {} is specified as supplementary group, but is not mapped in the user namespace", gid);
                         }
                     }
                 }
                 (false, false) => {
                     bail!(
-                        "user is {} (unpriviledged). Supplementary groups cannot be set in \
+                        "user is {} (unprivileged). Supplementary groups cannot be set in \
                         a rootless container for this user due to CVE-2014-8989",
                         nix::unistd::geteuid()
                     )

--- a/src/rootless.rs
+++ b/src/rootless.rs
@@ -123,7 +123,7 @@ fn validate(spec: &Spec) -> Result<()> {
             match (priviledged, additional_gids.is_empty()) {
                 (true, false) => {
                     for gid in additional_gids {
-                        if is_id_mapped(*gid, &gid_mappings).is_err() {
+                        if !is_id_mapped(*gid, &gid_mappings) {
                             bail!("gid {} is specified as supplementary group, but is not mapped in the user namespace", gid);
                         }
                     }
@@ -151,11 +151,11 @@ fn validate_mounts(
     for mount in mounts {
         if let Some(options) = &mount.options {
             for opt in options {
-                if opt.starts_with("uid=") && !is_id_mapped(opt[4..].parse()?, uid_mappings)? {
+                if opt.starts_with("uid=") && !is_id_mapped(opt[4..].parse()?, uid_mappings) {
                     bail!("Mount {:?} specifies option {} which is not mapped inside the rootless container", mount, opt);
                 }
 
-                if opt.starts_with("gid=") && !is_id_mapped(opt[4..].parse()?, gid_mappings)? {
+                if opt.starts_with("gid=") && !is_id_mapped(opt[4..].parse()?, gid_mappings) {
                     bail!("Mount {:?} specifies option {} which is not mapped inside the rootless container", mount, opt);
                 }
             }
@@ -165,10 +165,10 @@ fn validate_mounts(
     Ok(())
 }
 
-fn is_id_mapped(id: u32, mappings: &[LinuxIdMapping]) -> Result<bool> {
-    Ok(mappings
+fn is_id_mapped(id: u32, mappings: &[LinuxIdMapping]) -> bool {
+    mappings
         .iter()
-        .any(|m| id >= m.container_id && id <= m.container_id + m.size))
+        .any(|m| id >= m.container_id && id <= m.container_id + m.size)
 }
 
 /// Looks up the location of the newuidmap and newgidmap binaries which

--- a/src/rootless.rs
+++ b/src/rootless.rs
@@ -18,6 +18,42 @@ pub struct Rootless<'a> {
     pub gid_mappings: Option<&'a Vec<LinuxIdMapping>>,
     /// Info on the user namespaces
     user_namespace: Option<LinuxNamespace>,
+    /// Is rootless container requested by a priviledged
+    /// user
+    pub priviledged: bool,
+}
+
+impl<'a> Rootless<'a> {
+    pub fn new(spec: &'a Spec) -> Result<Option<Rootless<'a>>> {
+        let linux = spec.linux.as_ref().context("no linux in spec")?;
+        let namespaces = Namespaces::from(linux.namespaces.as_ref());
+        let user_namespace = namespaces.get(LinuxNamespaceType::User);
+
+        // If conditions requires us to use rootless, we must either create a new
+        // user namespace or enter an exsiting.
+        if rootless_required() && user_namespace.is_none() {
+            bail!("rootless container requires valid user namespace definition");
+        }
+
+        if user_namespace.is_some() && user_namespace.unwrap().path.is_none() {
+            log::debug!("rootless container should be created");
+            log::warn!(
+                "resource constraints and multi id mapping is unimplemented for rootless containers"
+            );
+
+            validate(spec).context("The spec failed to comply to rootless requirement")?;
+            let mut rootless = Rootless::from(linux);
+            if let Some((uid_binary, gid_binary)) = lookup_map_binaries(linux)? {
+                rootless.newuidmap = Some(uid_binary);
+                rootless.newgidmap = Some(gid_binary);
+            }
+
+            Ok(Some(rootless))
+        } else {
+            log::debug!("This is NOT a rootless container");
+            Ok(None)
+        }
+    }
 }
 
 impl<'a> From<&'a Linux> for Rootless<'a> {
@@ -30,47 +66,13 @@ impl<'a> From<&'a Linux> for Rootless<'a> {
             uid_mappings: linux.uid_mappings.as_ref(),
             gid_mappings: linux.gid_mappings.as_ref(),
             user_namespace: user_namespace.cloned(),
+            priviledged: nix::unistd::geteuid().is_root(),
         }
     }
-}
-
-// If user namespace is detected, then we are going into rootless.
-// If we are not root, check if we are user namespace.
-pub fn detect_rootless(spec: &Spec) -> Result<Option<Rootless>> {
-    let linux = spec.linux.as_ref().context("no linux in spec")?;
-    let namespaces = Namespaces::from(linux.namespaces.as_ref());
-    let user_namespace = namespaces.get(LinuxNamespaceType::User);
-    // If conditions requires us to use rootless, we must either create a new
-    // user namespace or enter an exsiting.
-    if should_use_rootless() && user_namespace.is_none() {
-        bail!("Rootless container requires valid user namespace definition");
-    }
-
-    // Go through rootless procedure only when entering into a new user namespace
-    let rootless = if user_namespace.is_some() && user_namespace.unwrap().path.is_none() {
-        log::debug!("rootless container should be created");
-        log::warn!(
-            "resource constraints and multi id mapping is unimplemented for rootless containers"
-        );
-        validate(spec).context("The spec failed to comply to rootless requirement")?;
-        let linux = spec.linux.as_ref().context("no linux in spec")?;
-        let mut rootless = Rootless::from(linux);
-        if let Some((uid_binary, gid_binary)) = lookup_map_binaries(linux)? {
-            rootless.newuidmap = Some(uid_binary);
-            rootless.newgidmap = Some(gid_binary);
-        }
-
-        Some(rootless)
-    } else {
-        log::debug!("This is NOT a rootless container");
-        None
-    };
-
-    Ok(rootless)
 }
 
 /// Checks if rootless mode should be used
-pub fn should_use_rootless() -> bool {
+pub fn rootless_required() -> bool {
     if !nix::unistd::geteuid().is_root() {
         return true;
     }
@@ -114,6 +116,30 @@ fn validate(spec: &Spec) -> Result<()> {
         gid_mappings,
     )?;
 
+    if let Some(process) = &spec.process {
+        if let Some(additional_gids) = &process.user.additional_gids {
+            let priviledged = nix::unistd::geteuid().is_root();
+
+            match (priviledged, additional_gids.is_empty()) {
+                (true, false) => {
+                    for gid in additional_gids {
+                        if is_id_mapped(*gid, &gid_mappings).is_err() {
+                            bail!("gid {} is specified as supplementary group, but is not mapped in the user namespace", gid);
+                        }
+                    }
+                }
+                (false, false) => {
+                    bail!(
+                        "user is {} (unpriviledged). Supplementary groups cannot be set in \
+                        a rootless container for this user due to CVE-2014-8989",
+                        nix::unistd::geteuid()
+                    )
+                }
+                _ => {}
+            }
+        }
+    }
+
     Ok(())
 }
 
@@ -125,11 +151,11 @@ fn validate_mounts(
     for mount in mounts {
         if let Some(options) = &mount.options {
             for opt in options {
-                if opt.starts_with("uid=") && !is_id_mapped(&opt[4..], uid_mappings)? {
+                if opt.starts_with("uid=") && !is_id_mapped(opt[4..].parse()?, uid_mappings)? {
                     bail!("Mount {:?} specifies option {} which is not mapped inside the rootless container", mount, opt);
                 }
 
-                if opt.starts_with("gid=") && !is_id_mapped(&opt[4..], gid_mappings)? {
+                if opt.starts_with("gid=") && !is_id_mapped(opt[4..].parse()?, gid_mappings)? {
                     bail!("Mount {:?} specifies option {} which is not mapped inside the rootless container", mount, opt);
                 }
             }
@@ -139,8 +165,7 @@ fn validate_mounts(
     Ok(())
 }
 
-fn is_id_mapped(id: &str, mappings: &[LinuxIdMapping]) -> Result<bool> {
-    let id = id.parse::<u32>()?;
+fn is_id_mapped(id: u32, mappings: &[LinuxIdMapping]) -> Result<bool> {
     Ok(mappings
         .iter()
         .any(|m| id >= m.container_id && id <= m.container_id + m.size))


### PR DESCRIPTION
Making this test pass is easy enough (just add the supplementary groups using setgroups system call) but there are some subtleties around this for rootless containers due to CVE-2014-8989.

The gist of this priviledge escalation is: Before 3.19 it was possible for an unprivileged user to enter an user namespace, become root and then call setgroups in order to drop membership in supplementary groups. This allowed access to files which blocked access based on being a member of these groups.

This leaves us with three scenarios:

Unprivileged user starting a rootless container: The main process is running as an unprivileged user and therefore cannot write the mapping until "deny" has been written to /proc/{pid}/setgroups. Once written /proc/{pid}/setgroups cannot be reset and the setgroups system call will be disabled for all processes in this user namespace. This also means that we should detect if the user is unprivileged and additional gids have been specified and bail out early as this can never work.

Privileged user starting a rootless container: It is not necessary to write "deny" to /proc/setgroups in order to create the gid mapping and therefore we don't. This means that setgroups could be used to drop groups, but this is fine as the user is privileged and could do so anyway.
We should check if the specified supplemental groups fall into the range that are specified in the gid mapping and bail out early if they do not. 

Privileged user starting a normal container: Just add the supplementary groups.

I noticed some problems when testing with rootless containers, which are not directly related to this feature and fixed them:
- An attempt was made to move the init process into cgroups which should not be done without systemd support
- When a privileged user starts a rootless container we try to change back into the old directory [here](https://github.com/containers/youki/blob/ff582b7f7f6bf4346294b9191916b105da885a3d/src/rootfs.rs#L80), but this fails in this case because the old directory belonged to the privileged user and we are now in a user namespace with a user mapped to an unprivileged user on the host. I removed changing back to the old directory because we pivot_root right after anyway and therefore this doesn't seem needed. Someone correct me if I am wrong here.