### PR TITLE
Add `new` method to instantiate Delete command

### DIFF
--- a/src/commands/delete.rs
+++ b/src/commands/delete.rs
@@ -20,6 +20,17 @@ pub struct Delete {
 }
 
 impl Delete {
+    /// instant Delete Command
+    ///
+    /// This method is provided for those using `youki` as a library to enable the use of the
+    /// Delete command to remove containers.
+    pub fn new(container_id: String, force: bool) -> Self {
+        Self {
+            container_id,
+            force,
+        }
+    }
+
     pub fn exec(&self, root_path: PathBuf, systemd_cgroup: bool) -> Result<()> {
         log::debug!("start deleting {}", self.container_id);
         // state of container is stored in a directory named as container id inside


### PR DESCRIPTION
We were trying to use `youki` as a library and notice that the `Delete` command was missing the `new` method. It can not be instantiated otherwise. This patch also improves the api consistency with other commands.