### PR TITLE
Rework cgroup detection

### DIFF
--- a/src/commands/info.rs
+++ b/src/commands/info.rs
@@ -106,9 +106,8 @@ pub fn print_hardware() {
 
 /// Print cgroups info of system
 pub fn print_cgroups() {
-    if let Ok(cgroup_fs) = cgroups::common::get_supported_cgroup_fs() {
-        let cgroup_fs: Vec<String> = cgroup_fs.into_iter().map(|c| c.to_string()).collect();
-        println!("{:<18}{}", "Cgroup version", cgroup_fs.join(" and "));
+    if let Ok(cgroup_setup) = cgroups::common::get_cgroup_setup() {
+        println!("{:<18}{}", "Cgroup setup", cgroup_setup);
     }
 
     println!("Cgroup mounts");


### PR DESCRIPTION
The original implementation assumed that cgroup v1 und cgroup v2 could be used side by side, but resource controllers are either attached to the one or the other. A system supports one of three modes (if it is systemd based): 
- Legacy: pure v1
- Unified: pure v2
- Hybrid: v1, but with some v2 features activated. Resource control needs to be done with v1 as all controllers are attached to the v1 hierarchy. Going forward, this mode will not be available anymore. 

One can check which filesystems are mounted where in order to determine in which mode the system is (see code comments). 
