### PR TITLE
Stablize cargo test

### DIFF
--- a/hack/stress_cargo_test.sh
+++ b/hack/stress_cargo_test.sh
@@ -1,0 +1,11 @@
+#!/bin/bash -ue
+
+# This is a simple script to stress test `cargo test` to rule out flaky tests.
+
+COUNT=${1:-20}
+
+for i in $(seq 1 ${COUNT})
+do 
+    echo "Run test ${i} iteration..."
+    cargo test -- --nocapture
+done

--- a/src/container/tenant_builder.rs
+++ b/src/container/tenant_builder.rs
@@ -8,7 +8,7 @@ use std::{
     collections::HashMap,
     convert::TryFrom,
     fs,
-    os::unix::prelude::{RawFd},
+    os::unix::prelude::RawFd,
     path::{Path, PathBuf},
     str::FromStr,
 };

--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -1,7 +1,10 @@
 use anyhow::{bail, Context, Result};
 use nix::{sys::signal, unistd::Pid};
 use oci_spec::Hook;
-use std::{collections::HashMap, fmt, os::unix::prelude::CommandExt, process, thread, time};
+use std::{
+    collections::HashMap, fmt, io::ErrorKind, io::Write, os::unix::prelude::CommandExt, process,
+    thread, time,
+};
 
 use crate::{container::Container, utils};
 // A special error used to signal a timeout. We want to differenciate between a
@@ -25,6 +28,12 @@ pub fn run_hooks(hooks: Option<&Vec<Hook>>, container: Option<&Container>) -> Re
     if let Some(hooks) = hooks {
         for hook in hooks {
             let mut hook_command = process::Command::new(&hook.path);
+            // Based on OCI spec, the first arguement of the args vector is the
+            // arg0, which can be different from the path.  For example, path
+            // may be "/usr/bin/true" and arg0 is set to "true". However, rust
+            // command differenciates arg0 from args, where rust command arg
+            // doesn't include arg0. So we have to make the split arg0 from the
+            // rest of args.
             if let Some((arg0, args)) = hook.args.as_ref().map(|a| a.split_first()).flatten() {
                 log::debug!("run_hooks arg0: {:?}, args: {:?}", arg0, args);
                 hook_command.arg0(arg0).args(args)
@@ -48,8 +57,25 @@ pub fn run_hooks(hooks: Option<&Vec<Hook>>, container: Option<&Container>) -> Re
             let hook_process_pid = Pid::from_raw(hook_process.id() as i32);
             // Based on the OCI spec, we need to pipe the container state into
             // the hook command through stdin.
-            if let Some(stdin) = hook_process.stdin.as_ref() {
-                serde_json::to_writer(stdin, state)?;
+            if let Some(mut stdin) = hook_process.stdin.as_ref() {
+                // We want to ignore BrokenPipe here. A BrokenPipe indicates
+                // either the hook is crashed/errored or it ran successfully.
+                // Either way, this is an indication that the hook command
+                // finished execution.  If the hook command was successful,
+                // which we will check later in this function, we should not
+                // fail this step here. We still want to check for all the other
+                // error, in the case that the hook command is waiting for us to
+                // write to stdin.
+                let encoded_state =
+                    serde_json::to_string(state).context("Failed to encode container state")?;
+                if let Err(e) = stdin.write_all(encoded_state.as_bytes()) {
+                    if e.kind() != ErrorKind::BrokenPipe {
+                        // Not a broken pipe. The hook command may be waiting
+                        // for us.
+                        let _ = signal::kill(hook_process_pid, signal::Signal::SIGKILL);
+                        bail!("Failed to write container state to stdin: {:?}", e);
+                    }
+                }
             }
 
             let res = if let Some(timeout_sec) = hook.timeout {
@@ -117,7 +143,7 @@ mod test {
     fn test_run_hook() -> Result<()> {
         {
             let default_container: Container = Default::default();
-            run_hooks(None, Some(&default_container))?;
+            run_hooks(None, Some(&default_container)).context("Failed simple test")?;
         }
 
         {
@@ -129,7 +155,7 @@ mod test {
                 timeout: None,
             };
             let hooks = Some(vec![hook]);
-            run_hooks(hooks.as_ref(), Some(&default_container))?;
+            run_hooks(hooks.as_ref(), Some(&default_container)).context("Failed /bin/true")?;
         }
 
         {
@@ -146,7 +172,7 @@ mod test {
                 timeout: None,
             };
             let hooks = Some(vec![hook]);
-            run_hooks(hooks.as_ref(), Some(&default_container))?;
+            run_hooks(hooks.as_ref(), Some(&default_container)).context("Failed printenv test")?;
         }
 
         Ok(())

--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -137,9 +137,11 @@ pub fn run_hooks(hooks: Option<&Vec<Hook>>, container: Option<&Container>) -> Re
 mod test {
     use super::*;
     use anyhow::{bail, Result};
+    use serial_test::serial;
     use std::path::PathBuf;
 
     #[test]
+    #[serial]
     fn test_run_hook() -> Result<()> {
         {
             let default_container: Container = Default::default();
@@ -179,13 +181,14 @@ mod test {
     }
 
     #[test]
+    #[serial]
     #[ignore]
     // This will test executing hook with a timeout. Since the timeout is set in
     // secs, minimally, the test will run for 1 second to trigger the timeout.
     // Therefore, we leave this test in the normal execution.
     fn test_run_hook_timeout() -> Result<()> {
         let default_container: Container = Default::default();
-        // We use `/bin/cat` here to simulate a hook command that hangs.
+        // We use `tail -f /dev/null` here to simulate a hook command that hangs.
         let hook = Hook {
             path: PathBuf::from("tail"),
             args: Some(vec![

--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -136,9 +136,13 @@ mod test {
             // Use `printenv` to make sure the environment is set correctly.
             let default_container: Container = Default::default();
             let hook = Hook {
-                path: PathBuf::from("/usr/bin/printenv"),
-                args: Some(vec!["printenv".to_string(), "key".to_string()]),
-                env: Some(vec!["key=value".to_string()]),
+                path: PathBuf::from("/usr/bin/bash"),
+                args: Some(vec![
+                    String::from("bash"),
+                    String::from("-c"),
+                    String::from("/usr/bin/printenv key > /dev/null"),
+                ]),
+                env: Some(vec![String::from("key=value")]),
                 timeout: None,
             };
             let hooks = Some(vec![hook]);

--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -140,6 +140,13 @@ mod test {
     use serial_test::serial;
     use std::path::PathBuf;
 
+    // Note: the run_hook will require the use of pipe to write the container
+    // state into stdin of the hook command. When cargo test runs these tests in
+    // parallel with other tests, the pipe becomes flaky and often we will get
+    // broken pipe or bad file descriptors. There is not much we can do and we
+    // decide not to retry in the test. The most sensible way to test this is
+    // ask cargo test to run these tests in serial.
+
     #[test]
     #[serial]
     fn test_run_hook() -> Result<()> {

--- a/src/process/channel.rs
+++ b/src/process/channel.rs
@@ -244,12 +244,12 @@ mod tests {
         let (sender, receiver) = &mut intermediate_to_main()?;
         match unsafe { unistd::fork()? } {
             unistd::ForkResult::Parent { child } => {
+                wait::waitpid(child, None)?;
                 let pid = receiver
                     .wait_for_intermediate_ready()
                     .with_context(|| "Failed to wait for intermadiate ready")?;
                 receiver.close()?;
                 assert_eq!(pid, child);
-                wait::waitpid(child, None)?;
             }
             unistd::ForkResult::Child => {
                 let pid = unistd::getpid();
@@ -268,9 +268,9 @@ mod tests {
         let (sender, receiver) = &mut intermediate_to_main()?;
         match unsafe { unistd::fork()? } {
             unistd::ForkResult::Parent { child } => {
+                wait::waitpid(child, None)?;
                 receiver.wait_for_mapping_request()?;
                 receiver.close()?;
-                wait::waitpid(child, None)?;
             }
             unistd::ForkResult::Child => {
                 sender
@@ -290,8 +290,8 @@ mod tests {
         let (sender, receiver) = &mut main_to_intermediate()?;
         match unsafe { unistd::fork()? } {
             unistd::ForkResult::Parent { child } => {
-                receiver.wait_for_mapping_ack()?;
                 wait::waitpid(child, None)?;
+                receiver.wait_for_mapping_ack()?;
             }
             unistd::ForkResult::Child => {
                 sender
@@ -310,9 +310,9 @@ mod tests {
         let (sender, receiver) = &mut init_to_intermediate()?;
         match unsafe { unistd::fork()? } {
             unistd::ForkResult::Parent { child } => {
+                wait::waitpid(child, None)?;
                 receiver.wait_for_init_ready()?;
                 receiver.close()?;
-                wait::waitpid(child, None)?;
             }
             unistd::ForkResult::Child => {
                 sender

--- a/src/process/channel.rs
+++ b/src/process/channel.rs
@@ -244,12 +244,12 @@ mod tests {
         let (sender, receiver) = &mut intermediate_to_main()?;
         match unsafe { unistd::fork()? } {
             unistd::ForkResult::Parent { child } => {
-                wait::waitpid(child, None)?;
                 let pid = receiver
                     .wait_for_intermediate_ready()
                     .with_context(|| "Failed to wait for intermadiate ready")?;
                 receiver.close()?;
                 assert_eq!(pid, child);
+                wait::waitpid(child, None)?;
             }
             unistd::ForkResult::Child => {
                 let pid = unistd::getpid();
@@ -268,9 +268,9 @@ mod tests {
         let (sender, receiver) = &mut intermediate_to_main()?;
         match unsafe { unistd::fork()? } {
             unistd::ForkResult::Parent { child } => {
-                wait::waitpid(child, None)?;
                 receiver.wait_for_mapping_request()?;
                 receiver.close()?;
+                wait::waitpid(child, None)?;
             }
             unistd::ForkResult::Child => {
                 sender
@@ -290,8 +290,8 @@ mod tests {
         let (sender, receiver) = &mut main_to_intermediate()?;
         match unsafe { unistd::fork()? } {
             unistd::ForkResult::Parent { child } => {
-                wait::waitpid(child, None)?;
                 receiver.wait_for_mapping_ack()?;
+                wait::waitpid(child, None)?;
             }
             unistd::ForkResult::Child => {
                 sender
@@ -310,9 +310,9 @@ mod tests {
         let (sender, receiver) = &mut init_to_intermediate()?;
         match unsafe { unistd::fork()? } {
             unistd::ForkResult::Parent { child } => {
-                wait::waitpid(child, None)?;
                 receiver.wait_for_init_ready()?;
                 receiver.close()?;
+                wait::waitpid(child, None)?;
             }
             unistd::ForkResult::Child => {
                 sender

--- a/src/process/channel.rs
+++ b/src/process/channel.rs
@@ -238,6 +238,13 @@ mod tests {
     use nix::unistd;
     use serial_test::serial;
 
+    // Note: due to cargo test by default runs tests in parallel using a single
+    // process, these tests should not be running in parallel with other tests.
+    // Because we run tests in the same process, other tests may decide to close
+    // down file descriptors or saturate the IOs in the OS.  The channel uses
+    // pipe to communicate and can potentially become flaky as a result. There
+    // is not much else we can do other than to run the tests in serial.
+
     #[test]
     #[serial]
     fn test_channel_intermadiate_ready() -> Result<()> {

--- a/src/process/init.rs
+++ b/src/process/init.rs
@@ -570,7 +570,13 @@ mod tests {
     use serial_test::serial;
     use std::fs;
 
+    // Note: We have to run these tests here as serial. The main issue is that
+    // these tests has a dependency on the system state. The
+    // cleanup_file_descriptors test is especially evil when running with other
+    // tests because it would ran around close down different fds.
+
     #[test]
+    #[serial]
     fn test_get_open_fds() -> Result<()> {
         let file = fs::File::open("/dev/null")?;
         let fd = file.as_raw_fd();

--- a/src/process/message.rs
+++ b/src/process/message.rs
@@ -14,7 +14,7 @@ impl From<u8> for Message {
             0x01 => Message::InitReady,
             0x02 => Message::WriteMapping,
             0x03 => Message::MappingWritten,
-            _ => panic!("unknown message."),
+            _ => panic!("unknown message: {:?}.", from),
         }
     }
 }


### PR DESCRIPTION
The root cause of the flakiness observed in the hook, clean up file descriptors, and channel tests are the result of running the tests in parallel in the same process by cargo test. Many of the operations have side effects on the underlying OS and the process, such as closing down fds. These tests also depends on the underlying OS state such as file descriptor states. The best we can do is to mark these tests as `serial` and properly clean up any left over resources such as opened fds before the test ends. If the underlying OS decided to generate errors for some of the IO calls we are doing, then there is not much we can do. Not sure if retry is a valid solution here and retry generally will make the code much more complex.

Note: `runc` actually doesn't have unit tests on most of these operations. The other solution is to fully depend on the `integration` tests to test out these code path. It may be the reasonable thing to do if these unit tests prove to be hard to get right.

Note2: Currently, I ran cargo test for 100 iterations and no failed tests. There may still be flakiness, but it should be extremely rare.