### PR TITLE
Change cache action from default to Swatinem/rust-cache@v1 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -116,19 +116,10 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: recursive
-      - uses: actions/cache@v2
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-            integration_test/src/github.com/opencontainers/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: ${{ matrix.rust }}
+      - uses: Swatinem/rust-cache@v1
       - run: sudo apt-get -y update
       - run: sudo apt-get install -y pkg-config libsystemd-dev libdbus-glib-1-dev libelf-dev
       - name: Build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,19 +30,11 @@ jobs:
         dirs: ${{ fromJSON(needs.changes.outputs.dirs) }}
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/cache@v2
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: ${{ matrix.rust }}
           override: true
+      - uses: Swatinem/rust-cache@v1
       - run: rustup component add rustfmt clippy
       - run: sudo apt-get -y update
       - run: sudo apt-get install -y pkg-config libsystemd-dev libdbus-glib-1-dev libelf-dev
@@ -59,19 +51,11 @@ jobs:
         rust: [1.54.0]
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/cache@v2
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: ${{ matrix.rust }}
           override: true
+      - uses: Swatinem/rust-cache@v1
       - run: sudo apt-get -y update
       - run: sudo apt-get install -y pkg-config libsystemd-dev libdbus-glib-1-dev libelf-dev
       - name: Run tests
@@ -86,25 +70,6 @@ jobs:
     name: Run test coverage
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/cache@v2
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry
-            ~/.cargo/git
-            target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-        continue-on-error: true
-      - name: install cargo-llvm-cov
-        run: |
-          wget https://github.com/taiki-e/cargo-llvm-cov/releases/download/v${CARGO_LLVM_COV_VERSION}/cargo-llvm-cov-x86_64-unknown-linux-gnu.tar.gz -qO- | tar -xzvf -
-          mv cargo-llvm-cov ~/.cargo/bin
-        env:
-          CARGO_LLVM_COV_VERSION: 0.1.5
-      - name: Update System Libraries
-        run: sudo apt-get -y update
-      - name: Install System Libraries
-        run: sudo apt-get install -y pkg-config libsystemd-dev libdbus-glib-1-dev libelf-dev
       - name: Toolchain setup
         uses: actions-rs/toolchain@v1
         with:
@@ -112,6 +77,17 @@ jobs:
           override: true
           profile: minimal
           components: llvm-tools-preview
+      - uses: Swatinem/rust-cache@v1
+      - name: install cargo-llvm-cov
+        env:
+          CARGO_LLVM_COV_VERSION: 0.1.5
+        run: |
+          wget https://github.com/taiki-e/cargo-llvm-cov/releases/download/v${CARGO_LLVM_COV_VERSION}/cargo-llvm-cov-x86_64-unknown-linux-gnu.tar.gz -qO- | tar -xzvf -
+          mv cargo-llvm-cov ~/.cargo/bin
+      - name: Update System Libraries
+        run: sudo apt-get -y update
+      - name: Install System Libraries
+        run: sudo apt-get install -y pkg-config libsystemd-dev libdbus-glib-1-dev libelf-dev
       - name: Run Test Coverage for youki
         run: |
           cargo llvm-cov clean --workspace

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,7 +34,12 @@ jobs:
         with:
           toolchain: ${{ matrix.rust }}
           override: true
-      - uses: Swatinem/rust-cache@v1
+      - name: Cache youki
+        uses: Swatinem/rust-cache@v1
+      - name: Cache Cgroups
+        uses: Swatinem/rust-cache@v1
+        with:
+          working-directory: ./cgroups
       - run: rustup component add rustfmt clippy
       - run: sudo apt-get -y update
       - run: sudo apt-get install -y pkg-config libsystemd-dev libdbus-glib-1-dev libelf-dev
@@ -82,7 +87,12 @@ jobs:
           override: true
           profile: minimal
           components: llvm-tools-preview
-      - uses: Swatinem/rust-cache@v1
+      - name: Cache youki
+        uses: Swatinem/rust-cache@v1
+      - name: Cache Cgroups
+        uses: Swatinem/rust-cache@v1
+        with:
+          working-directory: ./cgroups
       - name: install cargo-llvm-cov
         env:
           CARGO_LLVM_COV_VERSION: 0.1.5
@@ -124,7 +134,12 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: ${{ matrix.rust }}
-      - uses: Swatinem/rust-cache@v1
+      - name: Cache youki
+        uses: Swatinem/rust-cache@v1
+      - name: Cache Cgroups
+        uses: Swatinem/rust-cache@v1
+        with:
+          working-directory: ./cgroups
       - run: sudo apt-get -y update
       - run: sudo apt-get install -y pkg-config libsystemd-dev libdbus-glib-1-dev libelf-dev
       - name: Build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,7 +36,7 @@ jobs:
           override: true
       - name: Cache youki
         uses: Swatinem/rust-cache@v1
-      - name: Cache Cgroups
+      - name: Cache cgroups
         uses: Swatinem/rust-cache@v1
         with:
           working-directory: ./cgroups
@@ -62,7 +62,7 @@ jobs:
           override: true
       - name: Cache youki
         uses: Swatinem/rust-cache@v1
-      - name: Cache Cgroups
+      - name: Cache cgroups
         uses: Swatinem/rust-cache@v1
         with:
           working-directory: ./cgroups
@@ -89,7 +89,7 @@ jobs:
           components: llvm-tools-preview
       - name: Cache youki
         uses: Swatinem/rust-cache@v1
-      - name: Cache Cgroups
+      - name: Cache cgroups
         uses: Swatinem/rust-cache@v1
         with:
           working-directory: ./cgroups
@@ -136,7 +136,7 @@ jobs:
           toolchain: ${{ matrix.rust }}
       - name: Cache youki
         uses: Swatinem/rust-cache@v1
-      - name: Cache Cgroups
+      - name: Cache cgroups
         uses: Swatinem/rust-cache@v1
         with:
           working-directory: ./cgroups

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,7 +55,12 @@ jobs:
         with:
           toolchain: ${{ matrix.rust }}
           override: true
-      - uses: Swatinem/rust-cache@v1
+      - name: Cache youki
+        uses: Swatinem/rust-cache@v1
+      - name: Cache Cgroups
+        uses: Swatinem/rust-cache@v1
+        with:
+          working-directory: ./cgroups
       - run: sudo apt-get -y update
       - run: sudo apt-get install -y pkg-config libsystemd-dev libdbus-glib-1-dev libelf-dev
       - name: Run tests


### PR DESCRIPTION
This reduces CI time : for tests and coverage from 4 mins to 1 min, for integration test from ~7 mins to 5 mins. There is not much improvement in integrations tests, as go builds are not cached, maybe that can improve time even more.
Also as coverage uses nightly, the cache will be flushed daily, so the first PR on each day will have slow coverage report, but after that the cache should persist till end of the day. see https://github.com/marketplace/actions/rust-cache
Hope this will improve CI/CD experience for youki!