### PR TITLE
Convert memory swap values

### DIFF
--- a/cgroups/src/v2/memory.rs
+++ b/cgroups/src/v2/memory.rs
@@ -97,8 +97,22 @@ impl Memory {
                     bail!("invalid swap value: {}", swap);
                 }
                 Some(swap) => {
-                    Memory::set(path.join(CGROUP_MEMORY_SWAP), swap)?;
-                    Memory::set(path.join(CGROUP_MEMORY_MAX), limit)?;
+                    // -1 means max
+                    if swap == -1 || limit == -1 {
+                        Memory::set(path.join(CGROUP_MEMORY_SWAP), swap)?;
+                        Memory::set(path.join(CGROUP_MEMORY_MAX), limit)?;
+                    } else {
+                        if swap < limit {
+                            bail!("swap memory ({}) should be bigger than memory limit ({})", swap, limit);
+                        }
+    
+                        // In cgroup v1 swap is memory+swap, but in cgroup v2 swap is
+                        // a separate value, so the swap value in the runtime spec needs 
+                        // to be converted from the cgroup v1 value to the cgroup v2 value 
+                        // by subtracting limit from swap
+                        Memory::set(path.join(CGROUP_MEMORY_SWAP), swap - limit)?;
+                        Memory::set(path.join(CGROUP_MEMORY_MAX), limit)?;
+                    }               
                 }
                 None => {
                     if limit == -1 {
@@ -158,7 +172,7 @@ mod tests {
         assert_eq!(limit_content, limit.to_string());
 
         let swap_content = read_to_string(tmp.join(CGROUP_MEMORY_SWAP)).expect("read swap limit");
-        assert_eq!(swap_content, swap.to_string());
+        assert_eq!(swap_content, (swap - limit).to_string());
 
         let reservation_content =
             read_to_string(tmp.join(CGROUP_MEMORY_LOW)).expect("read memory reservation");
@@ -306,7 +320,7 @@ mod tests {
             let swap_content = read_to_string(tmp.join(CGROUP_MEMORY_SWAP)).expect("read swap limit to string");
             let swap_check = match linux_memory.swap {
                 Some(swap) if swap == -1 => swap_content == "max",
-                Some(swap) => swap_content == swap.to_string(),
+                Some(swap) =>  swap_content == (swap - linux_memory.limit.unwrap()).to_string(),
                 None => {
                     match linux_memory.limit {
                         Some(limit) if limit == -1 => swap_content == "max",


### PR DESCRIPTION
This [converts ](https://github.com/containers/crun/blob/main/crun.1.md#memory-controller) cgroup v1 memory swap values to cgroup v2.