### PR TITLE
Extend info cmd with status of cgroup controllers

### DIFF
--- a/cgroups/src/v2/controller_type.rs
+++ b/cgroups/src/v2/controller_type.rs
@@ -1,5 +1,6 @@
 use std::fmt::Display;
 
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
 pub enum ControllerType {
     Cpu,
     CpuSet,
@@ -33,6 +34,7 @@ pub const CONTROLLER_TYPES: &[ControllerType] = &[
     ControllerType::Pids,
 ];
 
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
 pub enum PseudoControllerType {
     Devices,
     Freezer,

--- a/cgroups/src/v2/controller_type.rs
+++ b/cgroups/src/v2/controller_type.rs
@@ -7,7 +7,6 @@ pub enum ControllerType {
     Memory,
     HugeTlb,
     Pids,
-    Freezer,
 }
 
 impl Display for ControllerType {
@@ -19,7 +18,6 @@ impl Display for ControllerType {
             Self::Memory => "memory",
             Self::HugeTlb => "hugetlb",
             Self::Pids => "pids",
-            Self::Freezer => "freezer",
         };
 
         write!(f, "{}", print)
@@ -33,11 +31,11 @@ pub const CONTROLLER_TYPES: &[ControllerType] = &[
     ControllerType::Io,
     ControllerType::Memory,
     ControllerType::Pids,
-    ControllerType::Freezer,
 ];
 
 pub enum PseudoControllerType {
     Devices,
+    Freezer,
     Unified,
 }
 
@@ -45,6 +43,7 @@ impl Display for PseudoControllerType {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let print = match self {
             Self::Devices => "devices",
+            Self::Freezer => "freezer",
             Self::Unified => "unified",
         };
 
@@ -52,5 +51,8 @@ impl Display for PseudoControllerType {
     }
 }
 
-pub const PSEUDO_CONTROLLER_TYPES: &[PseudoControllerType] =
-    &[PseudoControllerType::Devices, PseudoControllerType::Unified];
+pub const PSEUDO_CONTROLLER_TYPES: &[PseudoControllerType] = &[
+    PseudoControllerType::Devices,
+    PseudoControllerType::Freezer,
+    PseudoControllerType::Unified,
+];

--- a/cgroups/src/v2/manager.rs
+++ b/cgroups/src/v2/manager.rs
@@ -4,7 +4,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use anyhow::{bail, Result};
+use anyhow::Result;
 
 use nix::unistd::Pid;
 
@@ -23,15 +23,12 @@ use super::{
     memory::Memory,
     pids::Pids,
     unified::Unified,
+    util::{self, CGROUP_SUBTREE_CONTROL},
 };
 use crate::{
     common::{self, CgroupManager, ControllerOpt, FreezerState, PathBufExt, CGROUP_PROCS},
     stats::{Stats, StatsProvider},
 };
-
-const CGROUP_CONTROLLERS: &str = "cgroup.controllers";
-const CGROUP_SUBTREE_CONTROL: &str = "cgroup.subtree_control";
-
 pub struct Manager {
     root_path: PathBuf,
     cgroup_path: PathBuf,
@@ -52,8 +49,7 @@ impl Manager {
     }
 
     fn create_unified_cgroup(&self, pid: Pid) -> Result<()> {
-        let controllers: Vec<String> = self
-            .get_available_controllers()?
+        let controllers: Vec<String> = util::get_available_controllers(&self.root_path)?
             .iter()
             .map(|c| format!("{}{}", "+", c.to_string()))
             .collect();
@@ -78,32 +74,6 @@ impl Manager {
 
         common::write_cgroup_file(&self.full_path.join(CGROUP_PROCS), pid)?;
         Ok(())
-    }
-
-    fn get_available_controllers(&self) -> Result<Vec<ControllerType>> {
-        let controllers_path = self.root_path.join(CGROUP_CONTROLLERS);
-        if !controllers_path.exists() {
-            bail!(
-                "cannot get available controllers. {:?} does not exist",
-                controllers_path
-            )
-        }
-
-        let mut controllers = Vec::new();
-        for controller in fs::read_to_string(&controllers_path)?.split_whitespace() {
-            match controller {
-                "cpu" => controllers.push(ControllerType::Cpu),
-                "cpuset" => controllers.push(ControllerType::CpuSet),
-                "hugetlb" => controllers.push(ControllerType::HugeTlb),
-                "io" => controllers.push(ControllerType::Io),
-                "memory" => controllers.push(ControllerType::Memory),
-                "pids" => controllers.push(ControllerType::Pids),
-                "freezer" => controllers.push(ControllerType::Freezer),
-                tpe => log::warn!("Controller {} is not yet implemented.", tpe),
-            }
-        }
-
-        Ok(controllers)
     }
 
     fn write_controllers(path: &Path, controllers: &[String]) -> Result<()> {
@@ -141,8 +111,8 @@ impl CgroupManager for Manager {
                 Unified::apply(
                     controller_opt,
                     &self.cgroup_path,
-                    self.get_available_controllers()?,
-                )?
+                    util::get_available_controllers(&self.root_path)?,
+                )?;
             }
         }
 

--- a/cgroups/src/v2/manager.rs
+++ b/cgroups/src/v2/manager.rs
@@ -130,7 +130,6 @@ impl CgroupManager for Manager {
                 ControllerType::Io => Io::apply(controller_opt, &self.full_path)?,
                 ControllerType::Memory => Memory::apply(controller_opt, &self.full_path)?,
                 ControllerType::Pids => Pids::apply(controller_opt, &self.full_path)?,
-                ControllerType::Freezer => Freezer::apply(controller_opt, &self.full_path)?,
             }
         }
 

--- a/cgroups/src/v2/mod.rs
+++ b/cgroups/src/v2/mod.rs
@@ -1,5 +1,5 @@
 mod controller;
-mod controller_type;
+pub mod controller_type;
 mod cpu;
 mod cpuset;
 mod freezer;

--- a/cgroups/src/v2/systemd_manager.rs
+++ b/cgroups/src/v2/systemd_manager.rs
@@ -235,7 +235,6 @@ impl CgroupManager for SystemDCGroupManager {
                 ControllerType::Io => Io::apply(controller_opt, &self.full_path)?,
                 ControllerType::Memory => Memory::apply(controller_opt, &self.full_path)?,
                 ControllerType::Pids => Pids::apply(controller_opt, &self.full_path)?,
-                ControllerType::Freezer => Freezer::apply(controller_opt, &self.full_path)?,
             }
         }
 

--- a/cgroups/src/v2/util.rs
+++ b/cgroups/src/v2/util.rs
@@ -1,7 +1,14 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, bail, Result};
 use procfs::process::Process;
+
+use crate::common;
+
+use super::controller_type::ControllerType;
+
+pub const CGROUP_CONTROLLERS: &str = "cgroup.controllers";
+pub const CGROUP_SUBTREE_CONTROL: &str = "cgroup.subtree_control";
 
 pub fn get_unified_mount_point() -> Result<PathBuf> {
     Process::myself()?
@@ -10,4 +17,29 @@ pub fn get_unified_mount_point() -> Result<PathBuf> {
         .find(|m| m.fs_type == "cgroup2")
         .map(|m| m.mount_point)
         .ok_or_else(|| anyhow!("could not find mountpoint for unified"))
+}
+
+pub fn get_available_controllers(root_path: &Path) -> Result<Vec<ControllerType>> {
+    let controllers_path = root_path.join(CGROUP_CONTROLLERS);
+    if !controllers_path.exists() {
+        bail!(
+            "cannot get available controllers. {:?} does not exist",
+            controllers_path
+        )
+    }
+
+    let mut controllers = Vec::new();
+    for controller in common::read_cgroup_file(controllers_path)?.split_whitespace() {
+        match controller {
+            "cpu" => controllers.push(ControllerType::Cpu),
+            "cpuset" => controllers.push(ControllerType::CpuSet),
+            "hugetlb" => controllers.push(ControllerType::HugeTlb),
+            "io" => controllers.push(ControllerType::Io),
+            "memory" => controllers.push(ControllerType::Memory),
+            "pids" => controllers.push(ControllerType::Pids),
+            tpe => log::warn!("Controller {} is not yet implemented.", tpe),
+        }
+    }
+
+    Ok(controllers)
 }


### PR DESCRIPTION
This adds which controllers are attached to the cgroup v2 hierarchy. For devices I just check if it is possible to attach epbf programs to a cgroup. I also moved the freezer controller to pseudo controllers. While contrary to devices and unified, this is a real subsystem it is also quite different from the other controllers. More importantly you cannot read it from cgroup.controllers, nor write it to subtree_control which was one of the original motivations for introducing this distinction.