### PR TITLE
Pass uid_mapping test

### DIFF
--- a/integration_test.sh
+++ b/integration_test.sh
@@ -50,7 +50,7 @@ test_cases=(
   # "linux_rootfs_propagation/linux_rootfs_propagation.t"
   # "linux_seccomp/linux_seccomp.t"
   "linux_sysctl/linux_sysctl.t"
-  # "linux_uid_mappings/linux_uid_mappings.t"
+  "linux_uid_mappings/linux_uid_mappings.t"
   "misc_props/misc_props.t"
   "mounts/mounts.t"
   # "pidfile/pidfile.t"

--- a/src/rootfs.rs
+++ b/src/rootfs.rs
@@ -212,9 +212,9 @@ fn bind_dev(rootfs: &Path, dev: &LinuxDevice) -> Result<()> {
     )?;
     close(fd)?;
     nix_mount(
-        Some(&full_container_path),
-        &dev.path,
-        None::<&str>,
+        Some(&dev.path),
+        &full_container_path,
+        Some("bind"),
         MsFlags::MS_BIND,
         None::<&str>,
     )?;


### PR DESCRIPTION
#255

by running `./integration_test.sh uid_mapping`
below are the current not OK cases

```
not ok 226 - /dev/null (default device) has the expected type
not ok 228 - /dev/zero (default device) has the expected type
not ok 230 - /dev/full (default device) has the expected type
not ok 232 - /dev/random (default device) has the expected type
not ok 234 - /dev/urandom (default device) has the expected type
not ok 236 - /dev/tty (default device) has the expected type

"actual": "unmatched",
"expected": "c",
```