### PR TITLE
Forbid empty string values for container id in commands

### DIFF
--- a/src/commands/create.rs
+++ b/src/commands/create.rs
@@ -23,6 +23,7 @@ pub struct Create {
     #[clap(long, default_value = "0")]
     preserve_fds: i32,
     /// name of the container instance to be started
+    #[clap(forbid_empty_values = true, required = true)]
     pub container_id: String,
 }
 

--- a/src/commands/delete.rs
+++ b/src/commands/delete.rs
@@ -13,6 +13,7 @@ use nix::sys::signal as nix_signal;
 
 #[derive(Clap, Debug)]
 pub struct Delete {
+    #[clap(forbid_empty_values = true, required = true)]
     container_id: String,
     /// forces deletion of the container if it is still running (using SIGKILL)
     #[clap(short, long)]

--- a/src/commands/events.rs
+++ b/src/commands/events.rs
@@ -16,6 +16,7 @@ pub struct Events {
     #[clap(long)]
     pub stats: bool,
     /// Name of the container instance
+    #[clap(forbid_empty_values = true, required = true)]
     pub container_id: String,
 }
 

--- a/src/commands/exec.rs
+++ b/src/commands/exec.rs
@@ -30,6 +30,7 @@ pub struct Exec {
     #[clap(short, long)]
     pub detach: bool,
     /// Identifier of the container
+    #[clap(forbid_empty_values = true, required = true)]
     pub container_id: String,
     /// Command that should be executed in the container
     #[clap(required = false)]

--- a/src/commands/kill.rs
+++ b/src/commands/kill.rs
@@ -12,6 +12,7 @@ use crate::{
 
 #[derive(Clap, Debug)]
 pub struct Kill {
+    #[clap(forbid_empty_values = true, required = true)]
     container_id: String,
     signal: String,
 }

--- a/src/commands/pause.rs
+++ b/src/commands/pause.rs
@@ -14,6 +14,7 @@ use cgroups::common::FreezerState;
 /// Structure to implement pause command
 #[derive(Clap, Debug)]
 pub struct Pause {
+    #[clap(forbid_empty_values = true, required = true)]
     pub container_id: String,
 }
 

--- a/src/commands/ps.rs
+++ b/src/commands/ps.rs
@@ -10,6 +10,7 @@ pub struct Ps {
     /// format to display processes: table or json (default: "table")
     #[clap(short, long, default_value = "table")]
     format: String,
+    #[clap(forbid_empty_values = true, required = true)]
     pub container_id: String,
     /// options will be passed to the ps utility
     #[clap(setting = clap::ArgSettings::Last)]

--- a/src/commands/resume.rs
+++ b/src/commands/resume.rs
@@ -14,6 +14,7 @@ use cgroups::common::FreezerState;
 /// Structure to implement resume command
 #[derive(Clap, Debug)]
 pub struct Resume {
+    #[clap(forbid_empty_values = true, required = true)]
     pub container_id: String,
 }
 

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -22,6 +22,7 @@ pub struct Run {
     #[clap(long, default_value = "0")]
     preserve_fds: i32,
     /// name of the container instance to be started
+    #[clap(forbid_empty_values = true, required = true)]
     pub container_id: String,
 }
 

--- a/src/commands/start.rs
+++ b/src/commands/start.rs
@@ -12,6 +12,7 @@ use crate::notify_socket::{NotifySocket, NOTIFY_FILE};
 
 #[derive(Clap, Debug)]
 pub struct Start {
+    #[clap(forbid_empty_values = true, required = true)]
     pub container_id: String,
 }
 

--- a/src/commands/state.rs
+++ b/src/commands/state.rs
@@ -8,6 +8,7 @@ use crate::container::Container;
 
 #[derive(Clap, Debug)]
 pub struct State {
+    #[clap(forbid_empty_values = true, required = true)]
     pub container_id: String,
 }
 


### PR DESCRIPTION
Currently container_id is a required argument for all commands that require container_id, but there is no restriction that empty string value cannot be provided as container_id. For example :
```sh
youki --root (root_path) create --bundle (bundle path)
```
gives error, but
```sh
youki --root (root_path) create --bundle (bundle path) ""
```
does not, as (at least bash) passes "" as an empty string argument, and clap allows it, as it is a valid string value.
This PR adds forbid_empty_value to all container_id fields, which forces it to give an error message whenever empty string is provided.