### PR TITLE
Fix Changes Job in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,10 +17,11 @@ jobs:
         id: filter
         with:
           filters: |
-            .: 'src/*'
-            ./test_framework: test_framework/*
-            ./youki_integration_test: youki_integration_test/*
-            ./cgroups: cgroups/*
+            .: src/**
+            ./test_framework: test_framework/**
+            ./youki_integration_test: youki_integration_test/**
+            ./cgroups: cgroups/**
+            ./seccomp: seccomp/**
   check:
     needs: [changes]
     if: ${{ !contains(needs.changes.outputs.dirs, '[]') }}
@@ -148,6 +149,6 @@ jobs:
         run: ./build.sh --release
       - uses: actions/setup-go@v2
         with:
-          go-version: "1.11.0"
+          go-version: '1.11.0'
       - name: Run intetgration tests
         run: ./integration_test.sh


### PR DESCRIPTION
the quotes ('') in the changes job failed to glob match the changed files, and thus the check job was not run. This PR fixes that, as well as add seccomp directory in changes.