### PR TITLE
Support 'shared' and 'unbindable' rootfs propagations

### DIFF
--- a/integration_test.sh
+++ b/integration_test.sh
@@ -47,7 +47,7 @@ test_cases=(
   "linux_ns_path_type/linux_ns_path_type.t"
   # "linux_process_apparmor_profile/linux_process_apparmor_profile.t"
   "linux_readonly_paths/linux_readonly_paths.t"
-  # "linux_rootfs_propagation/linux_rootfs_propagation.t"
+  "linux_rootfs_propagation/linux_rootfs_propagation.t"
   "linux_seccomp/linux_seccomp.t"
   "linux_sysctl/linux_sysctl.t"
   "linux_uid_mappings/linux_uid_mappings.t"

--- a/src/process/init.rs
+++ b/src/process/init.rs
@@ -248,6 +248,8 @@ pub fn container_init(
                 .with_context(|| format!("Failed to chroot to {:?}", rootfs))?;
         }
 
+        rootfs::adjust_root_mount_propagation(spec)?;
+
         if let Some(kernel_params) = &linux.sysctl {
             sysctl(kernel_params)
                 .with_context(|| format!("Failed to sysctl: {:?}", kernel_params))?;


### PR DESCRIPTION
Resolve #256.

This pull request enables youki to handle `shared` and `unbindable` [rootfs propagation](https://github.com/opencontainers/runtime-spec/blob/master/config-linux.md#rootfs-mount-propagation).

Most of the change in the pull request follows runc implementation, but one difference is that runc actually doesn't pass `linux_rootfs_propagation/linux_rootfs_propagation.t` integration test (it fails in setting `shared` or `unbindable` propagation type).

This pull request added `rootfs::adjust_root_mount_propagation` after pivot_root to set appropriate propagation type at root mount point of container if `shared` or `unbindable` rootfs propagation is specified. This approach comes from [an open pull request of runc](https://github.com/opencontainers/runc/pull/1815).

