### PR TITLE
style: Fix indentation

### DIFF
--- a/src/rootless.rs
+++ b/src/rootless.rs
@@ -208,9 +208,9 @@ pub fn lookup_map_binaries(spec: &Linux) -> Result<Option<(PathBuf, PathBuf)>> {
         let gidmap = lookup_map_binary("newgidmap")?;
 
         match (uidmap, gidmap) {
-        (Some(newuidmap), Some(newgidmap)) => Ok(Some((newuidmap, newgidmap))),
-        _ => bail!("newuidmap/newgidmap binaries could not be found in path. This is required if multiple id mappings are specified"),
-    }
+            (Some(newuidmap), Some(newgidmap)) => Ok(Some((newuidmap, newgidmap))),
+            _ => bail!("newuidmap/newgidmap binaries could not be found in path. This is required if multiple id mappings are specified"),
+        }
     } else {
         Ok(None)
     }


### PR DESCRIPTION
Fixed trivial indentation.

I don't know why `cargo fmt` allows both before/after versions. Glancing issues of rustfmt, I suspect rustfmt allows [no indent for match arms](https://github.com/rust-lang/rustfmt/issues/4616).

While that being said, I think this should be fixed because:

- Originally, this match is properly indented. https://github.com/containers/youki/pull/98/files#diff-6b8c70294dc20a59afa843ccbe8e3ab2357842d13d737643d80bf325ad931a69R105
- AFAIK, using indent for match arms is the majority.