### PR TITLE
rootful mode for vagrant

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,13 +192,19 @@ $ ./integration_test.sh linux_*
 
 ### Setting up Vagrant
 
-You can try youki on platforms other than linux by using the Vagrantfile we have prepared.
+You can try youki on platforms other than linux by using the Vagrantfile we have prepared. We have prepared two environments for vagrant, namely rootless mode and rootful mode
 
 ```
 $ git clone git@github.com:containers/youki.git
 $ cd youki
+
+# If you want to develop in rootless mode, and this is the default mode
 $ vagrant up
 $ vagrant ssh
+
+# or if you want to develop in rootful mode
+$ VAGRANT_VAGRANTFILE=Vagrantfile.root vagrant up
+$ VAGRANT_VAGRANTFILE=Vagrantfile.root vagrant ssh
 
 # in virtual machine
 $ cd youki

--- a/Vagrantfile.root
+++ b/Vagrantfile.root
@@ -1,0 +1,26 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure("2") do |config|
+    config.vm.box = "fedora/33-cloud-base"
+    config.vm.synced_folder '.', '/vagrant', disabled: true
+    config.vm.define "rootful"
+
+    config.vm.provider "virtualbox" do |v|
+      v.memory = 2048
+      v.cpus = 2
+    end
+    config.vm.provision "shell", path: "./hack/set_root_login_for_vagrant.sh"
+    config.vm.provision "shell", inline: <<-SHELL
+      set -e -u -o pipefail
+      yum update -y
+      yum install -y git gcc docker systemd-devel dbus-devel libseccomp-devel
+      grubby --update-kernel=ALL --args="systemd.unified_cgroup_hierarchy=0"
+      service docker start
+      curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+      echo "export PATH=$PATH:$HOME/.cargo/bin" >> ~/.bashrc
+    SHELL
+    config.ssh.username = 'root'
+    config.ssh.insert_key = 'true'
+  end
+

--- a/hack/set_root_login_for_vagrant.sh
+++ b/hack/set_root_login_for_vagrant.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+set -x
+
+# change sshd config
+
+file="$1"
+param[1]="PermitRootLogin "
+param[2]="PubkeyAuthentication"
+param[3]="PasswordAuthentication"
+if [ -z "${file}" ]
+then
+
+file="/etc/ssh/sshd_config"
+fi
+
+for PARAM in ${param[@]}
+do
+/usr/bin/sed -i '/^'"${PARAM}"'/d' ${file}
+/usr/bin/echo "All lines beginning with '${PARAM}' were deleted from ${file}."
+done
+
+/usr/bin/echo "${param[1]} yes" >> ${file}
+/usr/bin/echo "'${param[1]} yes' was added to ${file}."
+/usr/bin/echo "${param[2]} yes" >> ${file}
+/usr/bin/echo "'${param[2]} yes' was added to ${file}."
+/usr/bin/echo "${param[3]} no" >> ${file}
+/usr/bin/echo "'${param[3]} no' was added to ${file}"
+
+# reload config
+service sshd reload


### PR DESCRIPTION
I added a rootful development mode to vagrant, which may provide us with convenience for debugging in vagrant using a similar vscode editor remote ssh.

It is very simple to use, like the following:
```shell
VAGRANT_VAGRANTFILE=Vagrantfile.root vagrant up
```