### PR TITLE
Complete command help information

### DIFF
--- a/src/commands/create.rs
+++ b/src/commands/create.rs
@@ -5,8 +5,7 @@ use std::path::PathBuf;
 
 use crate::{container::builder::ContainerBuilder, syscall::syscall::create_syscall};
 
-/// This is the main structure which stores various commandline options given by
-/// high-level container runtime
+/// Create a container
 #[derive(Clap, Debug)]
 pub struct Create {
     /// File to write pid of the container created

--- a/src/commands/delete.rs
+++ b/src/commands/delete.rs
@@ -3,6 +3,7 @@ use anyhow::{Context, Result};
 use clap::Clap;
 use std::path::PathBuf;
 
+/// Release any resources held by the container
 #[derive(Clap, Debug)]
 pub struct Delete {
     #[clap(forbid_empty_values = true, required = true)]

--- a/src/commands/events.rs
+++ b/src/commands/events.rs
@@ -5,6 +5,7 @@ use anyhow::{Context, Result};
 
 use crate::commands::load_container;
 
+/// Show resource statistics for the container
 #[derive(Clap, Debug)]
 pub struct Events {
     /// Sets the stats collection interval in seconds (default: 5s)

--- a/src/commands/exec.rs
+++ b/src/commands/exec.rs
@@ -4,6 +4,7 @@ use std::{error::Error, path::PathBuf};
 
 use crate::{container::builder::ContainerBuilder, syscall::syscall::create_syscall};
 
+/// Execute a process within an existing container
 #[derive(Clap, Debug)]
 pub struct Exec {
     /// Unix socket (file) path , which will receive file descriptor of the writing end of the pseudoterminal

--- a/src/commands/info.rs
+++ b/src/commands/info.rs
@@ -7,6 +7,7 @@ use procfs::{CpuInfo, Meminfo};
 
 use cgroups::{self, common::CgroupSetup, v2::controller_type::ControllerType};
 
+/// Show information about the system
 #[derive(Clap, Debug)]
 pub struct Info {}
 

--- a/src/commands/kill.rs
+++ b/src/commands/kill.rs
@@ -6,6 +6,7 @@ use clap::Clap;
 
 use crate::{commands::load_container, signal::ToSignal};
 
+/// Send the specified signal to the container
 #[derive(Clap, Debug)]
 pub struct Kill {
     #[clap(forbid_empty_values = true, required = true)]

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -12,7 +12,7 @@ use tabwriter::TabWriter;
 
 use crate::container::{state::State, Container};
 
-/// Empty struct for list command
+/// List created containers
 #[derive(Clap, Debug)]
 pub struct List {}
 

--- a/src/commands/pause.rs
+++ b/src/commands/pause.rs
@@ -5,7 +5,7 @@ use std::path::PathBuf;
 use anyhow::{Context, Result};
 use clap::Clap;
 
-/// Structure to implement pause command
+/// Suspend the processes within the container
 #[derive(Clap, Debug)]
 pub struct Pause {
     #[clap(forbid_empty_values = true, required = true)]

--- a/src/commands/ps.rs
+++ b/src/commands/ps.rs
@@ -4,7 +4,7 @@ use cgroups;
 use clap::{self, Clap};
 use std::{path::PathBuf, process::Command};
 
-/// display the processes inside a container
+/// Display the processes inside the container
 #[derive(Clap, Debug)]
 pub struct Ps {
     /// format to display processes: table or json (default: "table")

--- a/src/commands/resume.rs
+++ b/src/commands/resume.rs
@@ -6,7 +6,7 @@ use clap::Clap;
 
 use crate::commands::load_container;
 
-/// Structure to implement resume command
+/// Resume the processes within the container
 #[derive(Clap, Debug)]
 pub struct Resume {
     #[clap(forbid_empty_values = true, required = true)]

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -4,8 +4,8 @@ use crate::container::builder::ContainerBuilder;
 use crate::syscall::syscall::create_syscall;
 use anyhow::{Context, Result};
 use clap::Clap;
-/// Create and start a container.
-/// a shortcut for create followed by start.
+
+/// Create a container and immediately start it
 #[derive(Clap, Debug)]
 pub struct Run {
     /// File to write pid of the container created

--- a/src/commands/spec_json.rs
+++ b/src/commands/spec_json.rs
@@ -4,7 +4,7 @@ use oci_spec::runtime::Spec;
 use serde_json::to_writer_pretty;
 use std::fs::File;
 
-/// Command generates a config.json
+/// Create a new runtime specification
 #[derive(Clap, Debug)]
 pub struct SpecJson;
 

--- a/src/commands/start.rs
+++ b/src/commands/start.rs
@@ -7,6 +7,7 @@ use clap::Clap;
 
 use crate::commands::load_container;
 
+/// Start a previously created container
 #[derive(Clap, Debug)]
 pub struct Start {
     #[clap(forbid_empty_values = true, required = true)]

--- a/src/commands/state.rs
+++ b/src/commands/state.rs
@@ -6,6 +6,7 @@ use clap::Clap;
 
 use crate::container::Container;
 
+/// Show the container state
 #[derive(Clap, Debug)]
 pub struct State {
     #[clap(forbid_empty_values = true, required = true)]


### PR DESCRIPTION
Before 
```
SUBCOMMANDS:
    create    This is the main structure which stores various commandline options given by high-
              level container runtime
    delete    
    events    
    exec      
    help      Print this message or the help of the given subcommand(s)
    info      
    kill      
    list      Empty struct for list command
    pause     Structure to implement pause command
    ps        display the processes inside a container
    resume    Structure to implement resume command
    run       Create and start a container. a shortcut for create followed by start
    spec      Command generates a config.json
    start     
    state  
``` 

After
```
SUBCOMMANDS:
    create    Create a container
    delete    Release any resources held by the container
    events    Show resource statistics for the container
    exec      Execute a process within an existing container
    help      Print this message or the help of the given subcommand(s)
    info      Show information about the system
    kill      Send the specified signal to the container
    list      List created containers
    pause     Suspend the processes within a container
    ps        Display the processes inside a container
    resume    Resume the processes within a container
    run       Create a container and immediately start it
    spec      Create a new runtime specification
    start     Start a previously created container
    state     Show the container state

```

