### PR TITLE
Seal /proc/self/exe to protect against CVE-2019-5736

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -806,6 +806,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "pentacle"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e26ee4fbe38a973890ca68cace434e192d88f3703099fd64f799f3d6043ee7b6"
+dependencies = [
+ "libc",
+ "log",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1246,6 +1256,7 @@ dependencies = [
  "nix",
  "oci-spec",
  "once_cell",
+ "pentacle",
  "prctl",
  "procfs",
  "quickcheck",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ tabwriter = "1"
 fastrand = "1.4.1"
 crossbeam-channel = "0.5"
 seccomp = { version = "0.1.0", path = "./seccomp" }
+pentacle = "1.0.0"
 
 [dev-dependencies]
 # TODO: Fetch from crate.io instead of git when next release oci-spec-rs


### PR DESCRIPTION
youki is vulnerable to CVE-2019-5736, this can be fixed by sealing `/proc/self/exe`.
[pentacle](https://github.com/iliana/pentacle) crate implements the same technique that runc implemented to fix this vulnerability.

For more information about the vulnerability check the following links:
* https://blog.dragonsector.pl/2019/02/cve-2019-5736-escape-from-docker-and.html
* https://www.openwall.com/lists/oss-security/2019/02/11/2
* https://github.com/lxc/lxc/commit/6400238d08cdf1ca20d49bafb85f4e224348bf9d
* https://github.com/opencontainers/runc/commit/0a8e4117e7f715d5fbeef398405813ce8e88558b

Some PoCs:
* https://github.com/q3k/cve-2019-5736-poc
* https://github.com/Frichetten/CVE-2019-5736-PoC
