### PR TITLE
[WIP] Add test for rootfs propagation with mock mount

### DIFF
--- a/src/syscall/linux.rs
+++ b/src/syscall/linux.rs
@@ -211,4 +211,15 @@ impl Syscall for LinuxSyscall {
 
         Ok(())
     }
+
+    fn mount(
+        &self,
+        source: Option<&Path>,
+        target: &Path,
+        fstype: Option<&str>,
+        flags: MsFlags,
+        data: Option<&str>,
+    ) -> Result<(), nix::errno::Errno> {
+        mount(source, target, fstype, flags, data)
+    }
 }

--- a/src/syscall/syscall.rs
+++ b/src/syscall/syscall.rs
@@ -6,6 +6,7 @@ use std::{any::Any, ffi::OsStr, path::Path, sync::Arc};
 use anyhow::Result;
 use caps::{errors::CapsError, CapSet, CapsHashSet};
 use nix::{
+    mount::MsFlags,
     sched::CloneFlags,
     unistd::{Gid, Uid},
 };
@@ -27,6 +28,16 @@ pub trait Syscall {
     fn set_hostname(&self, hostname: &str) -> Result<()>;
     fn set_rlimit(&self, rlimit: &LinuxRlimit) -> Result<()>;
     fn get_pwuid(&self, uid: u32) -> Option<Arc<OsStr>>;
+    // TODO: method signature (have to use a concrete type such as Path, but is it ok?
+    fn mount(
+        &self,
+        // FIXME: this is not always path (such as 'tmpfs')...
+        source: Option<&Path>,
+        target: &Path,
+        fstype: Option<&str>,
+        flags: MsFlags,
+        data: Option<&str>,
+    ) -> Result<(), nix::errno::Errno>;
 }
 
 pub fn create_syscall() -> Box<dyn Syscall> {

--- a/src/syscall/test.rs
+++ b/src/syscall/test.rs
@@ -16,13 +16,13 @@ pub struct TestHelperSyscall {
     mount_args: RefCell<Vec<MountArgs>>,
 }
 
-#[derive(Clone)]
+#[derive(Clone, PartialEq, Eq, Debug)]
 pub struct MountArgs {
-    source: Option<PathBuf>,
-    target: PathBuf,
-    fstype: Option<String>,
-    flags: MsFlags,
-    data: Option<String>,
+    pub source: Option<PathBuf>,
+    pub target: PathBuf,
+    pub fstype: Option<String>,
+    pub flags: MsFlags,
+    pub data: Option<String>,
 }
 
 impl Default for TestHelperSyscall {
@@ -113,5 +113,9 @@ impl TestHelperSyscall {
 
     pub fn get_set_capability_args(&self) -> Vec<(CapSet, CapsHashSet)> {
         self.set_capability_args.borrow_mut().clone()
+    }
+
+    pub fn get_mount_args(&self) -> Vec<MountArgs> {
+        self.mount_args.borrow_mut().clone()
     }
 }


### PR DESCRIPTION
This is a follow-up pull request to add unit tests for functions implemented in #309.

This pull request calls mount system call through `Syscall` trait to mock it in unit tests. Although we can use fork and then execute real mount system call in child process, I feel checking mount arguments is simple and enough in this case.

@utam0k @yihuaf 
What do you think about the idea of using mock for these tests?