### PR TITLE
Use generic for signal argument in container_kill

### DIFF
--- a/src/commands/kill.rs
+++ b/src/commands/kill.rs
@@ -1,10 +1,10 @@
 //! Contains functionality of kill container command
-use std::path::PathBuf;
+use std::{convert::TryInto, path::PathBuf};
 
-use anyhow::{Context, Result};
+use anyhow::Result;
 use clap::Clap;
 
-use crate::{commands::load_container, signal::ToSignal};
+use crate::{commands::load_container, signal::Signal};
 
 /// Send the specified signal to the container
 #[derive(Clap, Debug)]
@@ -17,10 +17,7 @@ pub struct Kill {
 impl Kill {
     pub fn exec(&self, root_path: PathBuf) -> Result<()> {
         let mut container = load_container(root_path, &self.container_id)?;
-        let signal = self
-            .signal
-            .to_signal()
-            .with_context(|| format!("signal {} is unknown", self.signal))?;
+        let signal: Signal = self.signal.as_str().try_into()?;
         container.kill(signal)
     }
 }

--- a/src/container/container_kill.rs
+++ b/src/container/container_kill.rs
@@ -1,6 +1,7 @@
 use super::{Container, ContainerStatus};
+use crate::signal::Signal;
 use anyhow::{bail, Context, Result};
-use nix::sys::signal::{self, Signal};
+use nix::sys::signal::{self};
 
 impl Container {
     /// Sends the specified signal to the container init process
@@ -21,7 +22,8 @@ impl Container {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn kill(&mut self, signal: Signal) -> Result<()> {
+    pub fn kill<S: Into<Signal>>(&mut self, signal: S) -> Result<()> {
+        let signal = signal.into().into_raw();
         self.refresh_status()
             .context("failed to refresh container status")?;
         if self.can_kill() {


### PR DESCRIPTION
`nix::sys::signal::Signal` is part of the API for the `kill` related calls. This causes a problem for lib users when they have a different nix version.

This patch introduces a public `youki::signal::Signal` type to be used instead.
