### PR TITLE
Check libseccomp is available at correct version on build

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -978,9 +978,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.19"
+version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3831453b3449ceb48b6d9c7ad7c96d5ea673e9b470a1dc578c2ce6521230884c"
+checksum = "7c9b1041b4387893b91ee6746cddfc28516aff326a3519fb2adf820932c5e6cb"
 
 [[package]]
 name = "ppv-lite86"
@@ -1223,6 +1223,7 @@ name = "seccomp"
 version = "0.1.0"
 dependencies = [
  "libc",
+ "pkg-config",
 ]
 
 [[package]]

--- a/seccomp/Cargo.toml
+++ b/seccomp/Cargo.toml
@@ -5,5 +5,10 @@ edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+build = "build.rs"
+
 [dependencies]
 libc = "0.2.84"
+
+[build-dependencies]
+pkg-config = "0.3.20"

--- a/seccomp/build.rs
+++ b/seccomp/build.rs
@@ -1,0 +1,17 @@
+const MINIMUM_VERSION: &str = "2.5";
+const PKG_NAME: &str = "libseccomp";
+fn main() {
+    match pkg_config::Config::new()
+        .atleast_version(MINIMUM_VERSION)
+        .probe(PKG_NAME)
+    {
+        Ok(_) => return,
+        Err(err) => {
+            eprintln!(
+                "{:?} could not be found meeting minimum version requirement {:?}: {}",
+                PKG_NAME, MINIMUM_VERSION, err
+            );
+            std::process::exit(1);
+        }
+    }
+}

--- a/seccomp/build.rs
+++ b/seccomp/build.rs
@@ -5,7 +5,7 @@ fn main() {
         .atleast_version(MINIMUM_VERSION)
         .probe(PKG_NAME)
     {
-        Ok(_) => return,
+        Ok(_) => {}
         Err(err) => {
             eprintln!("{}", err);
             std::process::exit(1);

--- a/seccomp/build.rs
+++ b/seccomp/build.rs
@@ -7,10 +7,7 @@ fn main() {
     {
         Ok(_) => return,
         Err(err) => {
-            eprintln!(
-                "{:?} could not be found meeting minimum version requirement {:?}: {}",
-                PKG_NAME, MINIMUM_VERSION, err
-            );
+            eprintln!("{}", err);
             std::process::exit(1);
         }
     }


### PR DESCRIPTION
This adds a simple build.rs to the seccomp sub-crate. This gives more information in the case of #366, but doesn't necessarily resolve the issue. What this does is it checks to see if `libeseccomp` is available at the correct version. On systems where libseccomp isn't available or is available in an older version the current output is a giant linker error that isn't very helpful. With this change the build will fail right away if the dependency isn't available at an appropriate version and provide much better output.

On my system where the libseccomp version is too old it produces this much nicer message:

```
--- stderr
  `"pkg-config" "--libs" "--cflags" "libseccomp" "libseccomp >= 2.5"` did not exit successfully: exit status: 1
  --- stderr
  Requested 'libseccomp >= 2.5' but version of libseccomp is 2.4.3
  You may find new versions of libseccomp at https://github.com/seccomp/libseccomp
```