### PR TITLE
Add integration tests validation workflow

### DIFF
--- a/.github/workflows/integration_tests_validation.yaml
+++ b/.github/workflows/integration_tests_validation.yaml
@@ -1,0 +1,45 @@
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      dirs: ${{ steps.filter.outputs.changes }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: dorny/paths-filter@v2
+        id: filter
+        with:
+          filters: |
+            ./youki_integration_test: youki_integration_test/**
+  validate:
+    needs: [changes]
+    if: ${{ !contains(needs.changes.outputs.dirs, '[]') }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust: [1.55.0, 1.54.0]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ matrix.rust }}
+          override: true
+      - name: Cache youki
+        uses: Swatinem/rust-cache@v1
+      - name: Cache tests
+        uses: Swatinem/rust-cache@v1
+        with:
+          working-directory: ./youki_integration_test
+      - run: sudo apt-get -y update
+      - run: sudo apt-get install -y pkg-config libsystemd-dev libdbus-glib-1-dev libelf-dev libseccomp-dev
+      - name: Validate tests on runc
+        run: cd ./youki_integration_test && ./run_tests.sh runc
+      - name: Validate tests on youki
+        run: cd ./youki_integration_test && ./run_tests.sh ./youki

--- a/youki_integration_test/.gitignore
+++ b/youki_integration_test/.gitignore
@@ -1,2 +1,3 @@
 /target
 youki_integration_test
+*.log

--- a/youki_integration_test/run_tests.sh
+++ b/youki_integration_test/run_tests.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+cd ..
+./build.sh
+cp ./youki ./youki_integration_test
+cd ./youki_integration_test
+./build.sh
+RUNTIME=./youki
+if [[ -n "$1" ]]; then
+    RUNTIME="$1"
+fi
+logfile="./test_log.log"
+touch $logfile
+sudo ./youki_integration_test -r $RUNTIME > $logfile
+if [ 0 -ne $(grep "not ok" $logfile | wc -l ) ]; then
+    cat $logfile
+    exit 1
+fi
+echo "Validation successful for runtime $RUNTIME"


### PR DESCRIPTION
This adds another workflow, which will conditionally run, if there are any changes in the youki_integration_test directory, and validate that all tests are passing for runc and youki. This does not explicitly checks for formatting and clippy lints etc. as the main workflow will do it.