### PR TITLE
fix running unit tests multiple times will cause a rare failed

### DIFF
--- a/src/commands/spec_json.rs
+++ b/src/commands/spec_json.rs
@@ -108,8 +108,10 @@ impl SpecJson {
 mod tests {
     use super::*;
     use crate::utils::create_temp_dir;
+    use serial_test::serial;
 
     #[test]
+    #[serial]
     fn test_spec_json() -> Result<()> {
         let spec = get_rootless()?;
         let tmpdir = create_temp_dir("test_spec_json").expect("failed to create temp dir");

--- a/src/container/container.rs
+++ b/src/container/container.rs
@@ -202,6 +202,7 @@ impl Container {
 mod tests {
     use super::*;
     use crate::utils::create_temp_dir;
+    use serial_test::serial;
 
     #[test]
     fn test_get_set_pid() {
@@ -269,6 +270,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_refresh_load_save_state() -> Result<()> {
         let tmp_dir = create_temp_dir("test_refresh_load_save_state")?;
         let mut container_1 = Container::new(
@@ -293,6 +295,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_get_spec() -> Result<()> {
         let tmp_dir = create_temp_dir("test_get_spec")?;
         use oci_spec::runtime::Spec;
@@ -309,6 +312,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_get_set_refresh_status() -> Result<()> {
         // there already has a full and well-tested flow of status in state.rs
         // so we just let the coverage run through those can_xxx functions.
@@ -331,8 +335,7 @@ mod tests {
         assert_eq!(container.status(), ContainerStatus::Stopped);
 
         // with PID case
-        let myself = Process::myself()?;
-        container.set_pid(myself.pid());
+        container.set_pid(1);
         container.set_status(ContainerStatus::Paused);
         container.refresh_status()?;
         assert_eq!(container.status(), ContainerStatus::Paused);


### PR DESCRIPTION
in the current main branch, the unit tests will fail into rare failures by running the unit test multiple times without single-thread testing setting for the cargo or using serial derive,

below are the failures I can capture.

1. bad file descriptor (os error 9) at Process::new(pid.as_raw()) line caused
```
thread 'container::container::tests::test_get_set_refresh_status' panicked at 'assertion failed: `(left == right)`
  left: `Stopped`,
 right: `Paused`', src/container/container.rs:337:9
```

2.
```
Caused by:
    Bad file descriptor (os error 9)
thread 'container::container::tests::test_refresh_load_save_state' panicked at 'assertion failed: `(left == right)`
  left: `1`,
 right: `0`: the test returned a termination value with a non-zero status code (1) which indicates a failure', /rust
c/c8dfcfe046a7680554bf4eb612bad840e7631c4b/library/test/src/lib.rs:194:5
```

3. 
```
Caused by:
    0: Bad file descriptor (os error 9)
    1: Bad file descriptor (os error 9)
thread 'container::container::tests::test_get_spec' panicked at 'assertion failed: `(left == right)`
  left: `1`,
 right: `0`: the test returned a termination value with a non-zero status code (1) which indicates a failure', /rust
c/c8dfcfe046a7680554bf4eb612bad840e7631c4b/library/test/src/lib.rs:194:5
```

4.
```
Caused by:
    Bad file descriptor (os error 9)
thread 'commands::spec_json::tests::test_spec_json' panicked at 'assertion failed: `(left == right)`
  left: `1`,
 right: `0`: the test returned a termination value with a non-zero status code (1) which indicates a failure', /rust
c/c8dfcfe046a7680554bf4eb612bad840e7631c4b/library/test/src/lib.rs:194:5
```

5.
```
thread 'container::builder_impl::tests::setup_uid_mapping_should_succeed' panicked at 'unknown message: 49.', src/pr
ocess/message.rs:17:thread '18container::container::tests::test_get_set_refresh_status
' panicked at 'note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
attempt to subtract with overflow', /home/tommady/.cargo/registry/src/github.com-1ecc6299db9ec823/procfs-0.10.1/src/
process/stat.rs:255:28
```

6.
```
thread 'thread 'container::container::tests::test_get_set_refresh_statuscontainer::builder_impl::tests::setup_uid_ma
pping_should_succeed' panicked at '' panicked at 'attempt to subtract with overflowunknown message: 49.', ', /home/t
ommady/.cargo/registry/src/github.com-1ecc6299db9ec823/procfs-0.10.1/src/process/stat.rssrc/process/message.rs::2551
7::2818

note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
Error: Failed to write message [2] to the pipe
```

7.
```
Caused by:
    Broken pipe (os error 32)
thread 'container::builder_impl::tests::setup_uid_mapping_should_succeed' panicked at 'assertion failed: `(left == r
ight)`
  left: `1`,
 right: `0`: the test returned a termination value with a non-zero status code (1) which indicates a failure', /rust
c/c8dfcfe046a7680554bf4eb612bad840e7631c4b/library/test/src/lib.rs:194:5
```

by running 
```bash
./hack/stress_cargo_test.sh
```

will be very easy to reproduce.