### PR TITLE
refactoring the syscall test

### DIFF
--- a/crates/libcontainer/src/lib.rs
+++ b/crates/libcontainer/src/lib.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(coverage, feature(no_coverage))]
 pub mod apparmor;
 pub mod capabilities;
 pub mod container;

--- a/crates/libcontainer/src/process/container_init_process.rs
+++ b/crates/libcontainer/src/process/container_init_process.rs
@@ -515,7 +515,6 @@ mod tests {
         syscall::create_syscall,
         test::{ArgName, MountArgs, TestHelperSyscall},
     };
-    use anyhow::{anyhow, Context};
     use nix::{fcntl, sys, unistd};
     use oci_spec::runtime::{LinuxNamespaceBuilder, SpecBuilder, UserBuilder};
     use serial_test::serial;
@@ -726,7 +725,7 @@ mod tests {
             .as_any()
             .downcast_ref::<TestHelperSyscall>()
             .unwrap();
-        mocks.set_ret_err(ArgName::Mount, || Err(anyhow!(nix::errno::Errno::ENOENT)));
+        mocks.set_ret_err(ArgName::Mount, || bail!(nix::errno::Errno::ENOENT));
 
         assert!(masked_path(Path::new("/proc/self"), &None, syscall.as_ref()).is_ok());
         let got = mocks.get_mount_args();
@@ -740,8 +739,7 @@ mod tests {
             .as_any()
             .downcast_ref::<TestHelperSyscall>()
             .unwrap();
-
-        mocks.set_ret_err(ArgName::Mount, || Err(anyhow!(nix::errno::Errno::ENOTDIR)));
+        mocks.set_ret_err(ArgName::Mount, || bail!(nix::errno::Errno::ENOTDIR));
 
         assert!(masked_path(Path::new("/proc/self"), &None, syscall.as_ref()).is_ok());
 
@@ -764,8 +762,7 @@ mod tests {
             .as_any()
             .downcast_ref::<TestHelperSyscall>()
             .unwrap();
-
-        mocks.set_ret_err(ArgName::Mount, || Err(anyhow!(nix::errno::Errno::ENOTDIR)));
+        mocks.set_ret_err(ArgName::Mount, || bail!(nix::errno::Errno::ENOTDIR));
 
         assert!(masked_path(
             Path::new("/proc/self"),
@@ -793,7 +790,7 @@ mod tests {
             .as_any()
             .downcast_ref::<TestHelperSyscall>()
             .unwrap();
-        mocks.set_ret_err(ArgName::Mount, || Err(anyhow!("unknown error")));
+        mocks.set_ret_err(ArgName::Mount, || bail!("unknown error"));
 
         assert!(masked_path(Path::new("/proc/self"), &None, syscall.as_ref()).is_err());
         let got = mocks.get_mount_args();

--- a/crates/libcontainer/src/syscall/linux.rs
+++ b/crates/libcontainer/src/syscall/linux.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 use std::{any::Any, mem, path::Path, ptr};
 
 use anyhow::{anyhow, bail, Result};
-use caps::{errors::CapsError, CapSet, Capability, CapsHashSet};
+use caps::{CapSet, Capability, CapsHashSet};
 use libc::{c_char, uid_t};
 use nix::{
     errno::Errno,
@@ -127,7 +127,7 @@ impl Syscall for LinuxSyscall {
 
     #[cfg_attr(coverage, no_coverage)]
     /// Set capabilities for container process
-    fn set_capability(&self, cset: CapSet, value: &CapsHashSet) -> Result<(), CapsError> {
+    fn set_capability(&self, cset: CapSet, value: &CapsHashSet) -> Result<()> {
         match cset {
             // caps::set cannot set capabilities in bounding set,
             // so we do it differently
@@ -149,10 +149,12 @@ impl Syscall for LinuxSyscall {
                         _ => caps::drop(None, CapSet::Bounding, *c)?,
                     }
                 }
-                Ok(())
             }
-            _ => caps::set(None, cset, value),
+            _ => {
+                caps::set(None, cset, value)?;
+            }
         }
+        Ok(())
     }
 
     #[cfg_attr(coverage, no_coverage)]

--- a/crates/libcontainer/src/syscall/linux.rs
+++ b/crates/libcontainer/src/syscall/linux.rs
@@ -1,4 +1,5 @@
 //! Implements Command trait for Linux systems
+#[cfg_attr(coverage, no_coverage)]
 use std::ffi::{CStr, OsStr};
 use std::os::unix::ffi::OsStrExt;
 use std::os::unix::fs::symlink;
@@ -28,7 +29,6 @@ use crate::capabilities;
 pub struct LinuxSyscall;
 
 impl LinuxSyscall {
-    #[cfg_attr(coverage, no_coverage)]
     unsafe fn from_raw_buf<'a, T>(p: *const c_char) -> T
     where
         T: From<&'a OsStr>,
@@ -36,7 +36,6 @@ impl LinuxSyscall {
         T::from(OsStr::from_bytes(CStr::from_ptr(p).to_bytes()))
     }
 
-    #[cfg_attr(coverage, no_coverage)]
     /// Reads data from the `c_passwd` and returns it as a `User`.
     unsafe fn passwd_to_user(passwd: libc::passwd) -> Arc<OsStr> {
         let name: Arc<OsStr> = Self::from_raw_buf(passwd.pw_name);
@@ -45,14 +44,12 @@ impl LinuxSyscall {
 }
 
 impl Syscall for LinuxSyscall {
-    #[cfg_attr(coverage, no_coverage)]
     /// To enable dynamic typing,
     /// see https://doc.rust-lang.org/std/any/index.html for more information
     fn as_any(&self) -> &dyn Any {
         self
     }
 
-    #[cfg_attr(coverage, no_coverage)]
     /// Function to set given path as root path inside process
     fn pivot_rootfs(&self, path: &Path) -> Result<()> {
         // open the path as directory and read only
@@ -88,14 +85,12 @@ impl Syscall for LinuxSyscall {
         Ok(())
     }
 
-    #[cfg_attr(coverage, no_coverage)]
     /// Set namespace for process
     fn set_ns(&self, rawfd: i32, nstype: CloneFlags) -> Result<()> {
         nix::sched::setns(rawfd, nstype)?;
         Ok(())
     }
 
-    #[cfg_attr(coverage, no_coverage)]
     /// set uid and gid for process
     fn set_id(&self, uid: Uid, gid: Gid) -> Result<()> {
         if let Err(e) = prctl::set_keep_capabilities(true) {
@@ -117,7 +112,6 @@ impl Syscall for LinuxSyscall {
         Ok(())
     }
 
-    #[cfg_attr(coverage, no_coverage)]
     /// Disassociate parts of execution context
     // see https://man7.org/linux/man-pages/man2/unshare.2.html for more information
     fn unshare(&self, flags: CloneFlags) -> Result<()> {
@@ -125,7 +119,6 @@ impl Syscall for LinuxSyscall {
         Ok(())
     }
 
-    #[cfg_attr(coverage, no_coverage)]
     /// Set capabilities for container process
     fn set_capability(&self, cset: CapSet, value: &CapsHashSet) -> Result<()> {
         match cset {
@@ -157,7 +150,6 @@ impl Syscall for LinuxSyscall {
         Ok(())
     }
 
-    #[cfg_attr(coverage, no_coverage)]
     /// Sets hostname for process
     fn set_hostname(&self, hostname: &str) -> Result<()> {
         if let Err(e) = sethostname(hostname) {
@@ -166,7 +158,6 @@ impl Syscall for LinuxSyscall {
         Ok(())
     }
 
-    #[cfg_attr(coverage, no_coverage)]
     /// Sets resource limit for process
     fn set_rlimit(&self, rlimit: &LinuxRlimit) -> Result<()> {
         let rlim = &libc::rlimit {
@@ -180,7 +171,6 @@ impl Syscall for LinuxSyscall {
         Ok(())
     }
 
-    #[cfg_attr(coverage, no_coverage)]
     // taken from https://crates.io/crates/users
     fn get_pwuid(&self, uid: uid_t) -> Option<Arc<OsStr>> {
         let mut passwd = unsafe { mem::zeroed::<libc::passwd>() };
@@ -215,14 +205,12 @@ impl Syscall for LinuxSyscall {
         Some(user)
     }
 
-    #[cfg_attr(coverage, no_coverage)]
     fn chroot(&self, path: &Path) -> Result<()> {
         unistd::chroot(path)?;
 
         Ok(())
     }
 
-    #[cfg_attr(coverage, no_coverage)]
     fn mount(
         &self,
         source: Option<&Path>,
@@ -237,7 +225,6 @@ impl Syscall for LinuxSyscall {
         }
     }
 
-    #[cfg_attr(coverage, no_coverage)]
     fn symlink(&self, original: &Path, link: &Path) -> Result<()> {
         match symlink(original, link) {
             Ok(_) => Ok(()),
@@ -245,7 +232,6 @@ impl Syscall for LinuxSyscall {
         }
     }
 
-    #[cfg_attr(coverage, no_coverage)]
     fn mknod(&self, path: &Path, kind: SFlag, perm: Mode, dev: u64) -> Result<()> {
         match mknod(path, kind, perm, dev) {
             Ok(_) => Ok(()),
@@ -253,7 +239,6 @@ impl Syscall for LinuxSyscall {
         }
     }
 
-    #[cfg_attr(coverage, no_coverage)]
     fn chown(&self, path: &Path, owner: Option<Uid>, group: Option<Gid>) -> Result<()> {
         match chown(path, owner, group) {
             Ok(_) => Ok(()),
@@ -261,7 +246,6 @@ impl Syscall for LinuxSyscall {
         }
     }
 
-    #[cfg_attr(coverage, no_coverage)]
     fn set_groups(&self, groups: &[Gid]) -> Result<()> {
         match setgroups(groups) {
             Ok(_) => Ok(()),

--- a/crates/libcontainer/src/syscall/linux.rs
+++ b/crates/libcontainer/src/syscall/linux.rs
@@ -28,6 +28,7 @@ use crate::capabilities;
 pub struct LinuxSyscall;
 
 impl LinuxSyscall {
+    #[cfg_attr(coverage, no_coverage)]
     unsafe fn from_raw_buf<'a, T>(p: *const c_char) -> T
     where
         T: From<&'a OsStr>,
@@ -35,6 +36,7 @@ impl LinuxSyscall {
         T::from(OsStr::from_bytes(CStr::from_ptr(p).to_bytes()))
     }
 
+    #[cfg_attr(coverage, no_coverage)]
     /// Reads data from the `c_passwd` and returns it as a `User`.
     unsafe fn passwd_to_user(passwd: libc::passwd) -> Arc<OsStr> {
         let name: Arc<OsStr> = Self::from_raw_buf(passwd.pw_name);
@@ -43,12 +45,14 @@ impl LinuxSyscall {
 }
 
 impl Syscall for LinuxSyscall {
+    #[cfg_attr(coverage, no_coverage)]
     /// To enable dynamic typing,
     /// see https://doc.rust-lang.org/std/any/index.html for more information
     fn as_any(&self) -> &dyn Any {
         self
     }
 
+    #[cfg_attr(coverage, no_coverage)]
     /// Function to set given path as root path inside process
     fn pivot_rootfs(&self, path: &Path) -> Result<()> {
         // open the path as directory and read only
@@ -84,12 +88,14 @@ impl Syscall for LinuxSyscall {
         Ok(())
     }
 
+    #[cfg_attr(coverage, no_coverage)]
     /// Set namespace for process
     fn set_ns(&self, rawfd: i32, nstype: CloneFlags) -> Result<()> {
         nix::sched::setns(rawfd, nstype)?;
         Ok(())
     }
 
+    #[cfg_attr(coverage, no_coverage)]
     /// set uid and gid for process
     fn set_id(&self, uid: Uid, gid: Gid) -> Result<()> {
         if let Err(e) = prctl::set_keep_capabilities(true) {
@@ -111,6 +117,7 @@ impl Syscall for LinuxSyscall {
         Ok(())
     }
 
+    #[cfg_attr(coverage, no_coverage)]
     /// Disassociate parts of execution context
     // see https://man7.org/linux/man-pages/man2/unshare.2.html for more information
     fn unshare(&self, flags: CloneFlags) -> Result<()> {
@@ -118,6 +125,7 @@ impl Syscall for LinuxSyscall {
         Ok(())
     }
 
+    #[cfg_attr(coverage, no_coverage)]
     /// Set capabilities for container process
     fn set_capability(&self, cset: CapSet, value: &CapsHashSet) -> Result<(), CapsError> {
         match cset {
@@ -147,6 +155,7 @@ impl Syscall for LinuxSyscall {
         }
     }
 
+    #[cfg_attr(coverage, no_coverage)]
     /// Sets hostname for process
     fn set_hostname(&self, hostname: &str) -> Result<()> {
         if let Err(e) = sethostname(hostname) {
@@ -155,6 +164,7 @@ impl Syscall for LinuxSyscall {
         Ok(())
     }
 
+    #[cfg_attr(coverage, no_coverage)]
     /// Sets resource limit for process
     fn set_rlimit(&self, rlimit: &LinuxRlimit) -> Result<()> {
         let rlim = &libc::rlimit {
@@ -168,6 +178,7 @@ impl Syscall for LinuxSyscall {
         Ok(())
     }
 
+    #[cfg_attr(coverage, no_coverage)]
     // taken from https://crates.io/crates/users
     fn get_pwuid(&self, uid: uid_t) -> Option<Arc<OsStr>> {
         let mut passwd = unsafe { mem::zeroed::<libc::passwd>() };
@@ -202,12 +213,14 @@ impl Syscall for LinuxSyscall {
         Some(user)
     }
 
+    #[cfg_attr(coverage, no_coverage)]
     fn chroot(&self, path: &Path) -> Result<()> {
         unistd::chroot(path)?;
 
         Ok(())
     }
 
+    #[cfg_attr(coverage, no_coverage)]
     fn mount(
         &self,
         source: Option<&Path>,
@@ -222,6 +235,7 @@ impl Syscall for LinuxSyscall {
         }
     }
 
+    #[cfg_attr(coverage, no_coverage)]
     fn symlink(&self, original: &Path, link: &Path) -> Result<()> {
         match symlink(original, link) {
             Ok(_) => Ok(()),
@@ -229,6 +243,7 @@ impl Syscall for LinuxSyscall {
         }
     }
 
+    #[cfg_attr(coverage, no_coverage)]
     fn mknod(&self, path: &Path, kind: SFlag, perm: Mode, dev: u64) -> Result<()> {
         match mknod(path, kind, perm, dev) {
             Ok(_) => Ok(()),
@@ -236,6 +251,7 @@ impl Syscall for LinuxSyscall {
         }
     }
 
+    #[cfg_attr(coverage, no_coverage)]
     fn chown(&self, path: &Path, owner: Option<Uid>, group: Option<Gid>) -> Result<()> {
         match chown(path, owner, group) {
             Ok(_) => Ok(()),
@@ -243,6 +259,7 @@ impl Syscall for LinuxSyscall {
         }
     }
 
+    #[cfg_attr(coverage, no_coverage)]
     fn set_groups(&self, groups: &[Gid]) -> Result<()> {
         match setgroups(groups) {
             Ok(_) => Ok(()),

--- a/crates/libcontainer/src/syscall/mod.rs
+++ b/crates/libcontainer/src/syscall/mod.rs
@@ -2,6 +2,7 @@
 //! This provides a uniform interface for rest of Youki
 //! to call syscalls required for container management
 
+#![cfg_attr(coverage, feature(no_coverage))]
 pub mod linux;
 #[allow(clippy::module_inception)]
 pub mod syscall;

--- a/crates/libcontainer/src/syscall/mod.rs
+++ b/crates/libcontainer/src/syscall/mod.rs
@@ -2,7 +2,6 @@
 //! This provides a uniform interface for rest of Youki
 //! to call syscalls required for container management
 
-#![cfg_attr(coverage, feature(no_coverage))]
 pub mod linux;
 #[allow(clippy::module_inception)]
 pub mod syscall;

--- a/crates/libcontainer/src/syscall/syscall.rs
+++ b/crates/libcontainer/src/syscall/syscall.rs
@@ -4,7 +4,7 @@
 use std::{any::Any, ffi::OsStr, path::Path, sync::Arc};
 
 use anyhow::Result;
-use caps::{errors::CapsError, CapSet, CapsHashSet};
+use caps::{CapSet, CapsHashSet};
 use nix::{
     mount::MsFlags,
     sched::CloneFlags,
@@ -25,7 +25,7 @@ pub trait Syscall {
     fn set_ns(&self, rawfd: i32, nstype: CloneFlags) -> Result<()>;
     fn set_id(&self, uid: Uid, gid: Gid) -> Result<()>;
     fn unshare(&self, flags: CloneFlags) -> Result<()>;
-    fn set_capability(&self, cset: CapSet, value: &CapsHashSet) -> Result<(), CapsError>;
+    fn set_capability(&self, cset: CapSet, value: &CapsHashSet) -> Result<()>;
     fn set_hostname(&self, hostname: &str) -> Result<()>;
     fn set_rlimit(&self, rlimit: &LinuxRlimit) -> Result<()>;
     fn get_pwuid(&self, uid: u32) -> Option<Arc<OsStr>>;

--- a/crates/libcontainer/src/syscall/test.rs
+++ b/crates/libcontainer/src/syscall/test.rs
@@ -141,7 +141,7 @@ pub struct TestHelperSyscall {
 
 impl Default for TestHelperSyscall {
     fn default() -> Self {
-        let ts = TestHelperSyscall {
+        TestHelperSyscall {
             mocks: MockCalls::default(),
             set_ns_args: RefCell::new(vec![]),
             unshare_args: RefCell::new(vec![]),
@@ -151,9 +151,7 @@ impl Default for TestHelperSyscall {
             chown_args: RefCell::new(vec![]),
             hostname_args: RefCell::new(vec![]),
             groups_args: RefCell::new(vec![]),
-        };
-
-        ts
+        }
     }
 }
 


### PR DESCRIPTION
#279 
part of it.

- refactoring testing syscall
- taking off syscall Linux coverage rate because it cannot be covered