### PR TITLE
Implement json log format

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1400,6 +1400,7 @@ dependencies = [
  "anyhow",
  "chrono",
  "clap",
+ "env_logger 0.9.0",
  "libcgroups",
  "libcontainer",
  "log",

--- a/crates/youki/Cargo.toml
+++ b/crates/youki/Cargo.toml
@@ -25,6 +25,7 @@ procfs = "0.11.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tabwriter = "1"
+env_logger = "0.9.0"
 
 [dev-dependencies]
 serial_test = "0.5.1"

--- a/crates/youki/src/logger.rs
+++ b/crates/youki/src/logger.rs
@@ -1,28 +1,17 @@
 //! Default Youki Logger
 
-use std::env;
-use std::io::{stderr, Write};
+use anyhow::{bail, Context, Result};
+use std::fs::OpenOptions;
+use std::io::Write;
 use std::path::PathBuf;
-use std::{
-    fs::{File, OpenOptions},
-    str::FromStr,
-};
-
-use anyhow::{bail, Result};
-use log::{LevelFilter, Log, Metadata, Record};
-use once_cell::sync::OnceCell;
-
-/// Public global variables to access logger and logfile
-pub static YOUKI_LOGGER: OnceCell<YoukiLogger> = OnceCell::new();
-pub static LOG_FILE: OnceCell<Option<File>> = OnceCell::new();
 
 /// If in debug mode, default level is debug to get maximum logging
 #[cfg(debug_assertions)]
-const DEFAULT_LOG_LEVEL: LevelFilter = LevelFilter::Debug;
+const DEFAULT_LOG_LEVEL: &str = "debug";
 
 /// If not in debug mode, default level is warn to get important logs
 #[cfg(not(debug_assertions))]
-const DEFAULT_LOG_LEVEL: LevelFilter = LevelFilter::Warn;
+const DEFAULT_LOG_LEVEL: &str = "warn";
 
 const LOG_FORMAT_TEXT: &str = "text";
 const LOG_FORMAT_JSON: &str = "json";
@@ -31,98 +20,63 @@ const LOG_FORMAT_JSON: &str = "json";
 /// Multiple parts might call this at once, but the actual initialization
 /// is done only once due to use of OnceCell
 pub fn init(log_format: Option<String>, log_file: Option<PathBuf>) -> Result<()> {
-    // set the log level if specified in env variable or set to default
-    let level_filter = if let Ok(log_level_str) = env::var("YOUKI_LOG_LEVEL") {
-        LevelFilter::from_str(&log_level_str).unwrap_or(DEFAULT_LOG_LEVEL)
-    } else {
-        DEFAULT_LOG_LEVEL
-    };
-    let logger = match log_format.as_deref() {
-        None | Some(LOG_FORMAT_TEXT) => YoukiLogger::new(level_filter.to_level()),
-        Some(LOG_FORMAT_JSON) => YoukiLogger::new(level_filter.to_level()),
+    let formatter = match log_format.as_deref() {
+        None | Some(LOG_FORMAT_TEXT) => text_write,
+        Some(LOG_FORMAT_JSON) => json_write,
         Some(unknown) => bail!("unknown log format: {}", unknown),
     };
-
-    // If file exists, ignore, else create and open the file
-    let _log_file = LOG_FILE.get_or_init(|| -> Option<File> {
-        // Create a new logger, or get existing if already created
-        log::set_logger(YOUKI_LOGGER.get_or_init(|| logger))
-            .map(|()| log::set_max_level(level_filter))
-            .expect("set logger failed");
-
-        // Create and open log file
-        log_file.as_ref().map(|log_file_path| {
-            OpenOptions::new()
-                .create(true)
-                .write(true)
-                .truncate(false)
-                .open(log_file_path)
-                .expect("failed opening log file")
-        })
-    });
+    let target = if let Some(log_file) = log_file {
+        let file = OpenOptions::new()
+            .create(true)
+            .write(true)
+            .truncate(false)
+            .open(log_file)
+            .context("failed opening log file")?;
+        env_logger::Target::Pipe(Box::new(file))
+    } else {
+        env_logger::Target::Stderr
+    };
+    env_logger::Builder::from_env(
+        env_logger::Env::default().filter_or("YOUKI_LOG_LEVEL", DEFAULT_LOG_LEVEL),
+    )
+    .format(formatter)
+    .target(target)
+    .init();
 
     Ok(())
 }
 
-/// Youki's custom Logger
-pub struct YoukiLogger {
-    /// Indicates level up to which logs are to be printed
-    level: Option<log::Level>,
+fn json_write<F: 'static>(f: &mut F, record: &log::Record) -> std::io::Result<()>
+where
+    F: Write,
+{
+    write!(f, "{{")?;
+    write!(f, "\"level\":\"{}\",", record.level())?;
+    write!(f, "\"time\":\"{}\"", chrono::Local::now().to_rfc3339(),)?;
+    write!(f, ",\"msg\":")?;
+    // Use serde_json here so we don't have to worry about escaping special characters in the string.
+    serde_json::to_writer(f.by_ref(), &record.args().to_string())?;
+    writeln!(f, "}}")?;
+
+    Ok(())
 }
 
-impl YoukiLogger {
-    /// Create new logger
-    pub fn new(level: Option<log::Level>) -> Self {
-        Self { level }
-    }
-}
-
-/// Implements Log interface given by log crate, so we can use its functionality
-impl Log for YoukiLogger {
-    /// Check if level of given log is enabled or not
-    fn enabled(&self, metadata: &Metadata) -> bool {
-        if let Some(level) = self.level {
-            metadata.level() <= level
-        } else {
-            false
+fn text_write<F: 'static>(f: &mut F, record: &log::Record) -> std::io::Result<()>
+where
+    F: Write,
+{
+    match (record.file(), record.line()) {
+        (Some(file), Some(line)) => {
+            write!(f, "[{} {}:{}]", record.level(), file, line)?;
         }
-    }
+        (_, _) => write!(f, "[{}]", record.level(),)?,
+    };
+    write!(
+        f,
+        " {} {}\r\n",
+        chrono::Local::now().to_rfc3339(),
+        record.args()
+    )?;
 
-    /// Function to carry out logging
-    fn log(&self, record: &Record) {
-        if self.enabled(record.metadata()) {
-            let log_msg = match (record.file(), record.line()) {
-                (Some(file), Some(line)) => format!(
-                    "[{} {}:{}] {} {}\r",
-                    record.level(),
-                    file,
-                    line,
-                    chrono::Local::now().to_rfc3339(),
-                    record.args()
-                ),
-                (_, _) => format!(
-                    "[{}] {} {}\r",
-                    record.level(),
-                    chrono::Local::now().to_rfc3339(),
-                    record.args()
-                ),
-            };
-
-            // if log file is set, write to it, else write to stderr
-            if let Some(mut log_file) = LOG_FILE.get().unwrap().as_ref() {
-                let _ = writeln!(log_file, "{}", log_msg);
-            } else {
-                let _ = writeln!(stderr(), "{}", log_msg);
-            }
-        }
-    }
-
-    /// Flush logs to file
-    fn flush(&self) {
-        if let Some(mut log_file) = LOG_FILE.get().unwrap().as_ref() {
-            log_file.flush().expect("Failed to flush");
-        } else {
-            stderr().flush().expect("Failed to flush");
-        }
-    }
+    Ok(())
 }

--- a/crates/youki/src/main.rs
+++ b/crates/youki/src/main.rs
@@ -100,11 +100,11 @@ fn main() -> Result<()> {
     //
     // Ref: https://github.com/opencontainers/runc/commit/0a8e4117e7f715d5fbeef398405813ce8e88558b
     // Ref: https://github.com/lxc/lxc/commit/6400238d08cdf1ca20d49bafb85f4e224348bf9d
-    pentacle::ensure_sealed().context("Failed to seal /proc/self/exe")?;
+    pentacle::ensure_sealed().context("failed to seal /proc/self/exe")?;
 
     let opts = Opts::parse();
 
-    if let Err(e) = crate::logger::init(opts.log) {
+    if let Err(e) = crate::logger::init(opts.log_format, opts.log) {
         eprintln!("log init failed: {:?}", e);
     }
 


### PR DESCRIPTION
I am not sure how old the existing logger implementation is, but I decided to use env_logger to get rid a lot of the boilerplate code. Let me know if having our own logger is preferred, so it is OK just to `env_logger`.

Json logger field name are taken from golang logrus json formatter.

Fix #423