### PR TITLE
Remove systemd crate from dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,12 +53,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
-name = "build-env"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1522ac6ee801a11bf9ef3f80403f4ede6eb41291fac3dde3de09989679305f25"
-
-[[package]]
 name = "byteorder"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -217,16 +211,6 @@ checksum = "d82cfc11ce7f2c3faef78d8a684447b40d503d9681acebed6cb728d45940c4db"
 dependencies = [
  "cfg-if",
  "lazy_static",
-]
-
-[[package]]
-name = "cstr-argument"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6bd9c8e659a473bce955ae5c35b116af38af11a7acb0b480e01f3ed348aeb40"
-dependencies = [
- "cfg-if",
- "memchr",
 ]
 
 [[package]]
@@ -394,33 +378,6 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
-name = "foreign-types"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
-dependencies = [
- "foreign-types-macros",
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-macros"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63f713f8b2aa9e24fec85b0e290c56caee12e3b6ae0aeeda238a75b28251afd6"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7684cf33bb7f28497939e8c7cf17e3e4e3b8d9a0080ffa4f8ae2f515442ee855"
 
 [[package]]
 name = "futures"
@@ -670,7 +627,6 @@ dependencies = [
  "rbpf",
  "serde",
  "serde_json",
- "systemd",
 ]
 
 [[package]]
@@ -698,7 +654,6 @@ dependencies = [
  "serde",
  "serde_json",
  "serial_test",
- "systemd",
 ]
 
 [[package]]
@@ -714,17 +669,6 @@ dependencies = [
 name = "libseccomp"
 version = "0.1.0"
 dependencies = [
- "libc",
- "pkg-config",
-]
-
-[[package]]
-name = "libsystemd-sys"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c68c9b25d61a54754b491e1cb848e644ff90b6c11f6f11f9d2c170b7d2cd83b3"
-dependencies = [
- "build-env",
  "libc",
  "pkg-config",
 ]
@@ -1201,21 +1145,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "systemd"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe03808323f01aefb68591de263b994ffeb671af1fe040858dc820ed7b681996"
-dependencies = [
- "cstr-argument",
- "foreign-types",
- "libc",
- "libsystemd-sys",
- "log",
- "memchr",
- "utf8-cstr",
-]
-
-[[package]]
 name = "tabwriter"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1317,12 +1246,6 @@ name = "unicode-xid"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
-
-[[package]]
-name = "utf8-cstr"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55bcbb425141152b10d5693095950b51c3745d019363fc2929ffd8f61449b628"
 
 [[package]]
 name = "uuid"

--- a/crates/libcgroups/Cargo.toml
+++ b/crates/libcgroups/Cargo.toml
@@ -5,9 +5,7 @@ edition = "2018"
 autoexamples = false
 
 [features]
-default = ["systemd_cgroups"]
-systemd_cgroups = ["systemd"]
-cgroupsv2_devices = ["rbpf", "libbpf-sys", "errno", "libc"]
+cgroupsv2_devices = ["rbpf", "libbpf-sys", "errno"]
 
 [dependencies]
 nix = "0.23.0"
@@ -15,13 +13,12 @@ procfs = "0.11.0"
 log = "0.4"
 anyhow = "1.0"
 oci-spec = { git = "https://github.com/containers/oci-spec-rs",  rev = "d6fb1e91742313cd0d0085937e2d6df5d4669720" }
-systemd = { version = "0.9", default-features = false, optional = true }
 dbus = "0.9.5"
 serde = { version = "1.0", features = ["derive"] }
 rbpf = {version = "0.1.0", optional = true }
 libbpf-sys = { version = "0.5.0-2", optional = true }
 errno = { version = "0.2.8", optional = true }
-libc = { version = "0.2.106", optional = true }
+libc = "0.2.106"
 
 [dev-dependencies]
 oci-spec = { git = "https://github.com/containers/oci-spec-rs",  rev = "d6fb1e91742313cd0d0085937e2d6df5d4669720", features = ["proptests"] }

--- a/crates/libcgroups/src/common.rs
+++ b/crates/libcgroups/src/common.rs
@@ -1,4 +1,5 @@
 use std::{
+    ffi::CStr,
     fmt::{Debug, Display},
     fs::{self, File},
     io::{BufRead, BufReader, Write},
@@ -15,11 +16,16 @@ use oci_spec::runtime::{
     LinuxDevice, LinuxDeviceBuilder, LinuxDeviceCgroup, LinuxDeviceCgroupBuilder, LinuxDeviceType,
     LinuxResources,
 };
-#[cfg(feature = "systemd_cgroups")]
-use systemd::daemon::booted;
-#[cfg(not(feature = "systemd_cgroups"))]
+
 fn booted() -> Result<bool> {
-    bail!("This build does not include the systemd cgroups feature")
+    Ok(unsafe {
+        libc::faccessat(
+            libc::AT_FDCWD,
+            CStr::from_bytes_with_nul_unchecked(b"/run/systemd/system/\0").as_ptr(),
+            0,
+            libc::AT_SYMLINK_NOFOLLOW,
+        ) >= 0
+    })
 }
 
 use super::v1;

--- a/crates/libcontainer/Cargo.toml
+++ b/crates/libcontainer/Cargo.toml
@@ -5,10 +5,6 @@ authors = ["youki team"]
 edition = "2018"
 description = "Library for container creation"
 
-[features]
-default = ["systemd_cgroups"]
-systemd_cgroups = ["systemd"]
-
 [dependencies]
 anyhow = "1.0"
 caps = "0.5.3"
@@ -30,7 +26,6 @@ libcgroups = { version = "0.1.0", path = "../libcgroups" }
 libseccomp = { version = "0.1.0", path = "../libseccomp" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-systemd = { version = "0.9", default-features = false, optional = true }
 
 [dev-dependencies]
 oci-spec = { git = "https://github.com/containers/oci-spec-rs",  rev = "d6fb1e91742313cd0d0085937e2d6df5d4669720", features = ["proptests"] }


### PR DESCRIPTION
reimplement booted as implement in native systemd

[sd_booted](https://github.com/systemd/systemd/blob/main/src/libsystemd/sd-daemon/sd-daemon.c#L626) and [laccess](https://github.com/systemd/systemd/blob/93a5fe3e6579bb6db66412bbb08e01b8d3846fa0/src/basic/fs-util.h#L49)