### PR TITLE
cgroups v1 memory integration test

### DIFF
--- a/crates/integration_test/src/main.rs
+++ b/crates/integration_test/src/main.rs
@@ -64,6 +64,7 @@ fn main() -> Result<()> {
     let ns_itype = get_ns_itype_tests();
     let cgroup_v1_pids = cgroups::pids::get_test_group();
     let cgroup_v1_cpus = cgroups::cpus::get_test_group();
+    let cgroup_v1_memory = cgroups::memory::get_test_group();
     let seccomp_notify = get_seccomp_notify_test();
 
     tm.add_test_group(&cl);
@@ -73,6 +74,7 @@ fn main() -> Result<()> {
     tm.add_test_group(&ns_itype);
     tm.add_test_group(&cgroup_v1_pids);
     tm.add_test_group(&cgroup_v1_cpus);
+    tm.add_test_group(&cgroup_v1_memory);
 
     tm.add_cleanup(Box::new(cgroups::cleanup));
     tm.add_test_group(&seccomp_notify);

--- a/crates/integration_test/src/tests/cgroups/memory.rs
+++ b/crates/integration_test/src/tests/cgroups/memory.rs
@@ -1,0 +1,81 @@
+use std::path::Path;
+
+use anyhow::{Context, Result};
+use oci_spec::runtime::{
+    LinuxBuilder, LinuxMemoryBuilder, LinuxResourcesBuilder, Spec, SpecBuilder,
+};
+use test_framework::{test_result, ConditionalTest, TestGroup, TestResult};
+
+use crate::utils::{test_outside_container, test_utils::check_container_created};
+
+const CGROUP_MEMORY_LIMIT: &str = "memory.limit_in_bytes";
+const CGROUP_MEMORY_SWAPPINESS: &str = "memory.swappiness";
+
+fn create_spec(cgroup_name: &str, limit: i64, swappiness: u64) -> Result<Spec> {
+    let spec = SpecBuilder::default()
+        .linux(
+            LinuxBuilder::default()
+                .cgroups_path(Path::new("/runtime-test").join(cgroup_name))
+                .resources(
+                    LinuxResourcesBuilder::default()
+                        .memory(
+                            LinuxMemoryBuilder::default()
+                                .limit(limit)
+                                .swappiness(swappiness)
+                                .build()
+                                .context("failed to build memory spec")?,
+                        )
+                        .build()
+                        .context("failed to build resource spec")?,
+                )
+                .build()
+                .context("failed to build linux spec")?,
+        )
+        .build()
+        .context("failed to build spec")?;
+
+    Ok(spec)
+}
+
+fn test_memory_cgroups() -> TestResult {
+    let cgroup_name = "test_memory_cgroups";
+
+    let cases = vec![
+        test_result!(create_spec(cgroup_name, 50593792, 10)),
+        test_result!(create_spec(cgroup_name, 50593792, 50)),
+        test_result!(create_spec(cgroup_name, 50593792, 100)),
+        test_result!(create_spec(cgroup_name, 151781376, 10)),
+        test_result!(create_spec(cgroup_name, 151781376, 50)),
+        test_result!(create_spec(cgroup_name, 151781376, 100)),
+    ];
+
+    for spec in cases.into_iter() {
+        let test_result = test_outside_container(spec, &|data| {
+            test_result!(check_container_created(&data));
+
+            TestResult::Passed
+        });
+        if let TestResult::Failed(_) = test_result {
+            return test_result;
+        }
+    }
+
+    TestResult::Passed
+}
+
+fn can_run() -> bool {
+    Path::new(CGROUP_MEMORY_LIMIT).exists() && Path::new(CGROUP_MEMORY_SWAPPINESS).exists()
+}
+
+pub fn get_test_group<'a>() -> TestGroup<'a> {
+    let mut test_group = TestGroup::new("cgroup_v1_memory");
+    let linux_cgroups_memory = ConditionalTest::new(
+        "test_linux_cgroups_memory",
+        Box::new(can_run),
+        Box::new(test_memory_cgroups),
+    );
+
+    test_group.add(vec![Box::new(linux_cgroups_memory)]);
+
+    test_group
+}

--- a/crates/integration_test/src/tests/cgroups/mod.rs
+++ b/crates/integration_test/src/tests/cgroups/mod.rs
@@ -5,6 +5,7 @@ use procfs::process::Process;
 use std::fs;
 
 pub mod cpus;
+pub mod memory;
 pub mod pids;
 
 pub fn cleanup() -> Result<()> {


### PR DESCRIPTION
Essentially exactly like runtime-tools. This should however address this unresolved issue with runtime-tools: https://github.com/opencontainers/runtime-tools/issues/721

On systems with swap disabled in the kernel this test will likely be skipped entirely. Thing might not be the ideal behavior in that case, but I didn't want to change behavior from runtime-tools too much.