### PR TITLE
Create a subdirectory under XDG_RUNTIME_DIR

### DIFF
--- a/crates/youki/src/main.rs
+++ b/crates/youki/src/main.rs
@@ -5,7 +5,7 @@ mod commands;
 mod logger;
 
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use anyhow::bail;
 use anyhow::Context;
@@ -145,15 +145,18 @@ fn determine_root_path(root_path: Option<PathBuf>) -> Result<PathBuf> {
     }
 
     // see https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html
+    let uid = getuid().as_raw();
     if let Ok(path) = std::env::var("XDG_RUNTIME_DIR") {
-        return Ok(PathBuf::from(path));
+        let path = Path::new(&path).join("youki");
+        if create_dir_all_with_mode(&path, uid, Mode::S_IRWXU).is_ok() {
+            return Ok(path);
+        }
     }
 
     // XDG_RUNTIME_DIR is not set, try the usual location
-    let uid = getuid().as_raw();
-    let runtime_dir = PathBuf::from(format!("/run/user/{}", uid));
-    if create_dir_all_with_mode(&runtime_dir, uid, Mode::S_IRWXU).is_ok() {
-        return Ok(runtime_dir);
+    let path = PathBuf::from(format!("/run/user/{}/youki", uid));
+    if create_dir_all_with_mode(&path, uid, Mode::S_IRWXU).is_ok() {
+        return Ok(path);
     }
 
     if let Ok(path) = std::env::var("HOME") {


### PR DESCRIPTION
When using a root state directory from $XDG_RUNTIME_DIR, or from it's
default value of /run/user/<uid>, we don't add a tag specific to youki
to the path.  That means the directories for individual containers
will be placed directly in the general use runtime dir.

That's against normal conventions, and could mean that "youki list"
will see files or directories from other software as if they were
youki managed containers.  Therefore, add "youki" to the base runtime
path from XDG.

fixes #487

Signed-off-by: David Gibson <david@gibson.dropbear.id.au>