### PR TITLE
Use /tmp/youki-<uid> rather than /tmp/youki/<uid> in determine_root_path

### DIFF
--- a/crates/youki/src/main.rs
+++ b/crates/youki/src/main.rs
@@ -168,7 +168,7 @@ fn determine_root_path(root_path: Option<PathBuf>) -> Result<PathBuf> {
         }
     }
 
-    let tmp_dir = PathBuf::from(format!("/tmp/youki/{}", uid));
+    let tmp_dir = PathBuf::from(format!("/tmp/youki-{}", uid));
     if create_dir_all_with_mode(&tmp_dir, uid, Mode::S_IRWXU).is_ok() {
         return Ok(tmp_dir);
     }


### PR DESCRIPTION
determine_root_path goes through various options to find a state storage
location, the last of which is /tmp/youki/<uid>.

If a user (say, UID 1000) uses youki, and this final option is selected,
/tmp/youki will be created as well as /tmp/youki/1000.  Both will be
created owned by UID 1000 and with write permissions only for that user.

Them, if another user (say, UID 1001) attempts to use youki and the same
final option is selected, it will fail, because it cannot create
/tmp/youki/1001 under the /tmp/youki owned by UID 1000.

There's really no way to safely create a multi-user shared subdirectory in
/tmp, so instead we should create our per-user directory directly under
/tmp.  We do this by calling it /tmp/youki-<uid> instead.

fixes #496

Signed-off-by: David Gibson <david@gibson.dropbear.id.au>