### PR TITLE
Improvements to cgroup support

### DIFF
--- a/crates/libcgroups/Cargo.toml
+++ b/crates/libcgroups/Cargo.toml
@@ -5,6 +5,10 @@ edition = "2021"
 autoexamples = false
 
 [features]
+default = ["v1", "v2", "systemd"]
+v1 = []
+v2 = []
+systemd = ["v2", "dbus"]
 cgroupsv2_devices = ["rbpf", "libbpf-sys", "errno", "libc"]
 
 [dependencies]
@@ -13,7 +17,7 @@ procfs = "0.11.1"
 log = "0.4"
 anyhow = "1.0"
 oci-spec = { git = "https://github.com/containers/oci-spec-rs",  rev = "54c5e386f01ab37c9305cc4a83404eb157e42440" }
-dbus = "0.9.5"
+dbus = { version = "0.9.5", optional = true }
 fixedbitset = "0.4.0"
 serde = { version = "1.0", features = ["derive"] }
 rbpf = {version = "0.1.0", optional = true }

--- a/crates/libcgroups/src/common.rs
+++ b/crates/libcgroups/src/common.rs
@@ -16,8 +16,11 @@ use oci_spec::runtime::{
     LinuxResources,
 };
 
+#[cfg(feature = "systemd")]
 use super::systemd;
+#[cfg(feature = "v1")]
 use super::v1;
+#[cfg(feature = "v2")]
 use super::v2;
 
 use super::stats::Stats;
@@ -173,38 +176,70 @@ pub fn create_cgroup_manager<P: Into<PathBuf>>(
     container_name: &str,
 ) -> Result<Box<dyn CgroupManager>> {
     let cgroup_setup = get_cgroup_setup()?;
+    let cgroup_path = cgroup_path.into();
 
     match cgroup_setup {
         CgroupSetup::Legacy | CgroupSetup::Hybrid => {
-            log::info!("cgroup manager V1 will be used");
-            Ok(Box::new(v1::manager::Manager::new(cgroup_path.into())?))
-        }
+            return create_v1_cgroup_manager(cgroup_path);
+        },
         CgroupSetup::Unified => {
             if systemd_cgroup {
-                if !systemd::booted() {
-                    bail!("systemd cgroup flag passed, but systemd support for managing cgroups is not available");
-                }
-
-                let use_system = nix::unistd::geteuid().is_root();
-
-                log::info!(
-                    "systemd cgroup manager with system bus {} will be used",
-                    use_system
-                );
-                return Ok(Box::new(systemd::manager::Manager::new(
-                    DEFAULT_CGROUP_ROOT.into(),
-                    cgroup_path.into(),
-                    container_name.into(),
-                    use_system,
-                )?));
+               return create_systemd_cgroup_manager(cgroup_path, container_name);
             }
-            log::info!("cgroup manager V2 will be used");
-            Ok(Box::new(v2::manager::Manager::new(
-                DEFAULT_CGROUP_ROOT.into(),
-                cgroup_path.into(),
-            )?))
+
+            return create_v2_cgroup_manager(cgroup_path);
         }
     }
+}
+
+#[cfg(feature = "v1")]
+fn create_v1_cgroup_manager(cgroup_path: PathBuf) -> Result<Box<dyn CgroupManager>> {
+    log::info!("cgroup manager V1 will be used");
+    Ok(Box::new(v1::manager::Manager::new(cgroup_path)?))
+}
+
+#[cfg(not(feature = "v1"))]
+fn create_v1_cgroup_manager(_cgroup_path: PathBuf) -> Result<Box<dyn CgroupManager>> {
+    bail!("cgroup v1 feature is not activated");
+}
+
+#[cfg(feature = "v2")]
+fn create_v2_cgroup_manager(cgroup_path: PathBuf) -> Result<Box<dyn CgroupManager>> {
+    log::info!("cgroup manager V2 will be used");
+    Ok(Box::new(v2::manager::Manager::new(
+        DEFAULT_CGROUP_ROOT.into(),
+        cgroup_path.into(),
+    )?))
+}
+
+#[cfg(not(feature = "v2"))]
+fn create_v2_cgroup_manager(_cgroup_path: PathBuf) -> Result<Box<dyn CgroupManager>> {
+    bail!("cgroup v2 feature is not activated");
+}
+
+#[cfg(feature = "systemd")]
+fn create_systemd_cgroup_manager(cgroup_path: PathBuf, container_name: &str) -> Result<Box<dyn CgroupManager>> {
+    if !systemd::booted() {
+        bail!("systemd cgroup flag passed, but systemd support for managing cgroups is not available");
+    }
+
+    let use_system = nix::unistd::geteuid().is_root();
+
+    log::info!(
+        "systemd cgroup manager with system bus {} will be used",
+        use_system
+    );
+    return Ok(Box::new(systemd::manager::Manager::new(
+        DEFAULT_CGROUP_ROOT.into(),
+        cgroup_path.into(),
+        container_name.into(),
+        use_system,
+    )?));
+}
+
+#[cfg(not(feature = "systemd"))]
+fn create_systemd_cgroup_manager(_cgroup_path: PathBuf, _container_name: &str) -> Result<Box<dyn CgroupManager>> {
+    bail!("systemd cgroup feature is not activated");
 }
 
 pub fn get_all_pids(path: &Path) -> Result<Vec<Pid>> {

--- a/crates/libcgroups/src/lib.rs
+++ b/crates/libcgroups/src/lib.rs
@@ -8,7 +8,10 @@ mod test;
 
 pub mod common;
 pub mod stats;
+#[cfg(feature = "systemd")]
 pub mod systemd;
 pub mod test_manager;
+#[cfg(feature = "v1")]
 pub mod v1;
+#[cfg(feature = "v2")]
 pub mod v2;

--- a/crates/libcgroups/src/systemd/controller_type.rs
+++ b/crates/libcgroups/src/systemd/controller_type.rs
@@ -5,7 +5,7 @@ pub enum ControllerType {
     CpuSet,
     Io,
     Memory,
-    Tasks,
+    Pids,
 }
 
 impl Display for ControllerType {
@@ -15,7 +15,7 @@ impl Display for ControllerType {
             ControllerType::CpuSet => "cpuset",
             ControllerType::Io => "io",
             ControllerType::Memory => "memory",
-            ControllerType::Tasks => "tasks",
+            ControllerType::Pids => "pids",
         };
 
         write!(f, "{}", print)
@@ -29,7 +29,7 @@ impl AsRef<str> for ControllerType {
             ControllerType::CpuSet => "cpuset",
             ControllerType::Io => "io",
             ControllerType::Memory => "memory",
-            ControllerType::Tasks => "tasks",
+            ControllerType::Pids => "pids",
         }
     }
 }
@@ -39,5 +39,5 @@ pub const CONTROLLER_TYPES: &[ControllerType] = &[
     ControllerType::CpuSet,
     ControllerType::Io,
     ControllerType::Memory,
-    ControllerType::Tasks,
+    ControllerType::Pids,
 ];

--- a/crates/libcgroups/src/systemd/manager.rs
+++ b/crates/libcgroups/src/systemd/manager.rs
@@ -1,10 +1,7 @@
-#![allow(dead_code)]
-#![allow(unused_variables)]
 use std::{
     collections::HashMap,
     fmt::{Debug, Display},
     fs::{self},
-    os::unix::fs::PermissionsExt,
     path::Component::RootDir,
 };
 
@@ -28,7 +25,6 @@ use crate::{
 };
 use crate::{stats::Stats, v2::manager::Manager as FsManager};
 
-const CGROUP_PROCS: &str = "cgroup.procs";
 const CGROUP_CONTROLLERS: &str = "cgroup.controllers";
 const CGROUP_SUBTREE_CONTROL: &str = "cgroup.subtree_control";
 
@@ -408,22 +404,22 @@ mod tests {
 
         fn start_transient_unit(
             &self,
-            container_name: &str,
-            pid: u32,
-            parent: &str,
-            unit_name: &str,
+            _container_name: &str,
+            _pid: u32,
+            _parent: &str,
+            _unit_name: &str,
         ) -> Result<()> {
             Ok(())
         }
 
-        fn stop_transient_unit(&self, unit_name: &str) -> Result<()> {
+        fn stop_transient_unit(&self, _unit_name: &str) -> Result<()> {
             Ok(())
         }
 
         fn set_unit_properties(
             &self,
-            unit_name: &str,
-            properties: &HashMap<&str, Box<dyn RefArg>>,
+            _unit_name: &str,
+            _properties: &HashMap<&str, Box<dyn RefArg>>,
         ) -> Result<()> {
             Ok(())
         }

--- a/crates/libcontainer/src/config.rs
+++ b/crates/libcontainer/src/config.rs
@@ -42,8 +42,10 @@ impl<'a> YoukiConfig {
     }
 
     pub fn load<P: AsRef<Path>>(path: P) -> Result<Self> {
-        let file = fs::File::open(path.as_ref().join(YOUKI_CONFIG_NAME))?;
-        Ok(serde_json::from_reader(&file)?)
+        let path = path.as_ref();
+        let file = fs::File::open(path.join(YOUKI_CONFIG_NAME))?;
+        Ok(serde_json::from_reader(&file)
+            .with_context(|| format!("failed to load config from {:?}", path))?)
     }
 }
 

--- a/crates/libcontainer/src/config.rs
+++ b/crates/libcontainer/src/config.rs
@@ -44,8 +44,9 @@ impl<'a> YoukiConfig {
     pub fn load<P: AsRef<Path>>(path: P) -> Result<Self> {
         let path = path.as_ref();
         let file = fs::File::open(path.join(YOUKI_CONFIG_NAME))?;
-        Ok(serde_json::from_reader(&file)
-            .with_context(|| format!("failed to load config from {:?}", path))?)
+        let config = serde_json::from_reader(&file)
+            .with_context(|| format!("failed to load config from {:?}", path))?;
+        Ok(config)
     }
 }
 

--- a/crates/libcontainer/src/container/container.rs
+++ b/crates/libcontainer/src/container/container.rs
@@ -8,9 +8,9 @@ use chrono::DateTime;
 use nix::unistd::Pid;
 
 use chrono::Utc;
-use oci_spec::runtime::Spec;
 use procfs::process::Process;
 
+use crate::config::YoukiConfig;
 use crate::syscall::syscall::create_syscall;
 
 use crate::container::{ContainerStatus, State};
@@ -192,8 +192,8 @@ impl Container {
         self.state.save(&self.root)
     }
 
-    pub fn spec(&self) -> Result<Spec> {
-        let spec = Spec::load(self.root.join("config.json"))?;
+    pub fn spec(&self) -> Result<YoukiConfig> {
+        let spec = YoukiConfig::load(&self.root)?;
         Ok(spec)
     }
 }

--- a/crates/libcontainer/src/container/container.rs
+++ b/crates/libcontainer/src/container/container.rs
@@ -202,6 +202,7 @@ impl Container {
 mod tests {
     use super::*;
     use crate::utils::create_temp_dir;
+    use anyhow::Context;
     use serial_test::serial;
 
     #[test]
@@ -300,13 +301,14 @@ mod tests {
         let tmp_dir = create_temp_dir("test_get_spec")?;
         use oci_spec::runtime::Spec;
         let spec = Spec::default();
-        spec.save(tmp_dir.path().join("config.json"))?;
+        let config = YoukiConfig::from_spec(&spec, "123").context("convert spec to config")?;
+        config.save(tmp_dir.path()).context("save config")?;
 
         let container = Container {
             root: tmp_dir.path().to_path_buf(),
             ..Default::default()
         };
-        container.spec()?;
+        container.spec().context("get config")?;
 
         Ok(())
     }

--- a/crates/libcontainer/src/container/container_events.rs
+++ b/crates/libcontainer/src/container/container_events.rs
@@ -27,19 +27,16 @@ impl Container {
         if !self.state.status.eq(&ContainerStatus::Running) {
             bail!("{} is not in running state", self.id());
         }
-        log::debug!("Mark0");
 
         let cgroups_path = self.spec()?.cgroup_path;
         let use_systemd = self
             .systemd()
             .context("could not determine cgroup manager")?;
-        log::debug!("Mark1");
 
         let cgroup_manager =
             libcgroups::common::create_cgroup_manager(cgroups_path, use_systemd, self.id())?;
         match stats {
             true => {
-                log::debug!("Mark2");
                 let stats = cgroup_manager.stats()?;
                 println!("{}", serde_json::to_string_pretty(&stats)?);
             }

--- a/crates/libcontainer/src/container/container_events.rs
+++ b/crates/libcontainer/src/container/container_events.rs
@@ -1,7 +1,5 @@
 use std::{thread, time::Duration};
 
-use crate::utils;
-
 use super::{Container, ContainerStatus};
 use anyhow::{bail, Context, Result};
 
@@ -29,23 +27,19 @@ impl Container {
         if !self.state.status.eq(&ContainerStatus::Running) {
             bail!("{} is not in running state", self.id());
         }
+        log::debug!("Mark0");
 
-        let cgroups_path = utils::get_cgroup_path(
-            self.spec()?
-                .linux()
-                .as_ref()
-                .context("no linux in spec")?
-                .cgroups_path(),
-            self.id(),
-        );
+        let cgroups_path = self.spec()?.cgroup_path;
         let use_systemd = self
             .systemd()
-            .context("Could not determine cgroup manager")?;
+            .context("could not determine cgroup manager")?;
+        log::debug!("Mark1");
 
         let cgroup_manager =
             libcgroups::common::create_cgroup_manager(cgroups_path, use_systemd, self.id())?;
         match stats {
             true => {
+                log::debug!("Mark2");
                 let stats = cgroup_manager.stats()?;
                 println!("{}", serde_json::to_string_pretty(&stats)?);
             }

--- a/crates/libcontainer/src/container/container_pause.rs
+++ b/crates/libcontainer/src/container/container_pause.rs
@@ -1,5 +1,3 @@
-use crate::utils;
-
 use super::{Container, ContainerStatus};
 use anyhow::{bail, Context, Result};
 use libcgroups::common::FreezerState;
@@ -34,15 +32,7 @@ impl Container {
             );
         }
 
-        let spec = self.spec()?;
-        let cgroups_path = utils::get_cgroup_path(
-            spec.linux()
-                .as_ref()
-                .context("no linux in spec")?
-                .cgroups_path(),
-            self.id(),
-        );
-
+        let cgroups_path = self.spec()?.cgroup_path;
         let use_systemd = self
             .systemd()
             .context("container state does not contain cgroup manager")?;

--- a/crates/libcontainer/src/container/container_resume.rs
+++ b/crates/libcontainer/src/container/container_resume.rs
@@ -1,5 +1,3 @@
-use crate::utils;
-
 use super::{Container, ContainerStatus};
 
 use anyhow::{bail, Context, Result};
@@ -36,16 +34,7 @@ impl Container {
             );
         }
 
-        let spec = self.spec()?;
-        let cgroups_path = utils::get_cgroup_path(
-            spec.linux()
-                .as_ref()
-                .context("no linux in spec")?
-                .cgroups_path(),
-            self.id(),
-        );
-
-        // create cgroup manager structure from the config at the path
+        let cgroups_path = self.spec()?.cgroup_path;
         let use_systemd = self
             .systemd()
             .context("container state does not contain cgroup manager")?;

--- a/crates/youki/src/commands/mod.rs
+++ b/crates/youki/src/commands/mod.rs
@@ -25,7 +25,7 @@ fn load_container<P: AsRef<Path>>(root_path: P, container_id: &str) -> Result<Co
     // the state of the container is stored in a directory named after the container id
     let container_root = root_path.join(container_id);
     if !container_root.exists() {
-        bail!("{} does not exist.", container_id)
+        bail!("container {} does not exist.", container_id)
     }
 
     Container::load(container_root)


### PR DESCRIPTION
This contains multiple smaller improvements that did not really warrant their own PR.
- When a transient unit is created by systemd we now ensure that all controllers that have been delegated are inherited by the subtree
- Pause/Resume and stats are now enabled for systemd managed cgroups through the v2 cgroup manager
- The libcgroups crate now provides feature flags for v1, v2 and systemd managed cgroups
- Fixed some commands that failed due to trying to read the runtime config.json instead of the youki config.json