### PR TITLE
Integration test: cgroup v1 network tests, fix to memory tests

### DIFF
--- a/crates/integration_test/Cargo.toml
+++ b/crates/integration_test/Cargo.toml
@@ -28,3 +28,4 @@ serde_json = "1.0"
 nix = "0.23.0"
 libcontainer = { path = "../libcontainer" }
 num_cpus = "1.0"
+pnet = "0.28.0"

--- a/crates/integration_test/src/main.rs
+++ b/crates/integration_test/src/main.rs
@@ -65,6 +65,7 @@ fn main() -> Result<()> {
     let cgroup_v1_pids = cgroups::pids::get_test_group();
     let cgroup_v1_cpus = cgroups::cpus::get_test_group();
     let cgroup_v1_memory = cgroups::memory::get_test_group();
+    let cgroup_v1_network = cgroups::network::get_test_group();
     let seccomp_notify = get_seccomp_notify_test();
 
     tm.add_test_group(&cl);
@@ -75,6 +76,7 @@ fn main() -> Result<()> {
     tm.add_test_group(&cgroup_v1_pids);
     tm.add_test_group(&cgroup_v1_cpus);
     tm.add_test_group(&cgroup_v1_memory);
+    tm.add_test_group(&cgroup_v1_network);
 
     tm.add_cleanup(Box::new(cgroups::cleanup));
     tm.add_test_group(&seccomp_notify);

--- a/crates/integration_test/src/tests/cgroups/memory.rs
+++ b/crates/integration_test/src/tests/cgroups/memory.rs
@@ -8,8 +8,8 @@ use test_framework::{test_result, ConditionalTest, TestGroup, TestResult};
 
 use crate::utils::{test_outside_container, test_utils::check_container_created};
 
-const CGROUP_MEMORY_LIMIT: &str = "memory.limit_in_bytes";
-const CGROUP_MEMORY_SWAPPINESS: &str = "memory.swappiness";
+const CGROUP_MEMORY_LIMIT: &str = "/sys/fs/cgroup/memory/memory.limit_in_bytes";
+const CGROUP_MEMORY_SWAPPINESS: &str = "/sys/fs/cgroup/memory/memory.swappiness";
 
 fn create_spec(cgroup_name: &str, limit: i64, swappiness: u64) -> Result<Spec> {
     let spec = SpecBuilder::default()

--- a/crates/integration_test/src/tests/cgroups/mod.rs
+++ b/crates/integration_test/src/tests/cgroups/mod.rs
@@ -6,6 +6,7 @@ use std::fs;
 
 pub mod cpus;
 pub mod memory;
+pub mod network;
 pub mod pids;
 
 pub fn cleanup() -> Result<()> {

--- a/crates/integration_test/src/tests/cgroups/network.rs
+++ b/crates/integration_test/src/tests/cgroups/network.rs
@@ -67,7 +67,7 @@ fn get_network_interfaces() -> Option<(String, String)> {
     let lo_if_name = interfaces.get(0).map(|iface| &iface.name)?;
     let eth_if_name = interfaces.get(1).map(|iface| &iface.name)?;
 
-    return Some((lo_if_name.to_string(), eth_if_name.to_string()));
+    Some((lo_if_name.to_string(), eth_if_name.to_string()))
 }
 
 fn test_network_cgroups() -> TestResult {

--- a/crates/integration_test/src/tests/cgroups/network.rs
+++ b/crates/integration_test/src/tests/cgroups/network.rs
@@ -1,0 +1,146 @@
+use std::path::Path;
+
+use anyhow::{Context, Result};
+use pnet::datalink;
+
+use oci_spec::runtime::{
+    LinuxBuilder, LinuxInterfacePriorityBuilder, LinuxNamespace, LinuxNamespaceType,
+    LinuxNetworkBuilder, LinuxResourcesBuilder, Spec, SpecBuilder,
+};
+use test_framework::{test_result, ConditionalTest, TestGroup, TestResult};
+
+use crate::utils::{test_outside_container, test_utils::check_container_created};
+
+fn create_spec(
+    cgroup_name: &str,
+    class_id: u32,
+    prio: u32,
+    if_name: &str,
+    with_net_ns: bool,
+    with_user_ns: bool,
+) -> Result<Spec> {
+    // Get default namespaces and filter them to optional exclude network or user namespaces
+    let default_namespaces: Vec<LinuxNamespace> = oci_spec::runtime::get_default_namespaces()
+        .into_iter()
+        .filter(|ns| match ns.typ() {
+            LinuxNamespaceType::Network => with_net_ns,
+            LinuxNamespaceType::User => with_user_ns,
+            _ => true,
+        })
+        .collect();
+
+    // Create the Linux Spec
+    let linux_spec = LinuxBuilder::default()
+        .cgroups_path(Path::new("/runtime-test").join(cgroup_name))
+        .resources(
+            LinuxResourcesBuilder::default()
+                .network(
+                    LinuxNetworkBuilder::default()
+                        .class_id(class_id)
+                        .priorities(vec![LinuxInterfacePriorityBuilder::default()
+                            .name(if_name)
+                            .priority(prio)
+                            .build()
+                            .context("failed to build network interface priority spec")?])
+                        .build()
+                        .context("failed to build network spec")?,
+                )
+                .build()
+                .context("failed to build resource spec")?,
+        )
+        .namespaces(default_namespaces)
+        .build()
+        .context("failed to build linux spec")?;
+
+    // Create the top level Spec
+    let spec = SpecBuilder::default()
+        .linux(linux_spec)
+        .build()
+        .context("failed to build spec")?;
+
+    Ok(spec)
+}
+
+fn test_network_cgroups() -> TestResult {
+    let cgroup_name = "test_network_cgroups";
+
+    let interfaces = datalink::interfaces();
+
+    // Gets the loopback interface, or defaults to "lo"
+    let lo_if_name = interfaces.get(0).map_or_else(|| "lo", |iface| &iface.name);
+    // Gets the first ethernet interface, or defaults to "eth0"
+    let eth_if_name = interfaces
+        .get(1)
+        .map_or_else(|| "eth0", |iface| &iface.name);
+
+    let cases = vec![
+        test_result!(create_spec(cgroup_name, 255, 10, lo_if_name, true, true)),
+        test_result!(create_spec(cgroup_name, 255, 10, lo_if_name, true, false)),
+        test_result!(create_spec(cgroup_name, 255, 10, lo_if_name, false, true)),
+        test_result!(create_spec(cgroup_name, 255, 10, lo_if_name, false, false)),
+        test_result!(create_spec(cgroup_name, 255, 10, eth_if_name, true, true)),
+        test_result!(create_spec(cgroup_name, 255, 10, eth_if_name, true, false)),
+        test_result!(create_spec(cgroup_name, 255, 10, eth_if_name, false, true)),
+        test_result!(create_spec(cgroup_name, 255, 10, eth_if_name, false, false)),
+        test_result!(create_spec(cgroup_name, 255, 30, lo_if_name, true, true)),
+        test_result!(create_spec(cgroup_name, 255, 30, lo_if_name, true, false)),
+        test_result!(create_spec(cgroup_name, 255, 30, lo_if_name, false, true)),
+        test_result!(create_spec(cgroup_name, 255, 30, lo_if_name, false, false)),
+        test_result!(create_spec(cgroup_name, 255, 30, eth_if_name, true, true)),
+        test_result!(create_spec(cgroup_name, 255, 30, eth_if_name, true, false)),
+        test_result!(create_spec(cgroup_name, 255, 30, eth_if_name, false, true)),
+        test_result!(create_spec(cgroup_name, 255, 30, eth_if_name, false, false)),
+        test_result!(create_spec(cgroup_name, 550, 10, lo_if_name, true, true)),
+        test_result!(create_spec(cgroup_name, 550, 10, lo_if_name, true, false)),
+        test_result!(create_spec(cgroup_name, 550, 10, lo_if_name, false, true)),
+        test_result!(create_spec(cgroup_name, 550, 10, lo_if_name, false, false)),
+        test_result!(create_spec(cgroup_name, 550, 10, eth_if_name, true, true)),
+        test_result!(create_spec(cgroup_name, 550, 10, eth_if_name, true, false)),
+        test_result!(create_spec(cgroup_name, 550, 10, eth_if_name, false, true)),
+        test_result!(create_spec(cgroup_name, 550, 10, eth_if_name, false, false)),
+        test_result!(create_spec(cgroup_name, 550, 30, lo_if_name, true, true)),
+        test_result!(create_spec(cgroup_name, 550, 30, lo_if_name, true, false)),
+        test_result!(create_spec(cgroup_name, 550, 30, lo_if_name, false, true)),
+        test_result!(create_spec(cgroup_name, 550, 30, lo_if_name, false, false)),
+        test_result!(create_spec(cgroup_name, 550, 30, eth_if_name, true, true)),
+        test_result!(create_spec(cgroup_name, 550, 30, eth_if_name, true, false)),
+        test_result!(create_spec(cgroup_name, 550, 30, eth_if_name, false, true)),
+        test_result!(create_spec(cgroup_name, 550, 30, eth_if_name, false, false)),
+    ];
+
+    for spec in cases.into_iter() {
+        let test_result = test_outside_container(spec, &|data| {
+            test_result!(check_container_created(&data));
+
+            TestResult::Passed
+        });
+        if let TestResult::Failed(_) = test_result {
+            return test_result;
+        }
+    }
+
+    TestResult::Passed
+}
+
+fn can_run() -> bool {
+    // This is kind of annoying, network controller can be at a number of mount points
+    (Path::new("/sys/fs/cgroup/net_cls/net_cls.classid").exists()
+        && Path::new("/sys/fs/cgroup/net_prio/net_prio.ifpriomap").exists())
+        || (Path::new("/sys/fs/cgroup/net_cls,net_prio/net_cls.classid").exists()
+            && Path::new("/sys/fs/cgroup/net_cls,net_prio/net_prio.ifpriomap").exists())
+        || (Path::new("/sys/fs/cgroup/net_prio,net_cls/net_cls.classid").exists()
+            && Path::new("/sys/fs/cgroup/net_prio,net_cl/net_prio.ifpriomap").exists())
+}
+
+pub fn get_test_group<'a>() -> TestGroup<'a> {
+    let mut test_group = TestGroup::new("cgroup_v1_network");
+    let linux_cgroups_network = ConditionalTest::new(
+        "test_linux_cgroups_network",
+        Box::new(can_run),
+        Box::new(test_network_cgroups),
+    );
+
+    test_group.add(vec![Box::new(linux_cgroups_network)]);
+
+    test_group
+}


### PR DESCRIPTION
I have implemented a similar test to the oci-spec runtime tools, and I've verified that it is passing consistently. I also noticed that the cgroups path for memory was not set correctly and included the fix in this PR. I also verified the change the memory cgroups test is passing consistently. I also made sure both are able to fail, as I suspect the memory cgroup test wasn't even running before because the wrong path was set for the `can_run` check.