### PR TITLE
ignore integration test crate for code coverage

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -13,3 +13,6 @@ comment:
   layout: "header, diff"
   behavior: default
   require_changes: false
+
+ignore:
+  - "crates/integration_test"


### PR DESCRIPTION
Currently when you add integration tests it reduces coverage because the integration tests don't have any verifiable test on them and codecov doesn't really know that they are actually tests. So I think for now to reduce the false negatives in codecov we can just ignore the entire integration test crate for now per [this document](https://docs.codecov.com/docs/ignoring-paths). Perhaps we can eventually figure out how to get coverage reports on the integration tests in the future, but this is a quick fix.