### PR TITLE
Implement integration tests for cgroup v2 cpu

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -573,11 +573,13 @@ name = "integration_test"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "chrono",
  "clap",
  "clap_derive",
  "flate2",
  "libcgroups",
  "libcontainer",
+ "log",
  "nix",
  "num_cpus",
  "oci-spec 0.5.2 (git+https://github.com/containers/oci-spec-rs?rev=54c5e386f01ab37c9305cc4a83404eb157e42440)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -576,6 +576,7 @@ dependencies = [
  "clap",
  "clap_derive",
  "flate2",
+ "libcgroups",
  "libcontainer",
  "nix",
  "num_cpus",

--- a/crates/integration_test/Cargo.toml
+++ b/crates/integration_test/Cargo.toml
@@ -27,4 +27,5 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 nix = "0.23.0"
 libcontainer = { path = "../libcontainer" }
+libcgroups = { path = "../libcgroups" }
 num_cpus = "1.0"

--- a/crates/integration_test/Cargo.toml
+++ b/crates/integration_test/Cargo.toml
@@ -3,6 +3,26 @@ name = "integration_test"
 version = "0.1.0"
 edition = "2021"
 
+[dependencies]
+anyhow = "1.0"
+chrono = { version="0.4" }
+flate2 = "1.0"
+libcgroups = { path = "../libcgroups" }
+libcontainer = { path = "../libcontainer" }
+log = { version = "0.4", features = ["std"] }
+nix = "0.23.0"
+num_cpus = "1.0"
+oci-spec = { git = "https://github.com/containers/oci-spec-rs", rev = "54c5e386f01ab37c9305cc4a83404eb157e42440" }
+once_cell = "1.8.0"
+procfs = "0.11.1"
+rand = "0.8.0"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+tar = "0.4"
+test_framework = { path = "../test_framework" }
+uuid = "0.8"
+which = "4.2.2"
+
 [dependencies.clap]
 version = "=3.0.0-beta.5"
 default-features = false
@@ -11,21 +31,3 @@ features = ["std", "suggestions", "derive"]
 [dependencies.clap_derive]
 version = "=3.0.0-beta.5"
 default-features = true
-
-[dependencies]
-procfs = "0.11.1"
-uuid = "0.8"
-rand = "0.8.0"
-tar = "0.4"
-flate2 = "1.0"
-test_framework = { path = "../test_framework"}
-anyhow = "1.0"
-once_cell = "1.8.0"
-oci-spec = { git = "https://github.com/containers/oci-spec-rs",  rev = "54c5e386f01ab37c9305cc4a83404eb157e42440" }
-which = "4.2.2"
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
-nix = "0.23.0"
-libcontainer = { path = "../libcontainer" }
-libcgroups = { path = "../libcgroups" }
-num_cpus = "1.0"

--- a/crates/integration_test/run_tests.sh
+++ b/crates/integration_test/run_tests.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 cd ../../
-./build.sh
+./build.sh --release
 cp ./youki ./crates/integration_test
 cp ./youki_integration_test ./crates/integration_test
 cd ./crates/integration_test

--- a/crates/integration_test/src/lib.rs
+++ b/crates/integration_test/src/lib.rs
@@ -1,2 +1,3 @@
+pub mod logger;
 pub mod tests;
 pub mod utils;

--- a/crates/integration_test/src/logger.rs
+++ b/crates/integration_test/src/logger.rs
@@ -10,7 +10,6 @@ use std::str::FromStr;
 pub static LOG_FILE: OnceCell<Option<File>> = OnceCell::new();
 const LOG_LEVEL_ENV_NAME: &str = "YOUKI_INTEGRATION_LOG_LEVEL";
 
-
 /// Initialize the logger, must be called before accessing the logger
 /// Multiple parts might call this at once, but the actual initialization
 /// is done only once due to use of OnceCell
@@ -73,7 +72,7 @@ impl Log for IntegrationLogger {
     /// Function to carry out logging
     fn log(&self, record: &Record) {
         if self.enabled(record.metadata()) {
-            let log_msg =text_format(record);
+            let log_msg = text_format(record);
             // if log file is set, write to it, else write to stderr
             if let Some(mut log_file) = LOG_FILE.get().unwrap().as_ref() {
                 let _ = writeln!(log_file, "{}", log_msg);

--- a/crates/integration_test/src/logger.rs
+++ b/crates/integration_test/src/logger.rs
@@ -1,0 +1,151 @@
+//! Default Youki Logger
+
+use anyhow::{bail, Context, Result};
+use log::{LevelFilter, Log, Metadata, Record};
+use once_cell::sync::OnceCell;
+use std::borrow::Cow;
+use std::fs::{File, OpenOptions};
+use std::io::{stderr, Write};
+use std::path::PathBuf;
+use std::str::FromStr;
+
+pub static LOG_FILE: OnceCell<Option<File>> = OnceCell::new();
+const LOG_LEVEL_ENV_NAME: &str = "YOUKI_INTEGRATION_LOG_LEVEL";
+const LOG_FORMAT_TEXT: &str = "text";
+const LOG_FORMAT_JSON: &str = "json";
+enum LogFormat {
+    Text,
+    Json,
+}
+
+/// If in debug mode, default level is debug to get maximum logging
+#[cfg(debug_assertions)]
+const DEFAULT_LOG_LEVEL: &str = "debug";
+
+/// If not in debug mode, default level is warn to get important logs
+#[cfg(not(debug_assertions))]
+const DEFAULT_LOG_LEVEL: &str = "warn";
+
+/// Initialize the logger, must be called before accessing the logger
+/// Multiple parts might call this at once, but the actual initialization
+/// is done only once due to use of OnceCell
+pub fn init(log_file: Option<PathBuf>, log_format: Option<String>) -> Result<()> {
+    let level = detect_log_level(true).context("failed to parse log level")?;
+    let format = detect_log_format(log_format).context("failed to detect log format")?;
+    let _ = LOG_FILE.get_or_init(|| -> Option<File> {
+        log_file.map(|path| {
+            OpenOptions::new()
+                .create(true)
+                .write(true)
+                .truncate(false)
+                .open(path)
+                .expect("failed opening log file")
+        })
+    });
+
+    let logger = IntegrationLogger::new(level.to_level(), format);
+    log::set_boxed_logger(Box::new(logger))
+        .map(|()| log::set_max_level(level))
+        .expect("set logger failed");
+
+    Ok(())
+}
+
+fn detect_log_format(log_format: Option<String>) -> Result<LogFormat> {
+    match log_format.as_deref() {
+        None | Some(LOG_FORMAT_TEXT) => Ok(LogFormat::Text),
+        Some(LOG_FORMAT_JSON) => Ok(LogFormat::Json),
+        Some(unknown) => bail!("unknown log format: {}", unknown),
+    }
+}
+
+fn detect_log_level(is_debug: bool) -> Result<LevelFilter> {
+    let filter: Cow<str> = if is_debug {
+        "debug".into()
+    } else if let Ok(level) = std::env::var(LOG_LEVEL_ENV_NAME) {
+        level.into()
+    } else {
+        DEFAULT_LOG_LEVEL.into()
+    };
+    Ok(LevelFilter::from_str(filter.as_ref())?)
+}
+
+struct IntegrationLogger {
+    /// Indicates level up to which logs are to be printed
+    level: Option<log::Level>,
+    format: LogFormat,
+}
+
+impl IntegrationLogger {
+    /// Create new logger
+    pub fn new(level: Option<log::Level>, format: LogFormat) -> Self {
+        Self { level, format }
+    }
+}
+
+/// Implements Log interface given by log crate, so we can use its functionality
+impl Log for IntegrationLogger {
+    /// Check if level of given log is enabled or not
+    fn enabled(&self, metadata: &Metadata) -> bool {
+        if let Some(level) = self.level {
+            metadata.level() <= level
+        } else {
+            false
+        }
+    }
+
+    /// Function to carry out logging
+    fn log(&self, record: &Record) {
+        if self.enabled(record.metadata()) {
+            let log_msg = match self.format {
+                LogFormat::Text => text_format(record),
+                LogFormat::Json => json_format(record),
+            };
+            // if log file is set, write to it, else write to stderr
+            if let Some(mut log_file) = LOG_FILE.get().unwrap().as_ref() {
+                let _ = writeln!(log_file, "{}", log_msg);
+            } else {
+                let _ = writeln!(stderr(), "{}", log_msg);
+            }
+        }
+    }
+
+    /// Flush logs to file
+    fn flush(&self) {
+        if let Some(mut log_file) = LOG_FILE.get().unwrap().as_ref() {
+            log_file.flush().expect("failed to flush");
+        } else {
+            stderr().flush().expect("failed to flush");
+        }
+    }
+}
+
+fn json_format(record: &log::Record) -> String {
+    serde_json::to_string(&serde_json::json!({
+        "level": record.level().to_string(),
+        "time": chrono::Local::now().to_rfc3339(),
+        "message": record.args(),
+    }))
+    .expect("serde::to_string with string keys will not fail")
+}
+
+fn text_format(record: &log::Record) -> String {
+    let log_msg = match (record.file(), record.line()) {
+        (Some(file), Some(line)) => format!(
+            "[{} {}:{}] {} {}\r",
+            record.level(),
+            file,
+            line,
+            chrono::Local::now().to_rfc3339(),
+            record.args()
+        ),
+        (_, _) => format!(
+            "[{}] {} {}\r",
+            record.level(),
+            chrono::Local::now().to_rfc3339(),
+            record.args()
+        ),
+    };
+
+    log_msg
+}

--- a/crates/integration_test/src/logger.rs
+++ b/crates/integration_test/src/logger.rs
@@ -1,6 +1,4 @@
-//! Default Youki Logger
-
-use anyhow::{bail, Context, Result};
+use anyhow::{Context, Result};
 use log::{LevelFilter, Log, Metadata, Record};
 use once_cell::sync::OnceCell;
 use std::borrow::Cow;
@@ -11,27 +9,13 @@ use std::str::FromStr;
 
 pub static LOG_FILE: OnceCell<Option<File>> = OnceCell::new();
 const LOG_LEVEL_ENV_NAME: &str = "YOUKI_INTEGRATION_LOG_LEVEL";
-const LOG_FORMAT_TEXT: &str = "text";
-const LOG_FORMAT_JSON: &str = "json";
-enum LogFormat {
-    Text,
-    Json,
-}
 
-/// If in debug mode, default level is debug to get maximum logging
-#[cfg(debug_assertions)]
-const DEFAULT_LOG_LEVEL: &str = "debug";
-
-/// If not in debug mode, default level is warn to get important logs
-#[cfg(not(debug_assertions))]
-const DEFAULT_LOG_LEVEL: &str = "warn";
 
 /// Initialize the logger, must be called before accessing the logger
 /// Multiple parts might call this at once, but the actual initialization
 /// is done only once due to use of OnceCell
-pub fn init(log_file: Option<PathBuf>, log_format: Option<String>) -> Result<()> {
-    let level = detect_log_level(true).context("failed to parse log level")?;
-    let format = detect_log_format(log_format).context("failed to detect log format")?;
+pub fn init(log_file: Option<PathBuf>, debug: bool) -> Result<()> {
+    let level = detect_log_level(debug).context("failed to parse log level")?;
     let _ = LOG_FILE.get_or_init(|| -> Option<File> {
         log_file.map(|path| {
             OpenOptions::new()
@@ -43,20 +27,12 @@ pub fn init(log_file: Option<PathBuf>, log_format: Option<String>) -> Result<()>
         })
     });
 
-    let logger = IntegrationLogger::new(level.to_level(), format);
+    let logger = IntegrationLogger::new(level.to_level());
     log::set_boxed_logger(Box::new(logger))
         .map(|()| log::set_max_level(level))
         .expect("set logger failed");
 
     Ok(())
-}
-
-fn detect_log_format(log_format: Option<String>) -> Result<LogFormat> {
-    match log_format.as_deref() {
-        None | Some(LOG_FORMAT_TEXT) => Ok(LogFormat::Text),
-        Some(LOG_FORMAT_JSON) => Ok(LogFormat::Json),
-        Some(unknown) => bail!("unknown log format: {}", unknown),
-    }
 }
 
 fn detect_log_level(is_debug: bool) -> Result<LevelFilter> {
@@ -65,21 +41,21 @@ fn detect_log_level(is_debug: bool) -> Result<LevelFilter> {
     } else if let Ok(level) = std::env::var(LOG_LEVEL_ENV_NAME) {
         level.into()
     } else {
-        DEFAULT_LOG_LEVEL.into()
+        "off".into()
     };
+
     Ok(LevelFilter::from_str(filter.as_ref())?)
 }
 
 struct IntegrationLogger {
     /// Indicates level up to which logs are to be printed
     level: Option<log::Level>,
-    format: LogFormat,
 }
 
 impl IntegrationLogger {
     /// Create new logger
-    pub fn new(level: Option<log::Level>, format: LogFormat) -> Self {
-        Self { level, format }
+    pub fn new(level: Option<log::Level>) -> Self {
+        Self { level }
     }
 }
 
@@ -97,10 +73,7 @@ impl Log for IntegrationLogger {
     /// Function to carry out logging
     fn log(&self, record: &Record) {
         if self.enabled(record.metadata()) {
-            let log_msg = match self.format {
-                LogFormat::Text => text_format(record),
-                LogFormat::Json => json_format(record),
-            };
+            let log_msg =text_format(record);
             // if log file is set, write to it, else write to stderr
             if let Some(mut log_file) = LOG_FILE.get().unwrap().as_ref() {
                 let _ = writeln!(log_file, "{}", log_msg);
@@ -118,15 +91,6 @@ impl Log for IntegrationLogger {
             stderr().flush().expect("failed to flush");
         }
     }
-}
-
-fn json_format(record: &log::Record) -> String {
-    serde_json::to_string(&serde_json::json!({
-        "level": record.level().to_string(),
-        "time": chrono::Local::now().to_rfc3339(),
-        "message": record.args(),
-    }))
-    .expect("serde::to_string with string keys will not fail")
 }
 
 fn text_format(record: &log::Record) -> String {

--- a/crates/integration_test/src/main.rs
+++ b/crates/integration_test/src/main.rs
@@ -28,9 +28,6 @@ struct Opts {
     /// Enables debug output
     #[clap(short, long)]
     debug: bool,
-    /// Logs to the specified file
-    #[clap(long)]
-    log: Option<PathBuf>,
 }
 
 // parse test string given in commandline option as pair of testgroup name and tests belonging to that
@@ -51,7 +48,7 @@ fn parse_tests(tests: &[String]) -> Vec<(&str, Option<Vec<&str>>)> {
 fn main() -> Result<()> {
     let opts: Opts = Opts::parse();
 
-    if let Err(e) = logger::init(opts.log, opts.debug) {
+    if let Err(e) = logger::init(opts.debug) {
         eprintln!("logger could not be initialized: {:?}", e);
     }
 

--- a/crates/integration_test/src/main.rs
+++ b/crates/integration_test/src/main.rs
@@ -63,9 +63,11 @@ fn main() -> Result<()> {
     let pidfile = get_pidfile_test();
     let ns_itype = get_ns_itype_tests();
     let cgroup_v1_pids = cgroups::pids::get_test_group();
-    let cgroup_v1_cpus = cgroups::cpus::get_test_group();
+    let cgroup_v1_cpu = cgroups::cpu::v1::get_test_group();
+    let cgroup_v2_cpu = cgroups::cpu::v2::get_test_group();
     let cgroup_v1_memory = cgroups::memory::get_test_group();
     let seccomp_notify = get_seccomp_notify_test();
+
 
     tm.add_test_group(&cl);
     tm.add_test_group(&cc);
@@ -73,11 +75,12 @@ fn main() -> Result<()> {
     tm.add_test_group(&pidfile);
     tm.add_test_group(&ns_itype);
     tm.add_test_group(&cgroup_v1_pids);
-    tm.add_test_group(&cgroup_v1_cpus);
+    tm.add_test_group(&cgroup_v1_cpu);
+    tm.add_test_group(&cgroup_v2_cpu);
     tm.add_test_group(&cgroup_v1_memory);
+    tm.add_test_group(&seccomp_notify);
 
     tm.add_cleanup(Box::new(cgroups::cleanup));
-    tm.add_test_group(&seccomp_notify);
 
     if let Some(tests) = opts.tests {
         let tests_to_run = parse_tests(&tests);

--- a/crates/integration_test/src/main.rs
+++ b/crates/integration_test/src/main.rs
@@ -17,14 +17,20 @@ use tests::cgroups;
 #[derive(Parser, Debug)]
 #[clap(version = "0.0.1", author = "youki team")]
 struct Opts {
-    /// path for the container runtime to be tested
+    /// Path for the container runtime to be tested
     #[clap(short, long)]
     runtime: PathBuf,
-    /// selected tests to be run, format should be
+    /// Selected tests to be run, format should be
     /// space separated groups, eg
     /// -t group1::test1,test3 group2 group3::test5
     #[clap(short, long, multiple_values = true, value_delimiter = ' ')]
     tests: Option<Vec<String>>,
+    /// Enables debug output 
+    #[clap(short, long)]
+    debug: bool,
+    /// Logs to the specified file
+    #[clap(long)]
+    log: Option<PathBuf>,
 }
 
 // parse test string given in commandline option as pair of testgroup name and tests belonging to that
@@ -45,7 +51,7 @@ fn parse_tests(tests: &[String]) -> Vec<(&str, Option<Vec<&str>>)> {
 fn main() -> Result<()> {
     let opts: Opts = Opts::parse();
 
-    if let Err(e) = logger::init(None, None) {
+    if let Err(e) = logger::init(opts.log, opts.debug) {
         eprintln!("logger could not be initialized: {:?}", e);
     }
 

--- a/crates/integration_test/src/main.rs
+++ b/crates/integration_test/src/main.rs
@@ -9,6 +9,7 @@ use crate::tests::tlb::get_tlb_test;
 use crate::utils::support::set_runtime_path;
 use anyhow::Result;
 use clap::Parser;
+use integration_test::logger;
 use std::path::PathBuf;
 use test_framework::TestManager;
 use tests::cgroups;
@@ -43,6 +44,11 @@ fn parse_tests(tests: &[String]) -> Vec<(&str, Option<Vec<&str>>)> {
 
 fn main() -> Result<()> {
     let opts: Opts = Opts::parse();
+
+    if let Err(e) = logger::init(None, None) {
+        eprintln!("logger could not be initialized: {:?}", e);
+    }
+
     match std::fs::canonicalize(&opts.runtime) {
         // runtime path is relative or resolved correctly
         Ok(path) => set_runtime_path(&path),
@@ -67,7 +73,6 @@ fn main() -> Result<()> {
     let cgroup_v2_cpu = cgroups::cpu::v2::get_test_group();
     let cgroup_v1_memory = cgroups::memory::get_test_group();
     let seccomp_notify = get_seccomp_notify_test();
-
 
     tm.add_test_group(&cl);
     tm.add_test_group(&cc);

--- a/crates/integration_test/src/main.rs
+++ b/crates/integration_test/src/main.rs
@@ -25,7 +25,7 @@ struct Opts {
     /// -t group1::test1,test3 group2 group3::test5
     #[clap(short, long, multiple_values = true, value_delimiter = ' ')]
     tests: Option<Vec<String>>,
-    /// Enables debug output 
+    /// Enables debug output
     #[clap(short, long)]
     debug: bool,
     /// Logs to the specified file
@@ -91,7 +91,8 @@ fn main() -> Result<()> {
     tm.add_test_group(&cgroup_v1_memory);
     tm.add_test_group(&seccomp_notify);
 
-    tm.add_cleanup(Box::new(cgroups::cleanup));
+    tm.add_cleanup(Box::new(cgroups::cleanup_v1));
+    tm.add_cleanup(Box::new(cgroups::cleanup_v2));
 
     if let Some(tests) = opts.tests {
         let tests_to_run = parse_tests(&tests);

--- a/crates/integration_test/src/tests/cgroups/cpu/mod.rs
+++ b/crates/integration_test/src/tests/cgroups/cpu/mod.rs
@@ -1,0 +1,80 @@
+use anyhow::{Context, Result};
+use std::path::Path;
+
+use oci_spec::runtime::{
+    LinuxBuilder, LinuxCpu, LinuxCpuBuilder, LinuxResourcesBuilder, Spec, SpecBuilder,
+};
+
+pub mod v1;
+pub mod v2;
+
+fn create_cpu_spec(
+    shares: u64,
+    quota: i64,
+    period: u64,
+    cpus: &str,
+    mems: &str,
+    realtime_period_opt: Option<u64>,
+    realtime_runtime_opt: Option<i64>,
+) -> Result<LinuxCpu> {
+    let mut builder = LinuxCpuBuilder::default()
+        .shares(shares)
+        .quota(quota)
+        .period(period)
+        .cpus(cpus)
+        .mems(mems);
+
+    if let Some(realtime_period) = realtime_period_opt {
+        builder = builder.realtime_period(realtime_period);
+    }
+
+    if let Some(realtime_runtime) = realtime_runtime_opt {
+        builder = builder.realtime_runtime(realtime_runtime);
+    }
+
+    builder.build().context("failed to build cpu spec")
+}
+
+fn create_spec(cgroup_name: &str, case: LinuxCpu) -> Result<Spec> {
+    let spec = SpecBuilder::default()
+        .linux(
+            LinuxBuilder::default()
+                .cgroups_path(Path::new("/runtime-test").join(cgroup_name))
+                .resources(
+                    LinuxResourcesBuilder::default()
+                        .cpu(case)
+                        .build()
+                        .context("failed to build resource spec")?,
+                )
+                .build()
+                .context("failed to build linux spec")?,
+        )
+        .build()
+        .context("failed to build spec")?;
+
+    Ok(spec)
+}
+
+fn create_empty_spec(cgroup_name: &str) -> Result<Spec> {
+    let spec = SpecBuilder::default()
+        .linux(
+            LinuxBuilder::default()
+                .cgroups_path(Path::new("/runtime-test").join(cgroup_name))
+                .resources(
+                    LinuxResourcesBuilder::default()
+                        .cpu(
+                            LinuxCpuBuilder::default()
+                                .build()
+                                .context("failed to build cpus spec")?,
+                        )
+                        .build()
+                        .context("failed to build resource spec")?,
+                )
+                .build()
+                .context("failed to build linux spec")?,
+        )
+        .build()
+        .context("failed to build spec")?;
+
+    Ok(spec)
+}

--- a/crates/integration_test/src/tests/cgroups/cpu/v1.rs
+++ b/crates/integration_test/src/tests/cgroups/cpu/v1.rs
@@ -217,7 +217,7 @@ fn can_run() -> bool {
 }
 
 pub fn get_test_group<'a>() -> TestGroup<'a> {
-    let mut test_group = TestGroup::new("cgroup_v1_cpus");
+    let mut test_group = TestGroup::new("cgroup_v1_cpu");
     let linux_cgroups_cpus = ConditionalTest::new(
         "test_linux_cgroups_cpus",
         Box::new(can_run),

--- a/crates/integration_test/src/tests/cgroups/cpu/v1.rs
+++ b/crates/integration_test/src/tests/cgroups/cpu/v1.rs
@@ -1,88 +1,15 @@
 use std::path::Path;
 
-use anyhow::{Context, Result};
 use num_cpus;
-use oci_spec::runtime::{
-    LinuxBuilder, LinuxCpu, LinuxCpuBuilder, LinuxResourcesBuilder, Spec, SpecBuilder,
-};
 use test_framework::{test_result, ConditionalTest, TestGroup, TestResult};
 
 use crate::utils::{test_outside_container, test_utils::check_container_created};
 
+use super::{create_cpu_spec, create_empty_spec, create_spec};
+
 const CPU_CGROUP_PREFIX: &str = "/sys/fs/cgroup/cpu,cpuacct";
 const DEFAULT_REALTIME_PERIOD: u64 = 1000000;
 const DEFAULT_REALTIME_RUNTIME: i64 = 950000;
-
-fn create_cpu_spec(
-    shares: u64,
-    quota: i64,
-    period: u64,
-    cpus: &str,
-    mems: &str,
-    realtime_period_opt: Option<u64>,
-    realtime_runtime_opt: Option<i64>,
-) -> Result<LinuxCpu> {
-    let mut builder = LinuxCpuBuilder::default()
-        .shares(shares)
-        .quota(quota)
-        .period(period)
-        .cpus(cpus)
-        .mems(mems);
-
-    if let Some(realtime_period) = realtime_period_opt {
-        builder = builder.realtime_period(realtime_period);
-    }
-
-    if let Some(realtime_runtime) = realtime_runtime_opt {
-        builder = builder.realtime_runtime(realtime_runtime);
-    }
-
-    builder.build().context("failed to build cpu spec")
-}
-
-fn create_spec(cgroup_name: &str, case: LinuxCpu) -> Result<Spec> {
-    let spec = SpecBuilder::default()
-        .linux(
-            LinuxBuilder::default()
-                .cgroups_path(Path::new("/runtime-test").join(cgroup_name))
-                .resources(
-                    LinuxResourcesBuilder::default()
-                        .cpu(case)
-                        .build()
-                        .context("failed to build resource spec")?,
-                )
-                .build()
-                .context("failed to build linux spec")?,
-        )
-        .build()
-        .context("failed to build spec")?;
-
-    Ok(spec)
-}
-
-fn create_empty_spec(cgroup_name: &str) -> Result<Spec> {
-    let spec = SpecBuilder::default()
-        .linux(
-            LinuxBuilder::default()
-                .cgroups_path(Path::new("/runtime-test").join(cgroup_name))
-                .resources(
-                    LinuxResourcesBuilder::default()
-                        .cpu(
-                            LinuxCpuBuilder::default()
-                                .build()
-                                .context("failed to build cpus spec")?,
-                        )
-                        .build()
-                        .context("failed to build resource spec")?,
-                )
-                .build()
-                .context("failed to build linux spec")?,
-        )
-        .build()
-        .context("failed to build spec")?;
-
-    Ok(spec)
-}
 
 fn get_realtime_period() -> Option<u64> {
     if Path::new(CPU_CGROUP_PREFIX)

--- a/crates/integration_test/src/tests/cgroups/cpu/v2.rs
+++ b/crates/integration_test/src/tests/cgroups/cpu/v2.rs
@@ -1,0 +1,9 @@
+use test_framework::TestGroup;
+
+fn can_run() -> bool {
+    todo!();
+}
+
+pub fn get_test_group<'a>() -> TestGroup<'a> {
+    todo!()
+}

--- a/crates/integration_test/src/tests/cgroups/cpu/v2.rs
+++ b/crates/integration_test/src/tests/cgroups/cpu/v2.rs
@@ -1,9 +1,301 @@
-use test_framework::TestGroup;
+use std::{fs, path::PathBuf};
+
+use crate::utils::{
+    test_outside_container,
+    test_utils::{check_container_created, CGROUP_ROOT},
+};
+use anyhow::{bail, Context, Result};
+use libcgroups::{
+    common::{self, CgroupSetup},
+    v2::controller_type::ControllerType,
+};
+use log::debug;
+use oci_spec::runtime::LinuxCpuBuilder;
+use test_framework::{assert_result_eq, test_result, ConditionalTest, TestGroup, TestResult};
+
+use super::create_spec;
+
+// SPEC: The runtime spec does not specify what should happen if the cpu weight is outside
+// of the valid range of values [1, 10000]. We assume that a value of zero means that no action
+// should be taken and a value of over 10000 (after being converted into the cgroup v2 format)
+// should be set to the maximum value (i.e. 10000).
+// It also does not specify what should happen if the cpu quota or cpu period is negative or zero.
+// We assume that a negative value means that it should be set to the default value and zero means
+// that it should be unchanged.
+
+/// Tests if a cpu weight that is in the valid range [1, 10000] is successfully set
+fn test_cpu_weight_valid_set() -> TestResult {
+    let cpu_weight = 22_000u64;
+    let converted_cpu_weight = 840u64;
+    let cpu = test_result!(LinuxCpuBuilder::default()
+        .shares(cpu_weight)
+        .build()
+        .context("build cpu spec"));
+
+    let spec = test_result!(create_spec("test_cpu_weight_valid_set", cpu));
+    test_outside_container(spec, &|data| {
+        test_result!(check_container_created(&data));
+        test_result!(check_cpu_weight(
+            "test_cpu_weight_valid_set",
+            converted_cpu_weight
+        ));
+        TestResult::Passed
+    })
+}
+
+/// Tests if a cpu weight of zero is ignored
+fn test_cpu_weight_zero_ignored() -> TestResult {
+    let cpu_weight = 0u64;
+    let default_cpu_weight = 100;
+    let cpu = test_result!(LinuxCpuBuilder::default()
+        .shares(cpu_weight)
+        .build()
+        .context("build cpu spec"));
+
+    let spec = test_result!(create_spec("test_cpu_weight_zero_ignored", cpu));
+    test_outside_container(spec, &|data| {
+        test_result!(check_container_created(&data));
+        test_result!(check_cpu_weight(
+            "test_cpu_weight_zero_ignored",
+            default_cpu_weight
+        ));
+        TestResult::Passed
+    })
+}
+
+/// Tests if a cpu weight that is too high (over 10000 after conversion) is set to the maximum value
+fn test_cpu_weight_too_high_maximum_set() -> TestResult {
+    let cpu_weight = 500_000u64;
+    let converted_cpu_weight = 10_000;
+    let cpu = test_result!(LinuxCpuBuilder::default()
+        .shares(cpu_weight)
+        .build()
+        .context("build cpu spec"));
+
+    let spec = test_result!(create_spec("test_cpu_weight_too_high_maximum_set", cpu));
+    test_outside_container(spec, &|data| {
+        test_result!(check_container_created(&data));
+        test_result!(check_cpu_weight(
+            "test_cpu_weight_too_high_maximum_set",
+            converted_cpu_weight
+        ));
+        TestResult::Passed
+    })
+}
+
+/// Tests if a valid cpu quota (x > 0) is set successfully
+fn test_cpu_quota_valid_set() -> TestResult {
+    let cpu_quota = 250_000;
+    let cpu = test_result!(LinuxCpuBuilder::default()
+        .quota(cpu_quota)
+        .build()
+        .context("build cpu spec"));
+
+    let spec = test_result!(create_spec("test_cpu_quota_valid_set", cpu));
+    test_outside_container(spec, &|data| {
+        test_result!(check_container_created(&data));
+        test_result!(check_cpu_quota("test_cpu_quota_valid_set", cpu_quota));
+        TestResult::Passed
+    })
+}
+
+/// Tests if the cpu quota is unchanged if the cpu quota is unspecified (should be 'max')
+fn test_cpu_quota_unspecified_unchanged() -> TestResult {
+    let cpu = test_result!(LinuxCpuBuilder::default()
+        .build()
+        .context("build cpu spec"));
+
+    let spec = test_result!(create_spec("test_cpu_quota_unspecified_unchanged", cpu));
+    test_outside_container(spec, &|data| {
+        test_result!(check_container_created(&data));
+        test_result!(check_cpu_quota(
+            "test_cpu_quota_unspecified_unchanged",
+            i64::MAX
+        ));
+        TestResult::Passed
+    })
+}
+
+/// Tests if the cpu quota is the default value (max) if a negative cpu quota has been specified
+fn test_cpu_quota_negative_value_default_set() -> TestResult {
+    let cpu_quota = -9999;
+    let cpu = test_result!(LinuxCpuBuilder::default()
+        .quota(cpu_quota)
+        .build()
+        .context("build cpu spec"));
+
+    let spec = test_result!(create_spec(
+        "test_cpu_quota_negative_value_default_set",
+        cpu
+    ));
+    test_outside_container(spec, &|data| {
+        test_result!(check_container_created(&data));
+        test_result!(check_cpu_quota(
+            "test_cpu_quota_negative_value_default_set",
+            i64::MAX
+        ));
+        TestResult::Passed
+    })
+}
+
+/// Tests if a valid cpu period (x > 0) is set successfully
+fn test_cpu_period_valid_set() -> TestResult {
+    todo!()
+}
+
+/// Tests if the cpu period is unchanged if the cpu period is unspecified
+fn test_cpu_period_unspecified_unchanged() -> TestResult {
+    todo!()
+}
+
+/// Tests if the cpu period is the default value (100000) if a negative value has been specified
+fn test_cpu_period_negative_value_default_set() -> TestResult {
+    todo!()
+}
+
+fn check_cpu_weight(cgroup_name: &str, expected_weight: u64) -> Result<()> {
+    let data = read_cgroup_data(cgroup_name, "cpu.weight")?;
+
+    let actual_weight = data
+        .parse::<u64>()
+        .with_context(|| format!("failed to parse {:?}", data))?;
+    assert_result_eq!(actual_weight, expected_weight, "unexpected cpu weight")
+}
+
+fn check_cpu_quota(cgroup_name: &str, expected_quota: i64) -> Result<()> {
+    let data = read_cgroup_data(cgroup_name, "cpu.max")?;
+    let parts: Vec<&str> = data.split_whitespace().collect();
+    if parts.len() != 2 {
+        bail!(
+            "expected cpu.max to consist of 'quota period' but was {:?}",
+            data
+        );
+    }
+
+    let quota = parts[0].trim();
+    if expected_quota == i64::MAX {
+        if quota == "max" {
+            return Ok(());
+        } else {
+            bail!("expected cpu quota to be 'max', but was {:?}", quota);
+        }
+    }
+
+    let actual_quota = quota
+        .parse::<i64>()
+        .with_context(|| format!("failed to parse {:?}", quota))?;
+    assert_result_eq!(expected_quota, actual_quota, "unexpected cpu quota");
+}
+
+fn read_cgroup_data(cgroup_name: &str, cgroup_file: &str) -> Result<String> {
+    let cgroup_path = PathBuf::from(CGROUP_ROOT)
+        .join("runtime-test")
+        .join(cgroup_name)
+        .join(cgroup_file);
+
+    log::debug!("reading value from {:?}", cgroup_path);
+    let content = fs::read_to_string(&cgroup_path)
+        .with_context(|| format!("failed to read {:?}", cgroup_path))?;
+    let trimmed = content.trim();
+    Ok(trimmed.to_owned())
+}
 
 fn can_run() -> bool {
-    todo!();
+    let setup_result = common::get_cgroup_setup();
+    if !matches!(setup_result, Ok(CgroupSetup::Unified)) {
+        debug!("cgroup setup is not v2, was {:?}", setup_result);
+        return false;
+    }
+
+    let controllers_result =
+        libcgroups::v2::util::get_available_controllers(common::DEFAULT_CGROUP_ROOT);
+    if controllers_result.is_err() {
+        debug!(
+            "could not retrieve cgroup controllers: {:?}",
+            controllers_result
+        );
+        return false;
+    }
+
+    if controllers_result
+        .unwrap()
+        .into_iter()
+        .find(|c| *c == ControllerType::Cpu)
+        .is_none()
+    {
+        debug!("cpu controller is not attached to the v2 hierarchy");
+        return false;
+    }
+
+    true
 }
 
 pub fn get_test_group<'a>() -> TestGroup<'a> {
-    todo!()
+    let mut test_group = TestGroup::new("cgroup_v2_cpu");
+    let test_cpu_weight_valid_set = ConditionalTest::new(
+        "test_cpu_weight_valid_set",
+        Box::new(can_run),
+        Box::new(test_cpu_weight_valid_set),
+    );
+
+    let test_cpu_weight_zero_ignored = ConditionalTest::new(
+        "test_cpu_weight_zero_ignored",
+        Box::new(can_run),
+        Box::new(test_cpu_weight_zero_ignored),
+    );
+
+    let test_cpu_weight_too_high_maximum_set = ConditionalTest::new(
+        "test_cpu_weight_too_high_maximum_set",
+        Box::new(can_run),
+        Box::new(test_cpu_weight_too_high_maximum_set),
+    );
+
+    let test_cpu_quota_valid_set = ConditionalTest::new(
+        "test_cpu_quota_valid_set",
+        Box::new(can_run),
+        Box::new(test_cpu_quota_valid_set),
+    );
+
+    let test_cpu_quota_unspecified_unchanged = ConditionalTest::new(
+        "test_cpu_quota_unspecified_unchanged",
+        Box::new(can_run),
+        Box::new(test_cpu_quota_unspecified_unchanged),
+    );
+
+    let test_cpu_quota_negative_value_default_set = ConditionalTest::new(
+        "test_cpu_quota_negative_value_default_set",
+        Box::new(can_run),
+        Box::new(test_cpu_quota_negative_value_default_set),
+    );
+
+    let test_cpu_period_valid_set = ConditionalTest::new(
+        "test_cpu_period_valid_set",
+        Box::new(can_run),
+        Box::new(test_cpu_period_valid_set),
+    );
+
+    let test_cpu_period_unspecified_unchanged = ConditionalTest::new(
+        "test_cpu_period_unspecified_unchanged",
+        Box::new(can_run),
+        Box::new(test_cpu_period_unspecified_unchanged),
+    );
+
+    let test_cpu_period_negative_value_default_set = ConditionalTest::new(
+        "test_cpu_period_negative_value_default_set",
+        Box::new(can_run),
+        Box::new(test_cpu_period_negative_value_default_set),
+    );
+
+    test_group.add(vec![
+        Box::new(test_cpu_weight_valid_set),
+        Box::new(test_cpu_weight_zero_ignored),
+        Box::new(test_cpu_weight_too_high_maximum_set),
+        Box::new(test_cpu_quota_valid_set),
+        Box::new(test_cpu_quota_unspecified_unchanged),
+        Box::new(test_cpu_quota_negative_value_default_set),
+        // Box::new(test_cpu_period_valid_set),
+        // Box::new(test_cpu_period_unspecified_unchanged),
+        // Box::new(test_cpu_period_negative_value_default_set),
+    ]);
+    test_group
 }

--- a/crates/integration_test/src/tests/cgroups/mod.rs
+++ b/crates/integration_test/src/tests/cgroups/mod.rs
@@ -28,7 +28,7 @@ pub fn cleanup_v2() -> Result<()> {
             .filter_map(|e| e.ok())
             .map(|e| e.path())
             .filter(|e| e.is_dir())
-            .map(|e| fs::remove_dir(e))
+            .map(fs::remove_dir)
             .collect();
 
         fs::remove_dir(&runtime_test)

--- a/crates/integration_test/src/tests/cgroups/mod.rs
+++ b/crates/integration_test/src/tests/cgroups/mod.rs
@@ -4,7 +4,7 @@ use anyhow::{Context, Result};
 use procfs::process::Process;
 use std::fs;
 
-pub mod cpus;
+pub mod cpu;
 pub mod memory;
 pub mod pids;
 

--- a/crates/libcgroups/src/v2/controller_type.rs
+++ b/crates/libcgroups/src/v2/controller_type.rs
@@ -1,6 +1,6 @@
 use std::fmt::Display;
 
-#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub enum ControllerType {
     Cpu,
     CpuSet,

--- a/crates/libcgroups/src/v2/cpu.rs
+++ b/crates/libcgroups/src/v2/cpu.rs
@@ -13,7 +13,6 @@ use super::controller::Controller;
 const CGROUP_CPU_WEIGHT: &str = "cpu.weight";
 const CGROUP_CPU_MAX: &str = "cpu.max";
 const UNRESTRICTED_QUOTA: &str = "max";
-const DEFAULT_PERIOD: &str = "100000";
 const MAX_CPU_WEIGHT: u64 = 10000;
 
 const CPU_STAT: &str = "cpu.stat";

--- a/crates/libcgroups/src/v2/cpu.rs
+++ b/crates/libcgroups/src/v2/cpu.rs
@@ -14,6 +14,7 @@ const CGROUP_CPU_WEIGHT: &str = "cpu.weight";
 const CGROUP_CPU_MAX: &str = "cpu.max";
 const DEFAULT_PERIOD: &str = "100000";
 const UNRESTRICTED_QUOTA: &str = "max";
+const MAX_CPU_WEIGHT: u64 = 10000;
 
 const CPU_STAT: &str = "cpu.stat";
 
@@ -99,7 +100,8 @@ impl Cpu {
             return 0;
         }
 
-        1 + ((shares - 2) * 9999) / 262142
+        let weight = 1 + ((shares - 2) * 9999) / 262142;
+        weight.min(MAX_CPU_WEIGHT)
     }
 
     fn is_realtime_requested(cpu: &LinuxCpu) -> bool {

--- a/crates/libcgroups/src/v2/cpu.rs
+++ b/crates/libcgroups/src/v2/cpu.rs
@@ -120,7 +120,7 @@ impl Cpu {
         if let Some(old_quota) = old_cpu_max.split_whitespace().next() {
             return Ok(Some(format!("{} {}", old_quota, period).into()));
         }
-        return Ok(None);
+        Ok(None)
     }
 }
 
@@ -176,10 +176,7 @@ mod tests {
         // assert
         let content = fs::read_to_string(max)
             .unwrap_or_else(|_| panic!("read {} file content", CGROUP_CPU_MAX));
-        assert_eq!(
-            content,
-            format!("{}", UNRESTRICTED_QUOTA)
-        )
+        assert_eq!(content, UNRESTRICTED_QUOTA)
     }
 
     #[test]

--- a/crates/libcgroups/src/v2/cpu.rs
+++ b/crates/libcgroups/src/v2/cpu.rs
@@ -1,5 +1,5 @@
 use anyhow::{bail, Context, Result};
-use std::path::Path;
+use std::{borrow::Cow, path::Path};
 
 use crate::{
     common::{self, ControllerOpt},
@@ -12,8 +12,8 @@ use super::controller::Controller;
 
 const CGROUP_CPU_WEIGHT: &str = "cpu.weight";
 const CGROUP_CPU_MAX: &str = "cpu.max";
-const DEFAULT_PERIOD: &str = "100000";
 const UNRESTRICTED_QUOTA: &str = "max";
+const DEFAULT_PERIOD: &str = "100000";
 const MAX_CPU_WEIGHT: u64 = 10000;
 
 const CPU_STAT: &str = "cpu.stat";
@@ -70,27 +70,27 @@ impl Cpu {
             }
         }
 
-        // if quota is unrestricted set to 'max'
-        let mut quota_string = UNRESTRICTED_QUOTA.to_owned();
-        if let Some(quota) = cpu.quota() {
-            if quota > 0 {
-                quota_string = quota.to_string();
+        let cpu_max_file = path.join(CGROUP_CPU_MAX);
+        let new_cpu_max: Option<Cow<str>> = match (cpu.quota(), cpu.period()) {
+            (None, Some(period)) => Self::create_period_only_value(&cpu_max_file, period)?,
+            (Some(quota), None) if quota >= 0 => Some(quota.to_string().into()),
+            (Some(quota), None) if quota < 0 => Some(UNRESTRICTED_QUOTA.into()),
+            (Some(quota), Some(period)) if quota >= 0 => {
+                Some(format!("{} {}", quota, period).into())
             }
-        }
-
-        let mut period_string: String = DEFAULT_PERIOD.to_owned();
-        if let Some(period) = cpu.period() {
-            if period > 0 {
-                period_string = period.to_string();
+            (Some(quota), Some(period)) if quota < 0 => {
+                Some(format!("{} {}", UNRESTRICTED_QUOTA, period).into())
             }
-        }
+            _ => None,
+        };
 
         // format is 'quota period'
         // the kernel default is 'max 100000'
         // 250000 250000 -> 1 CPU worth of runtime every 250ms
         // 10000 50000 -> 20% of one CPU every 50ms
-        let max = quota_string + " " + &period_string;
-        common::write_cgroup_file_str(path.join(CGROUP_CPU_MAX), &max)?;
+        if let Some(cpu_max) = new_cpu_max {
+            common::write_cgroup_file_str(&cpu_max_file, &cpu_max)?;
+        }
 
         Ok(())
     }
@@ -115,6 +115,14 @@ impl Cpu {
 
         false
     }
+
+    fn create_period_only_value(cpu_max_file: &Path, period: u64) -> Result<Option<Cow<str>>> {
+        let old_cpu_max = common::read_cgroup_file(cpu_max_file)?;
+        if let Some(old_quota) = old_cpu_max.split_whitespace().next() {
+            return Ok(Some(format!("{} {}", old_quota, period).into()));
+        }
+        return Ok(None);
+    }
 }
 
 #[cfg(test)]
@@ -125,7 +133,7 @@ mod tests {
     use std::fs;
 
     #[test]
-    fn test_set_shares() {
+    fn test_set_valid_shares() {
         // arrange
         let (tmp, weight) = setup("test_set_shares", CGROUP_CPU_WEIGHT);
         let _ = set_fixture(&tmp, CGROUP_CPU_MAX, "")
@@ -154,14 +162,14 @@ mod tests {
         // assert
         let content = fs::read_to_string(max)
             .unwrap_or_else(|_| panic!("read {} file content", CGROUP_CPU_MAX));
-        assert_eq!(content, format!("{} {}", QUOTA, DEFAULT_PERIOD))
+        assert_eq!(content, format!("{}", QUOTA))
     }
 
     #[test]
-    fn test_set_zero_quota() {
+    fn test_set_negative_quota() {
         // arrange
-        let (tmp, max) = setup("test_set_zero_quota", CGROUP_CPU_MAX);
-        let cpu = LinuxCpuBuilder::default().quota(0).build().unwrap();
+        let (tmp, max) = setup("test_set_negative_quota", CGROUP_CPU_MAX);
+        let cpu = LinuxCpuBuilder::default().quota(-500).build().unwrap();
 
         // act
         Cpu::apply(&tmp, &cpu).expect("apply cpu");
@@ -171,15 +179,17 @@ mod tests {
             .unwrap_or_else(|_| panic!("read {} file content", CGROUP_CPU_MAX));
         assert_eq!(
             content,
-            format!("{} {}", UNRESTRICTED_QUOTA, DEFAULT_PERIOD)
+            format!("{}", UNRESTRICTED_QUOTA)
         )
     }
 
     #[test]
     fn test_set_positive_period() {
         // arrange
+        const QUOTA: u64 = 50000;
         const PERIOD: u64 = 100000;
         let (tmp, max) = setup("test_set_positive_period", CGROUP_CPU_MAX);
+        common::write_cgroup_file(&max, QUOTA).unwrap();
         let cpu = LinuxCpuBuilder::default().period(PERIOD).build().unwrap();
 
         // act
@@ -188,25 +198,7 @@ mod tests {
         // assert
         let content = fs::read_to_string(max)
             .unwrap_or_else(|_| panic!("read {} file content", CGROUP_CPU_MAX));
-        assert_eq!(content, format!("{} {}", UNRESTRICTED_QUOTA, PERIOD))
-    }
-
-    #[test]
-    fn test_set_zero_period() {
-        // arrange
-        let (tmp, max) = setup("test_set_zero_period", CGROUP_CPU_MAX);
-        let cpu = LinuxCpuBuilder::default().period(0u64).build().unwrap();
-
-        // act
-        Cpu::apply(&tmp, &cpu).expect("apply cpu");
-
-        // assert
-        let content = fs::read_to_string(max)
-            .unwrap_or_else(|_| panic!("read {} file content", CGROUP_CPU_MAX));
-        assert_eq!(
-            content,
-            format!("{} {}", UNRESTRICTED_QUOTA, DEFAULT_PERIOD)
-        );
+        assert_eq!(content, format!("{} {}", QUOTA, PERIOD))
     }
 
     #[test]

--- a/crates/libcgroups/src/v2/util.rs
+++ b/crates/libcgroups/src/v2/util.rs
@@ -19,7 +19,8 @@ pub fn get_unified_mount_point() -> Result<PathBuf> {
         .ok_or_else(|| anyhow!("could not find mountpoint for unified"))
 }
 
-pub fn get_available_controllers(root_path: &Path) -> Result<Vec<ControllerType>> {
+pub fn get_available_controllers<P: AsRef<Path>>(root_path: P) -> Result<Vec<ControllerType>> {
+    let root_path = root_path.as_ref();
     let controllers_path = root_path.join(CGROUP_CONTROLLERS);
     if !controllers_path.exists() {
         bail!(

--- a/crates/test_framework/src/testable.rs
+++ b/crates/test_framework/src/testable.rs
@@ -82,23 +82,34 @@ macro_rules! assert_result_eq {
 }
 
 #[doc(hidden)]
-pub fn assert_failed<T, U>(expected: &T, actual: &U, args: Option<std::fmt::Arguments<'_>>) -> Result<()>
+pub fn assert_failed<T, U>(
+    expected: &T,
+    actual: &U,
+    args: Option<std::fmt::Arguments<'_>>,
+) -> Result<()>
 where
     T: Debug + ?Sized,
     U: Debug + ?Sized,
 {
     match args {
         Some(args) => {
-            bail!(r#"assertion failed:
+            bail!(
+                r#"assertion failed:
             expected: `{:?}`,
             actual: `{:?}`: {}"#,
-            expected, actual, args)
-        },
+                expected,
+                actual,
+                args
+            )
+        }
         None => {
-            bail!(r#"assertion failed:
+            bail!(
+                r#"assertion failed:
             expected: `{:?}`,
             actual: `{:?}`"#,
-            expected, actual)
+                expected,
+                actual
+            )
         }
     }
 }

--- a/crates/test_framework/src/testable.rs
+++ b/crates/test_framework/src/testable.rs
@@ -61,9 +61,9 @@ macro_rules! assert_result_eq {
         match (&$expected, &$actual) {
             (expected_val, actual_val) => {
                 if !(*expected_val == *actual_val) {
-                   return test_framework::testable::assert_failed(&*expected_val, &*actual_val, std::option::Option::None);
+                   test_framework::testable::assert_failed(&*expected_val, &*actual_val, std::option::Option::None)
                 } else {
-                    return Ok(())
+                    Ok(())
                 }
             }
         }
@@ -72,9 +72,9 @@ macro_rules! assert_result_eq {
         match (&$expected, &$actual) {
             (expected_val, actual_val) => {
                 if !(*expected_val == *actual_val) {
-                    return test_framework::testable::assert_failed(&*expected_val, &*actual_val, std::option::Option::Some(format_args!($($arg)+)));
+                    test_framework::testable::assert_failed(&*expected_val, &*actual_val, std::option::Option::Some(format_args!($($arg)+)))
                 } else {
-                    return Ok(())
+                    Ok(())
                 }
             }
         }


### PR DESCRIPTION
Extends our integration with tests for cpu resource restrictions on cgroup v2 systems. It also enables logging for the tests in case you need to debug them.