### PR TITLE
Update version for runc compatibility for Moby

### DIFF
--- a/crates/youki/Cargo.toml
+++ b/crates/youki/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.0.1"
 authors = ["youki team"]
 edition = "2021"
 description = "A container runtime written in Rust"
+build = "build.rs"
 
 [dependencies.clap]
 version = "3.0.0-beta.5"
@@ -12,7 +13,7 @@ features = ["std", "suggestions", "derive", "cargo"]
 
 
 [dependencies]
-anyhow = "1.0"
+anyhow = "1.0.51"
 chrono = { version="0.4", features = ["serde"] }
 libcgroups = { path = "../libcgroups" }
 libcontainer = { path = "../libcontainer" }
@@ -31,3 +32,6 @@ clap_generate = { version = "3.0.0-beta.5" }
 [dev-dependencies]
 serial_test = "0.5.1"
 
+[build-dependencies]
+anyhow = "1.0.51"
+vergen = "6.0"

--- a/crates/youki/build.rs
+++ b/crates/youki/build.rs
@@ -1,0 +1,8 @@
+use anyhow::Result;
+use vergen::{vergen, Config, ShaKind};
+
+fn main() -> Result<()> {
+    let mut config = Config::default();
+    *config.git_mut().sha_kind_mut() = ShaKind::Short;
+    vergen(config)
+}

--- a/crates/youki/src/main.rs
+++ b/crates/youki/src/main.rs
@@ -25,7 +25,7 @@ use liboci_cli::{CommonCmd, GlobalOpts, StandardCmd};
 // This takes global options as well as individual commands as specified in [OCI runtime-spec](https://github.com/opencontainers/runtime-spec/blob/master/runtime.md)
 // Also check [runc commandline documentation](https://github.com/opencontainers/runc/blob/master/man/runc.8.md) for more explanation
 #[derive(Parser, Debug)]
-#[clap(version = crate_version!(), author = "youki team")]
+#[clap(version = youki_version!(), author = env!("CARGO_PKG_AUTHORS"))]
 struct Opts {
     #[clap(flatten)]
     global: GlobalOpts,
@@ -47,6 +47,23 @@ enum SubCommand {
     // Youki specific extensions
     Info(info::Info),
     Completion(commands::completion::Completion),
+}
+
+/// output Youki version in Moby compatible format
+#[macro_export]
+macro_rules! youki_version {
+    // For compatibility with Moby, match format here:
+    // https://github.com/moby/moby/blob/65cc84abc522a564699bb171ca54ea1857256d10/daemon/info_unix.go#L280
+    () => {
+        concat!(
+            "version ",
+            crate_version!(),
+            "\ncommit: ",
+            crate_version!(),
+            "-0-",
+            env!("VERGEN_GIT_SHA_SHORT")
+        )
+    };
 }
 
 /// This is the entry point in the container runtime. The binary is run by a high-level container runtime,


### PR DESCRIPTION
Update version for compatibility with Moby. Fix for #529.

![image](https://user-images.githubusercontent.com/9849069/145698386-aff278bc-6b40-4d39-8873-3b3a00f0b531.png)
