### PR TITLE
Update mdbook docs and Add doc link in the Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,9 +121,8 @@ youki is not at the practical stage yet. However, it is getting closer to practi
 |    OCI Compliance     |        Compliance with OCI Runtime Spec         |                                 ✅ 50 out of 50 test cases passing                                  |
 
 # Design and implementation of youki
-![sequence diagram of youki](docs/.drawio.svg)
 
-More details are in the works [#14](https://github.com/containers/youki/issues/14)
+The User and Developer Documentation for youki is hosted at [https://containers.github.io/youki/](https://containers.github.io/youki/)
 
 # Getting Started
 

--- a/docs/src/developer/documentation_mdbook.md
+++ b/docs/src/developer/documentation_mdbook.md
@@ -4,17 +4,23 @@ This documentation is created using mdbook and aims to provide a concise referen
 
 Please make sure that you update this documentation along with newly added features and resources that you found helpful while developing, so that it will be helpful for newcomers.
 
-TODO, update after deciding the final way to host the mdbook
-To compile and deploy this mdbook follow the instructions
+Currently this documentation is hosted at [https://containers.github.io/youki/](https://containers.github.io/youki/), using GitHub pages. GitHub CI actions are used to automatically check if any files are changed in /docs on each push / PR merge to main branch, and if there are any changes, the mdbook is build and deployed to gh-pages. We use [https://github.com/peaceiris/actions-mdbook](https://github.com/peaceiris/actions-mdbook) to build and then [https://github.com/peaceiris/actions-gh-pages](https://github.com/peaceiris/actions-gh-pages) GitHub action to deploy the mdbook.
 
-```
-git worktree add /tmp/book -b gh-pages
+When testing locally you can manually test the changes by running `mdbook serve` in the docs directory (after installing mdbook), which will temporarily serve the mdbook at `localhost:3000` by default. You can check the mdbook documentation for more information.
+
+If you want to test it using gh-pages on your own fork, you can use following steps in the docs directory.
+
+```console
+git worktree prune
+# Do this if you are running this command first time after booting,
+# As after shutdown /tmp files are removed
+git branch -D gh-pages && git worktree add /tmp/book -b gh-pages
 mdbook build
 rm -rf /tmp/book/* # this won't delete the .git directory
 cp -rp book/* /tmp/book/
 cd /tmp/book
 git add -A
 git commit 'new book message'
-git push origin gh-pages
+git push -f origin gh-pages
 cd -
 ```


### PR DESCRIPTION
This adds the final documentation for the mdbook documentation itself, as well as adds the link for it in the Readme