### PR TITLE
Resolved `needs_to_handle` TODO's

### DIFF
--- a/crates/libcgroups/src/v1/manager.rs
+++ b/crates/libcgroups/src/v1/manager.rs
@@ -71,8 +71,8 @@ impl Manager {
                 CtrlType::CpuSet => CpuSet::needs_to_handle(controller_opt).is_some(),
                 CtrlType::Devices => Devices::needs_to_handle(controller_opt).is_some(),
                 CtrlType::HugeTlb => HugeTlb::needs_to_handle(controller_opt).is_some(),
-                CtrlType::Memory => controller_opt.resources.memory().is_some(), // TODO: Fix Memory::need_to_handle
-                CtrlType::Pids => controller_opt.resources.pids().is_some(), // TODO: Fix Pids::need_to_handle
+                CtrlType::Memory => Memory::needs_to_handle(controller_opt).is_some(),
+                CtrlType::Pids => Pids::needs_to_handle(controller_opt).is_some(),
                 CtrlType::PerfEvent => PerfEvent::needs_to_handle(controller_opt).is_some(),
                 CtrlType::Blkio => Blkio::needs_to_handle(controller_opt).is_some(),
                 CtrlType::NetworkPriority => {

--- a/crates/libcgroups/src/v1/memory.rs
+++ b/crates/libcgroups/src/v1/memory.rs
@@ -101,13 +101,8 @@ impl Controller for Memory {
         Ok(())
     }
 
-    fn needs_to_handle<'a>(_controller_opt: &'a ControllerOpt) -> Option<&'a Self::Resource> {
-        // TODO: fix compile error
-        // error[E0515]: cannot return value referencing temporary value
-        // if let Some(memory) = &controller_opt.resources.memory() {
-        //     return Some(memory);
-        // }
-        None
+    fn needs_to_handle<'a>(controller_opt: &'a ControllerOpt) -> Option<&'a Self::Resource> {
+        controller_opt.resources.memory().as_ref()
     }
 }
 

--- a/crates/libcgroups/src/v1/pids.rs
+++ b/crates/libcgroups/src/v1/pids.rs
@@ -27,14 +27,8 @@ impl Controller for Pids {
         Ok(())
     }
 
-    fn needs_to_handle<'a>(_controller_opt: &'a ControllerOpt) -> Option<&'a Self::Resource> {
-        // TODO: fix compile error
-        // error[E0515]: cannot return value referencing temporary value
-        // if let Some(pids) = &controller_opt.resources.pids() {
-        //     return Some(pids);
-        // }
-
-        None
+    fn needs_to_handle<'a>(controller_opt: &'a ControllerOpt) -> Option<&'a Self::Resource> {
+        controller_opt.resources.pids().as_ref()
     }
 }
 

--- a/crates/libcontainer/src/container/builder.rs
+++ b/crates/libcontainer/src/container/builder.rs
@@ -25,7 +25,7 @@ pub struct ContainerBuilder<'a> {
 ///
 /// ```no_run
 /// use libcontainer::container::builder::ContainerBuilder;
-/// use libcontainer::syscall::syscall::create_syscall;;
+/// use libcontainer::syscall::syscall::create_syscall;
 ///
 /// ContainerBuilder::new("74f1a4cb3801".to_owned(), create_syscall().as_ref())
 /// .with_root_path("/run/containers/youki")
@@ -42,7 +42,7 @@ impl<'a> ContainerBuilder<'a> {
     ///
     /// ```no_run
     /// use libcontainer::container::builder::ContainerBuilder;
-    /// use libcontainer::syscall::syscall::create_syscall;;
+    /// use libcontainer::syscall::syscall::create_syscall;
     ///
     /// let builder = ContainerBuilder::new("74f1a4cb3801".to_owned(), create_syscall().as_ref());
     /// ```

--- a/crates/libcontainer/src/container/container_delete.rs
+++ b/crates/libcontainer/src/container/container_delete.rs
@@ -14,7 +14,7 @@ impl Container {
     ///
     /// ```no_run
     /// use libcontainer::container::builder::ContainerBuilder;
-    /// use libcontainer::syscall::syscall::create_syscall;;
+    /// use libcontainer::syscall::syscall::create_syscall;
     ///
     /// # fn main() -> anyhow::Result<()> {
     /// let mut container = ContainerBuilder::new("74f1a4cb3801".to_owned(), create_syscall().as_ref())

--- a/crates/libcontainer/src/container/container_events.rs
+++ b/crates/libcontainer/src/container/container_events.rs
@@ -10,7 +10,7 @@ impl Container {
     ///
     /// ```no_run
     /// use libcontainer::container::builder::ContainerBuilder;
-    /// use libcontainer::syscall::syscall::create_syscall;;
+    /// use libcontainer::syscall::syscall::create_syscall;
     ///
     /// # fn main() -> anyhow::Result<()> {
     /// let mut container = ContainerBuilder::new("74f1a4cb3801".to_owned(), create_syscall().as_ref())

--- a/crates/libcontainer/src/container/container_kill.rs
+++ b/crates/libcontainer/src/container/container_kill.rs
@@ -10,7 +10,7 @@ impl Container {
     ///
     /// ```no_run
     /// use libcontainer::container::builder::ContainerBuilder;
-    /// use libcontainer::syscall::syscall::create_syscall;;
+    /// use libcontainer::syscall::syscall::create_syscall;
     /// use nix::sys::signal::Signal;
     ///
     /// # fn main() -> anyhow::Result<()> {

--- a/crates/libcontainer/src/container/container_pause.rs
+++ b/crates/libcontainer/src/container/container_pause.rs
@@ -9,7 +9,7 @@ impl Container {
     ///
     /// ```no_run
     /// use libcontainer::container::builder::ContainerBuilder;
-    /// use libcontainer::syscall::syscall::create_syscall;;
+    /// use libcontainer::syscall::syscall::create_syscall;
     ///
     /// # fn main() -> anyhow::Result<()> {
     /// let mut container = ContainerBuilder::new("74f1a4cb3801".to_owned(), create_syscall().as_ref())

--- a/crates/libcontainer/src/container/container_resume.rs
+++ b/crates/libcontainer/src/container/container_resume.rs
@@ -10,7 +10,7 @@ impl Container {
     ///
     /// ```no_run
     /// use libcontainer::container::builder::ContainerBuilder;
-    /// use libcontainer::syscall::syscall::create_syscall;;
+    /// use libcontainer::syscall::syscall::create_syscall;
     ///
     /// # fn main() -> anyhow::Result<()> {
     /// let mut container = ContainerBuilder::new("74f1a4cb3801".to_owned(), create_syscall().as_ref())

--- a/crates/libcontainer/src/container/container_start.rs
+++ b/crates/libcontainer/src/container/container_start.rs
@@ -15,7 +15,7 @@ impl Container {
     ///
     /// ```no_run
     /// use libcontainer::container::builder::ContainerBuilder;
-    /// use libcontainer::syscall::syscall::create_syscall;;
+    /// use libcontainer::syscall::syscall::create_syscall;
     ///
     /// # fn main() -> anyhow::Result<()> {
     /// let mut container = ContainerBuilder::new("74f1a4cb3801".to_owned(), create_syscall().as_ref())


### PR DESCRIPTION
The compiler error mentioned in the TODO doesn't occur in any version of rust that can use the 2021 edition.
Ran `cargo test` on the following versions without getting any errors:
- 1.56.0
- 1.56.1
- 1.57.0
- 1.58.0-beta.2 (0e07bcb68 2021-12-04)
- 1.59.0-nightly (51e8031e1 2021-12-25)