### PR TITLE
Interpret a cpu quota of zero as default value

### DIFF
--- a/crates/integration_test/src/tests/cgroups/cpu/v2.rs
+++ b/crates/integration_test/src/tests/cgroups/cpu/v2.rs
@@ -112,6 +112,26 @@ fn test_cpu_quota_valid_set() -> TestResult {
     })
 }
 
+/// Tests if the cpu quota is the defalt value (max) if a cpu quota of zero has been specified
+fn test_cpu_quota_zero_default_set() -> TestResult {
+    let cpu_quota = 0;
+    let cpu = test_result!(LinuxCpuBuilder::default()
+        .quota(cpu_quota)
+        .build()
+        .context("build cpu spec"));
+
+    let spec = test_result!(create_spec("test_cpu_quota_zero_default_set", cpu));
+    test_outside_container(spec, &|data| {
+        test_result!(check_container_created(&data));
+        test_result!(check_cpu_max(
+            "test_cpu_quota_zero_default_set",
+            i64::MAX,
+            DEFAULT_PERIOD
+        ));
+        TestResult::Passed
+    })
+}
+
 /// Tests if the cpu quota is the default value (max) if a negative cpu quota has been specified
 fn test_cpu_quota_negative_default_set() -> TestResult {
     let cpu_quota = -9999;
@@ -342,6 +362,12 @@ pub fn get_test_group<'a>() -> TestGroup<'a> {
         Box::new(test_cpu_quota_valid_set),
     );
 
+    let test_cpu_quota_zero_default_set = ConditionalTest::new(
+        "test_cpu_quota_zero_default_set",
+        Box::new(can_run),
+        Box::new(test_cpu_quota_zero_default_set),
+    );
+
     let test_cpu_quota_negative_default_set = ConditionalTest::new(
         "test_cpu_quota_negative_value_default_set",
         Box::new(can_run),
@@ -371,6 +397,7 @@ pub fn get_test_group<'a>() -> TestGroup<'a> {
         Box::new(test_cpu_weight_zero_ignored),
         Box::new(test_cpu_weight_too_high_maximum_set),
         Box::new(test_cpu_quota_valid_set),
+        Box::new(test_cpu_quota_zero_default_set),
         Box::new(test_cpu_quota_negative_default_set),
         Box::new(test_cpu_period_valid_set),
         Box::new(test_cpu_period_unspecified_unchanged),

--- a/crates/libcgroups/src/v2/cpu.rs
+++ b/crates/libcgroups/src/v2/cpu.rs
@@ -72,12 +72,12 @@ impl Cpu {
         let cpu_max_file = path.join(CGROUP_CPU_MAX);
         let new_cpu_max: Option<Cow<str>> = match (cpu.quota(), cpu.period()) {
             (None, Some(period)) => Self::create_period_only_value(&cpu_max_file, period)?,
-            (Some(quota), None) if quota >= 0 => Some(quota.to_string().into()),
-            (Some(quota), None) if quota < 0 => Some(UNRESTRICTED_QUOTA.into()),
-            (Some(quota), Some(period)) if quota >= 0 => {
+            (Some(quota), None) if quota > 0 => Some(quota.to_string().into()),
+            (Some(quota), None) if quota <= 0 => Some(UNRESTRICTED_QUOTA.into()),
+            (Some(quota), Some(period)) if quota > 0 => {
                 Some(format!("{} {}", quota, period).into())
             }
-            (Some(quota), Some(period)) if quota < 0 => {
+            (Some(quota), Some(period)) if quota <= 0 => {
                 Some(format!("{} {}", UNRESTRICTED_QUOTA, period).into())
             }
             _ => None,


### PR DESCRIPTION
Runc interpretes a cpu quota of zero as an instruction to set the default value for cpu quota. As runtimes like CRI-O [depend](https://github.com/containers/youki/issues/78#issuecomment-1001039717) on this behavior we should do the same.