### PR TITLE
Add option to list test groups

### DIFF
--- a/crates/integration_test/run_tests.sh
+++ b/crates/integration_test/run_tests.sh
@@ -10,7 +10,7 @@ if [[ -n "$1" ]]; then
 fi
 logfile="./test_log.log"
 touch $logfile
-sudo ./youki_integration_test -r $RUNTIME > $logfile
+sudo ./youki_integration_test run -r $RUNTIME > $logfile
 if [ 0 -ne $(grep "not ok" $logfile | wc -l ) ]; then
     cat $logfile
     exit 1

--- a/crates/integration_test/src/main.rs
+++ b/crates/integration_test/src/main.rs
@@ -7,7 +7,7 @@ use crate::tests::pidfile::get_pidfile_test;
 use crate::tests::seccomp_notify::get_seccomp_notify_test;
 use crate::tests::tlb::get_tlb_test;
 use crate::utils::support::set_runtime_path;
-use anyhow::Result;
+use anyhow::{Context, Result};
 use clap::Parser;
 use integration_test::logger;
 use std::path::PathBuf;
@@ -17,6 +17,22 @@ use tests::cgroups;
 #[derive(Parser, Debug)]
 #[clap(version = "0.0.1", author = "youki team")]
 struct Opts {
+    /// Enables debug output
+    #[clap(short, long)]
+    debug: bool,
+
+    #[clap(subcommand)]
+    command: SubCommand,
+}
+
+#[derive(Parser, Debug)]
+enum SubCommand {
+    Run(Run),
+    List,
+}
+
+#[derive(Parser, Debug)]
+struct Run {
     /// Path for the container runtime to be tested
     #[clap(short, long)]
     runtime: PathBuf,
@@ -25,9 +41,6 @@ struct Opts {
     /// -t group1::test1,test3 group2 group3::test5
     #[clap(short, long, multiple_values = true, value_delimiter = ' ')]
     tests: Option<Vec<String>>,
-    /// Enables debug output
-    #[clap(short, long)]
-    debug: bool,
 }
 
 // parse test string given in commandline option as pair of testgroup name and tests belonging to that
@@ -52,18 +65,6 @@ fn main() -> Result<()> {
         eprintln!("logger could not be initialized: {:?}", e);
     }
 
-    match std::fs::canonicalize(&opts.runtime) {
-        // runtime path is relative or resolved correctly
-        Ok(path) => set_runtime_path(&path),
-        // runtime path is name of program which probably exists in $PATH
-        Err(_) => match which::which(opts.runtime) {
-            Ok(path) => set_runtime_path(&path),
-            Err(e) => {
-                eprintln!("Error in finding runtime : {}\nexiting.", e);
-                std::process::exit(66);
-            }
-        },
-    }
     let mut tm = TestManager::new();
 
     let cl = ContainerLifecycle::new();
@@ -95,11 +96,42 @@ fn main() -> Result<()> {
     tm.add_cleanup(Box::new(cgroups::cleanup_v1));
     tm.add_cleanup(Box::new(cgroups::cleanup_v2));
 
-    if let Some(tests) = opts.tests {
-        let tests_to_run = parse_tests(&tests);
-        tm.run_selected(tests_to_run);
-    } else {
-        tm.run_all();
+    match &opts.command {
+        SubCommand::Run(args) => run(args, &tm).context("run tests")?,
+        SubCommand::List => list(&tm).context("list tests")?,
     }
+
+    Ok(())
+}
+
+fn run(opts: &Run, test_manager: &TestManager) -> Result<()> {
+    match std::fs::canonicalize(&opts.runtime) {
+        // runtime path is relative or resolved correctly
+        Ok(path) => set_runtime_path(&path),
+        // runtime path is name of program which probably exists in $PATH
+        Err(_) => match which::which(&opts.runtime) {
+            Ok(path) => set_runtime_path(&path),
+            Err(e) => {
+                eprintln!("Error in finding runtime : {}\nexiting.", e);
+                std::process::exit(66);
+            }
+        },
+    }
+
+    if let Some(tests) = &opts.tests {
+        let tests_to_run = parse_tests(tests);
+        test_manager.run_selected(tests_to_run);
+    } else {
+        test_manager.run_all();
+    }
+
+    Ok(())
+}
+
+fn list(test_manager: &TestManager) -> Result<()> {
+    for test_group in test_manager.tests_groups() {
+        println!("{}", test_group);
+    }
+
     Ok(())
 }

--- a/crates/test_framework/src/test_manager.rs
+++ b/crates/test_framework/src/test_manager.rs
@@ -105,4 +105,8 @@ impl<'a> TestManager<'a> {
             }
         }
     }
+
+    pub fn tests_groups(&self) -> Vec<String> {
+        self.test_groups.iter().map(|tg| tg.0.to_string()).collect()
+    }
 }


### PR DESCRIPTION
When I only want to run specific tests, I have to look up the test group name in the code, which is inconvenient. This adds a command to the integration test executable to list all test groups.