### PR TITLE
Add gitpod as development option

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,0 +1,9 @@
+FROM gitpod/workspace-full
+
+RUN sudo apt-get update && sudo apt-get install -y \
+      pkg-config \
+      libsystemd-dev \
+      libdbus-1-dev \
+      build-essential \
+      libelf-dev \
+      libseccomp-dev

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,9 @@
+image:
+  file: .gitpod.Dockerfile
+tasks:
+  - name: Build
+    init: cargo build 
+github:
+  prebuilds:
+    pullRequestsFromForks: true
+    addBadge: true

--- a/README.md
+++ b/README.md
@@ -127,7 +127,9 @@ The User and Developer Documentation for youki is hosted at [https://containers.
 # Getting Started
 
 Local build is only supported on Linux.
-For other platforms, please use [Vagrantfile](#setting-up-vagrant) that we prepared.
+For other platforms, please use the [Vagrantfile](#setting-up-vagrant) that we have prepared. You can also spin up a fully preconfigured development environment in the cloud with gitpod.
+
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/containers/youki)
 
 ## Requires
 


### PR DESCRIPTION
@utam0k Do you have permissions to install the [app](https://github.com/apps/gitpod-io) for this repository? Then we could also enable prebuilds.

<a href="https://gitpod.io/#https://github.com/containers/youki/pull/576"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

