### PR TITLE
Add `create` integration tests.

### DIFF
--- a/crates/integration_test/src/main.rs
+++ b/crates/integration_test/src/main.rs
@@ -1,6 +1,7 @@
 mod tests;
 mod utils;
 
+use crate::tests::create::get_create_test_group;
 use crate::tests::lifecycle::{ContainerCreate, ContainerLifecycle};
 use crate::tests::linux_ns_itype::get_ns_itype_tests;
 use crate::tests::pidfile::get_pidfile_test;
@@ -79,6 +80,7 @@ fn main() -> Result<()> {
     let cgroup_v1_network = cgroups::network::get_test_group();
     let cgroup_v1_blkio = cgroups::blkio::get_test_group();
     let seccomp_notify = get_seccomp_notify_test();
+    let create = get_create_test_group();
 
     tm.add_test_group(&cl);
     tm.add_test_group(&cc);
@@ -92,6 +94,7 @@ fn main() -> Result<()> {
     tm.add_test_group(&cgroup_v1_network);
     tm.add_test_group(&cgroup_v1_blkio);
     tm.add_test_group(&seccomp_notify);
+    tm.add_test_group(&create);
 
     tm.add_cleanup(Box::new(cgroups::cleanup_v1));
     tm.add_cleanup(Box::new(cgroups::cleanup_v2));

--- a/crates/integration_test/src/tests/create.rs
+++ b/crates/integration_test/src/tests/create.rs
@@ -1,0 +1,1 @@
+// Our create module.

--- a/crates/integration_test/src/tests/create.rs
+++ b/crates/integration_test/src/tests/create.rs
@@ -1,1 +1,51 @@
-// Our create module.
+use test_framework::{Test, TestGroup, TestResult};
+
+// runtime should not create container with empty id
+fn create_empty_id() -> TestResult {
+    // let temp = create::create(&self.project_path, "");
+    // match temp {
+    //     TestResult::Passed => TestResult::Failed(anyhow::anyhow!(
+    //         "Container should not have been created with empty id, but was created."
+    //     )),
+    //     TestResult::Failed(_) => TestResult::Passed,
+    //     TestResult::Skipped => TestResult::Skipped,
+    // }
+    todo!()
+}
+
+// runtime should create container with valid id
+fn create_valid_id(&self) -> TestResult {
+    let temp = create::create(&self.project_path, &self.container_id);
+    if let TestResult::Passed = temp {
+        kill::kill(&self.project_path, &self.container_id);
+        delete::delete(&self.project_path, &self.container_id);
+    }
+    temp
+}
+
+// runtime should not create container with is that already exists
+fn create_duplicate_id(&self) -> TestResult {
+    let id = generate_uuid().to_string();
+    let _ = create::create(&self.project_path, &id);
+    let temp = create::create(&self.project_path, &id);
+    kill::kill(&self.project_path, &id);
+    delete::delete(&self.project_path, &id);
+    match temp {
+        TestResult::Passed => TestResult::Failed(anyhow::anyhow!(
+            "Container should not have been created with same id, but was created."
+        )),
+        TestResult::Failed(_) => TestResult::Passed,
+        TestResult::Skipped => TestResult::Skipped,
+    }
+}
+
+pub fn get_create_test_group<'a>() -> TestGroup<'a> {
+    let empty_id = Box::new(Test::new("empty_id", Box::new(create_empty_id)));
+    let valid_id = Box::new(Test::new("valid_id", Box::new(create_valid_id)));
+    let duplicate_id = Box::new(Test::new("duplicate_id", Box::new(create_duplicate_id)));
+
+    let mut tg = TestGroup::new("create");
+    tg.add(vec![empty_id, valid_id, duplicate_id]);
+
+    tg
+}

--- a/crates/integration_test/src/tests/lifecycle/mod.rs
+++ b/crates/integration_test/src/tests/lifecycle/mod.rs
@@ -6,6 +6,7 @@ mod kill;
 mod start;
 mod state;
 mod util;
+
 pub use container_create::ContainerCreate;
 pub use container_lifecycle::ContainerLifecycle;
 pub use util::get_result_from_output;

--- a/crates/integration_test/src/tests/mod.rs
+++ b/crates/integration_test/src/tests/mod.rs
@@ -1,4 +1,5 @@
 pub mod cgroups;
+pub mod create;
 pub mod lifecycle;
 pub mod linux_ns_itype;
 pub mod pidfile;


### PR DESCRIPTION
This PR is meant to add `create` integration tests which are bring tracked in #361.

I will outline the basic approach I have decided to add the necessary tests:
1. Remove `ContainerCreate` struct.
2. Replace it with something similar to syntax such as `get_test_group`.
3. ... (I will add more stuff here, as I go on)

Signed-off-by: Tejas Sanap <sanap.tejas@gmail.com>