### PR TITLE
Ignore autogenerated code

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -13,6 +13,3 @@ comment:
   layout: "header, diff"
   behavior: default
   require_changes: false
-
-ignore:
-  - "crates/integration_test"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -92,7 +92,7 @@ jobs:
         run: |
           cargo llvm-cov clean --workspace
           cargo llvm-cov --no-report
-          cargo llvm-cov --no-run --lcov --output-path ./coverage.lcov
+          cargo llvm-cov --no-run --lcov --ignore-filename-regex "libseccomp/src|integration_test/src|test_framework/src|systemd_api.rs" --output-path ./coverage.lcov
       - name: Upload Youki Code Coverage Results
         uses: codecov/codecov-action@v2
         with:


### PR DESCRIPTION
This excludes the code that has been auto generated for seccomp and dbus from code coverage.