### PR TITLE
Add commit id to info cmd

### DIFF
--- a/crates/youki/src/commands/info.rs
+++ b/crates/youki/src/commands/info.rs
@@ -7,7 +7,6 @@ use libcontainer::rootless;
 use procfs::{CpuInfo, Meminfo};
 
 use libcgroups::{common::CgroupSetup, v2::controller_type::ControllerType};
-
 /// Show information about the system
 #[derive(Parser, Debug)]
 pub struct Info {}
@@ -26,6 +25,7 @@ pub fn info(_: Info) -> Result<()> {
 /// print Version of Youki
 pub fn print_youki() {
     println!("{:<18}{}", "Version", env!("CARGO_PKG_VERSION"));
+    println!("{:<18}{}", "Commit", env!("VERGEN_GIT_SHA_SHORT"));
 }
 
 /// Print Kernel Release, Version and Architecture
@@ -100,11 +100,19 @@ pub fn print_hardware() {
 
 /// Print cgroups info of system
 pub fn print_cgroups() {
+    print_cgroups_setup();
+    print_cgroup_mounts();
+    print_cgroup_v2_controllers();
+}
+
+pub fn print_cgroups_setup() {
     let cgroup_setup = libcgroups::common::get_cgroup_setup();
     if let Ok(cgroup_setup) = &cgroup_setup {
         println!("{:<18}{}", "Cgroup setup", cgroup_setup);
     }
+}
 
+pub fn print_cgroup_mounts() {
     println!("Cgroup mounts");
     if let Ok(v1_mounts) = libcgroups::v1::util::list_supported_mount_points() {
         let mut v1_mounts: Vec<String> = v1_mounts
@@ -122,6 +130,11 @@ pub fn print_cgroups() {
     if let Ok(mount_point) = &unified {
         println!("  {:<16}{}", "unified", mount_point.display());
     }
+}
+
+pub fn print_cgroup_v2_controllers() {
+    let cgroup_setup = libcgroups::common::get_cgroup_setup();
+    let unified = libcgroups::v2::util::get_unified_mount_point();
 
     if let Ok(cgroup_setup) = cgroup_setup {
         if let Ok(unified) = &unified {


### PR DESCRIPTION
```
Version           0.0.1
Commit            f378fd0
Kernel-Release    5.11.0-43-generic
Kernel-Version    #47~20.04.2-Ubuntu SMP Mon Dec 13 11:06:56 UTC 2021
Architecture      x86_64
Operating System  Ubuntu 20.04.2 LTS
Cores             4
Total Memory      5877
Cgroup setup      hybrid
Cgroup mounts
  blkio           /sys/fs/cgroup/blkio
  cpu             /sys/fs/cgroup/cpu,cpuacct
  cpuacct         /sys/fs/cgroup/cpu,cpuacct
  cpuset          /sys/fs/cgroup/cpuset
  devices         /sys/fs/cgroup/devices
  freezer         /sys/fs/cgroup/freezer
  hugetlb         /sys/fs/cgroup/hugetlb
  memory          /sys/fs/cgroup/memory
  net_cls         /sys/fs/cgroup/net_cls,net_prio
  net_prio        /sys/fs/cgroup/net_cls,net_prio
  perf_event      /sys/fs/cgroup/perf_event
  pids            /sys/fs/cgroup/pids
  unified         /sys/fs/cgroup/unified
CGroup v2 controllers
  cpu             detached
  cpuset          detached
  hugetlb         detached
  io              detached
  memory          detached
  pids            detached
  device          attached
Namespaces        enabled
  mount           enabled
  uts             enabled
  ipc             enabled
  user            enabled
  pid             enabled
  network         enabled
  cgroup          enabled
```

Also printing out the cgroup info became a bit unwieldy, so I split it into several functions.