### PR TITLE
Improve cgroup path handling for rootless containers

### DIFF
--- a/crates/libcgroups/src/stats.rs
+++ b/crates/libcgroups/src/stats.rs
@@ -481,7 +481,7 @@ mod tests {
 
     #[test]
     fn test_parse_space_separated_as_nested_keyed_data() {
-        let tmp = create_temp_dir("test_parse_newline_separated_as_nested_keyed_data").unwrap();
+        let tmp = create_temp_dir("test_parse_space_separated_as_nested_keyed_data").unwrap();
         let file_content = ["key1", "key2", "key3", "key4"].join(" ");
         let file_path = set_fixture(&tmp, "space_separated", &file_content).unwrap();
 
@@ -501,7 +501,7 @@ mod tests {
 
     #[test]
     fn test_parse_flat_keyed_as_nested_keyed_data() {
-        let tmp = create_temp_dir("test_parse_newline_separated_as_nested_keyed_data").unwrap();
+        let tmp = create_temp_dir("test_parse_flat_keyed_as_nested_keyed_data").unwrap();
         let file_content = ["key1 1", "key2 2", "key3 3"].join("\n");
         let file_path = set_fixture(&tmp, "newline_separated", &file_content).unwrap();
 

--- a/crates/libcgroups/src/systemd/dbus/client.rs
+++ b/crates/libcgroups/src/systemd/dbus/client.rs
@@ -112,8 +112,7 @@ impl SystemdClient for Client {
         properties.push(("DefaultDependencies", Variant(Box::new(false))));
         properties.push(("PIDs", Variant(Box::new(vec![pid]))));
 
-        log::debug!("START UNIT: {:?}", properties);
-
+        log::debug!("Starting transient unit: {:?}", properties);
         proxy
             .start_transient_unit(unit_name, "replace", properties, vec![])
             .with_context(|| {

--- a/crates/libcontainer/src/config.rs
+++ b/crates/libcontainer/src/config.rs
@@ -22,7 +22,7 @@ pub struct YoukiConfig {
 }
 
 impl<'a> YoukiConfig {
-    pub fn from_spec(spec: &'a Spec, container_id: &str) -> Result<Self> {
+    pub fn from_spec(spec: &'a Spec, container_id: &str, rootless: bool) -> Result<Self> {
         Ok(YoukiConfig {
             hooks: spec.hooks().clone(),
             cgroup_path: utils::get_cgroup_path(
@@ -31,6 +31,7 @@ impl<'a> YoukiConfig {
                     .context("no linux in spec")?
                     .cgroups_path(),
                 container_id,
+                rootless,
             ),
         })
     }
@@ -61,7 +62,7 @@ mod tests {
     fn test_config_from_spec() -> Result<()> {
         let container_id = "sample";
         let spec = Spec::default();
-        let config = YoukiConfig::from_spec(&spec, container_id)?;
+        let config = YoukiConfig::from_spec(&spec, container_id, false)?;
         assert_eq!(&config.hooks, spec.hooks());
         dbg!(&config.cgroup_path);
         assert_eq!(config.cgroup_path, PathBuf::from(container_id));
@@ -73,7 +74,7 @@ mod tests {
         let container_id = "sample";
         let tmp = create_temp_dir("test_config_save_and_load").expect("create test directory");
         let spec = Spec::default();
-        let config = YoukiConfig::from_spec(&spec, container_id)?;
+        let config = YoukiConfig::from_spec(&spec, container_id, false)?;
         config.save(&tmp)?;
         let act = YoukiConfig::load(&tmp)?;
         assert_eq!(act, config);

--- a/crates/libcontainer/src/container/builder_impl.rs
+++ b/crates/libcontainer/src/container/builder_impl.rs
@@ -54,7 +54,11 @@ impl<'a> ContainerBuilderImpl<'a> {
 
     fn run_container(&mut self) -> Result<()> {
         let linux = self.spec.linux().as_ref().context("no linux in spec")?;
-        let cgroups_path = utils::get_cgroup_path(linux.cgroups_path(), &self.container_id);
+        let cgroups_path = utils::get_cgroup_path(
+            linux.cgroups_path(),
+            &self.container_id,
+            self.rootless.is_some(),
+        );
         let cmanager = libcgroups::common::create_cgroup_manager(
             &cgroups_path,
             self.use_systemd || self.rootless.is_some(),
@@ -139,7 +143,11 @@ impl<'a> ContainerBuilderImpl<'a> {
 
     fn cleanup_container(&self) -> Result<()> {
         let linux = self.spec.linux().as_ref().context("no linux in spec")?;
-        let cgroups_path = utils::get_cgroup_path(linux.cgroups_path(), &self.container_id);
+        let cgroups_path = utils::get_cgroup_path(
+            linux.cgroups_path(),
+            &self.container_id,
+            self.rootless.is_some(),
+        );
         let cmanager = libcgroups::common::create_cgroup_manager(
             &cgroups_path,
             self.use_systemd || self.rootless.is_some(),

--- a/crates/libcontainer/src/container/container.rs
+++ b/crates/libcontainer/src/container/container.rs
@@ -301,7 +301,8 @@ mod tests {
         let tmp_dir = create_temp_dir("test_get_spec")?;
         use oci_spec::runtime::Spec;
         let spec = Spec::default();
-        let config = YoukiConfig::from_spec(&spec, "123").context("convert spec to config")?;
+        let config =
+            YoukiConfig::from_spec(&spec, "123", false).context("convert spec to config")?;
         config.save(tmp_dir.path()).context("save config")?;
 
         let container = Container {

--- a/crates/libcontainer/src/container/init_builder.rs
+++ b/crates/libcontainer/src/container/init_builder.rs
@@ -47,9 +47,6 @@ impl<'a> InitContainerBuilder<'a> {
             .set_systemd(self.use_systemd)
             .set_annotations(spec.annotations().clone());
 
-        let config = YoukiConfig::from_spec(&spec, container.id())?;
-        config.save(&container_dir)?;
-
         unistd::chdir(&container_dir)?;
         let notify_path = container_dir.join(NOTIFY_FILE);
         // convert path of root file system of the container to absolute path
@@ -68,6 +65,9 @@ impl<'a> InitContainerBuilder<'a> {
         };
 
         let rootless = Rootless::new(&spec)?;
+        let config = YoukiConfig::from_spec(&spec, container.id(), rootless.is_some())?;
+        config.save(&container_dir)?;
+
         let mut builder_impl = ContainerBuilderImpl {
             init: true,
             syscall: self.base.syscall,

--- a/crates/libcontainer/src/utils.rs
+++ b/crates/libcontainer/src/utils.rs
@@ -68,10 +68,17 @@ pub fn do_exec(path: impl AsRef<Path>, args: &[String]) -> Result<()> {
 }
 
 /// If None, it will generate a default path for cgroups.
-pub fn get_cgroup_path(cgroups_path: &Option<PathBuf>, container_id: &str) -> PathBuf {
+pub fn get_cgroup_path(
+    cgroups_path: &Option<PathBuf>,
+    container_id: &str,
+    rootless: bool,
+) -> PathBuf {
     match cgroups_path {
         Some(cpath) => cpath.clone(),
-        None => PathBuf::from(container_id),
+        None => match rootless {
+            false => PathBuf::from(container_id),
+            true => PathBuf::from(format!(":youki:{}", container_id)),
+        },
     }
 }
 
@@ -315,11 +322,11 @@ mod tests {
     fn test_get_cgroup_path() {
         let cid = "sample_container_id";
         assert_eq!(
-            get_cgroup_path(&None, cid),
+            get_cgroup_path(&None, cid, false),
             PathBuf::from("sample_container_id")
         );
         assert_eq!(
-            get_cgroup_path(&Some(PathBuf::from("/youki")), cid),
+            get_cgroup_path(&Some(PathBuf::from("/youki")), cid, false),
             PathBuf::from("/youki")
         );
     }


### PR DESCRIPTION
- Ensure that a valid cgroup path is created for rootless containers if the cgroup path is not specified
- Handle that a cgroup path without a parent is provided

See #595