### PR TITLE
Ensure youki runs under podman

### DIFF
--- a/crates/libcgroups/src/systemd/dbus/client.rs
+++ b/crates/libcgroups/src/systemd/dbus/client.rs
@@ -9,6 +9,8 @@ use std::time::Duration;
 pub trait SystemdClient {
     fn is_system(&self) -> bool;
 
+    fn transient_unit_exists(&self, unit_name: &str) -> bool;
+
     fn start_transient_unit(
         &self,
         container_name: &str,
@@ -65,6 +67,11 @@ impl Client {
 impl SystemdClient for Client {
     fn is_system(&self) -> bool {
         self.system
+    }
+
+    fn transient_unit_exists(&self, unit_name: &str) -> bool {
+        let proxy = self.create_proxy();
+        proxy.get_unit(unit_name).is_ok()
     }
 
     /// start_transient_unit is a higher level API for starting a unit

--- a/crates/libcgroups/src/systemd/manager.rs
+++ b/crates/libcgroups/src/systemd/manager.rs
@@ -370,11 +370,13 @@ impl CgroupManager for Manager {
 
     fn remove(&self) -> Result<()> {
         log::debug!("remove {}", self.unit_name);
-        self.client
-            .stop_transient_unit(&self.unit_name)
-            .with_context(|| {
-                format!("could not remove control group {}", self.destructured_path)
-            })?;
+        if self.client.transient_unit_exists(&self.unit_name) {
+            self.client
+                .stop_transient_unit(&self.unit_name)
+                .with_context(|| {
+                    format!("could not remove control group {}", self.destructured_path)
+                })?;
+        }
 
         Ok(())
     }
@@ -402,6 +404,10 @@ mod tests {
 
     impl SystemdClient for TestSystemdClient {
         fn is_system(&self) -> bool {
+            true
+        }
+
+        fn transient_unit_exists(&self, _: &str) -> bool {
             true
         }
 

--- a/crates/youki/src/commands/delete.rs
+++ b/crates/youki/src/commands/delete.rs
@@ -1,4 +1,4 @@
-use crate::commands::load_container;
+use crate::commands::{container_exists, load_container};
 use anyhow::{Context, Result};
 use std::path::PathBuf;
 
@@ -6,6 +6,10 @@ use liboci_cli::Delete;
 
 pub fn delete(args: Delete, root_path: PathBuf) -> Result<()> {
     log::debug!("start deleting {}", args.container_id);
+    if !container_exists(&root_path, &args.container_id)? && args.force {
+        return Ok(());
+    }
+
     let mut container = load_container(root_path, &args.container_id)?;
     container
         .delete(args.force)

--- a/crates/youki/src/commands/mod.rs
+++ b/crates/youki/src/commands/mod.rs
@@ -1,5 +1,8 @@
 use anyhow::{bail, Context, Result};
-use std::{fs, path::Path};
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
 
 use libcgroups::common::CgroupManager;
 use libcontainer::container::Container;
@@ -21,18 +24,32 @@ pub mod start;
 pub mod state;
 pub mod update;
 
-fn load_container<P: AsRef<Path>>(root_path: P, container_id: &str) -> Result<Container> {
+fn construct_container_root<P: AsRef<Path>>(root_path: P, container_id: &str) -> Result<PathBuf> {
     // resolves relative paths, symbolic links etc. and get complete path
-    let root_path = fs::canonicalize(&root_path)
-        .with_context(|| format!("failed to canonicalize {}", root_path.as_ref().display()))?;
+    let root_path = fs::canonicalize(&root_path).with_context(|| {
+        format!(
+            "failed to canonicalize {} for container {}",
+            root_path.as_ref().display(),
+            container_id
+        )
+    })?;
     // the state of the container is stored in a directory named after the container id
-    let container_root = root_path.join(container_id);
+    Ok(root_path.join(container_id))
+}
+
+fn load_container<P: AsRef<Path>>(root_path: P, container_id: &str) -> Result<Container> {
+    let container_root = construct_container_root(root_path, container_id)?;
     if !container_root.exists() {
         bail!("container {} does not exist.", container_id)
     }
 
     Container::load(container_root)
         .with_context(|| format!("could not load state for container {}", container_id))
+}
+
+fn container_exists<P: AsRef<Path>>(root_path: P, container_id: &str) -> Result<bool> {
+    let container_root = construct_container_root(root_path, container_id)?;
+    Ok(container_root.exists())
 }
 
 fn create_cgroup_manager<P: AsRef<Path>>(


### PR DESCRIPTION
We need to be more defensive when deleting a container as podman executes delete twice and cleans up the cgroup of the container before we have a chance to clean it up.

Fixes #607