### PR TITLE
Pin nightly version in CI as temporary fix to coverage issue

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -73,7 +73,7 @@ jobs:
       - name: Toolchain setup
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly
+          toolchain: nightly-2022-01-14 
           override: true
           profile: minimal
           components: llvm-tools-preview


### PR DESCRIPTION
This PR pins the version of nightly in the CI to fix the error in the CI coverage job, which is occurring. I had opened https://github.com/taiki-e/cargo-llvm-cov/issues/128 where it linked to an closed issue in upstream rust repo, where it is explained that due to some changes in nightly there is some error in generating llvm coverage information.

The current fix is to pin the nightly version to a working version in CI until the nightly version is compatible again.