### PR TITLE
Add minimum rust version requirement to libcgroups and libcontainers

### DIFF
--- a/.github/workflows/integration_tests_validation.yaml
+++ b/.github/workflows/integration_tests_validation.yaml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rust: [1.56.1, 1.58.0]
+        rust: [1.58.1]
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rust: [1.56.1, 1.58.0]
+        rust: [1.58.1]
         dirs: ${{ fromJSON(needs.changes.outputs.dirs) }}
     steps:
       - uses: actions/checkout@v2
@@ -52,7 +52,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rust: [1.56.1, 1.58.0]
+        rust: [1.58.1]
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
@@ -102,7 +102,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rust: [1.56.1, 1.58.0]
+        rust: [1.58.1]
     steps:
       - uses: actions/checkout@v2
         with:
@@ -116,6 +116,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: ${{ matrix.rust }}
+          override: true
       - name: Cache youki
         uses: Swatinem/rust-cache@v1
       - run: sudo apt-get -y update

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -718,7 +718,7 @@ checksum = "1b03d17f364a3a042d5e5d46b053bbbf82c92c9430c592dd4c064dc6ee997125"
 
 [[package]]
 name = "libcgroups"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -740,7 +740,7 @@ dependencies = [
 
 [[package]]
 name = "libcontainer"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
  "anyhow",
  "caps",
@@ -788,14 +788,14 @@ dependencies = [
 
 [[package]]
 name = "liboci-cli"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
  "clap",
 ]
 
 [[package]]
 name = "libseccomp"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
  "libc",
  "pkg-config",
@@ -1661,7 +1661,7 @@ dependencies = [
 
 [[package]]
 name = "youki"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,5 @@
+
+
 [workspace]
 members = [
     "crates/*"

--- a/crates/libcgroups/Cargo.toml
+++ b/crates/libcgroups/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "libcgroups"
-version = "0.0.1"
+version = "0.0.2"
 edition = "2021"
+rust-version = "1.58.1"
 autoexamples = false
 
 [features]

--- a/crates/libcontainer/Cargo.toml
+++ b/crates/libcontainer/Cargo.toml
@@ -1,8 +1,9 @@
 [package]
 name = "libcontainer"
-version = "0.0.1"
+version = "0.0.2"
 authors = ["youki team"]
 edition = "2021"
+rust-version = "1.58.1"
 description = "Library for container creation"
 
 [dependencies]
@@ -22,8 +23,8 @@ oci-spec = "0.5.3"
 path-clean = "0.1.0"
 procfs = "0.12.0"
 prctl = "1.0.0"
-libcgroups = { version = "0.0.1", path = "../libcgroups" }
-libseccomp = { version = "0.0.1", path = "../libseccomp" }
+libcgroups = { version = "0.0.2", path = "../libcgroups" }
+libseccomp = { version = "0.0.2", path = "../libseccomp" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 

--- a/crates/liboci-cli/Cargo.toml
+++ b/crates/liboci-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "liboci-cli"
-version = "0.0.1"
+version = "0.0.2"
 authors = ["youki team"]
 edition = "2021"
 description = "Parse command line arguments for OCI container runtimes"

--- a/crates/libseccomp/Cargo.toml
+++ b/crates/libseccomp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libseccomp"
-version = "0.0.1"
+version = "0.0.2"
 edition = "2021"
 
 build = "build.rs"

--- a/crates/youki/Cargo.toml
+++ b/crates/youki/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "youki"
-version = "0.0.1"
+version = "0.0.2"
 authors = ["youki team"]
 edition = "2021"
 description = "A container runtime written in Rust"
@@ -15,9 +15,9 @@ features = ["std", "suggestions", "derive", "cargo"]
 [dependencies]
 anyhow = "1.0.52"
 chrono = { version="0.4", features = ["serde"] }
-libcgroups = { version = "0.0.1", path = "../libcgroups" }
-libcontainer = { version = "0.0.1", path = "../libcontainer" }
-liboci-cli = { version = "0.0.1", path = "../liboci-cli" }
+libcgroups = { version = "0.0.2", path = "../libcgroups" }
+libcontainer = { version = "0.0.2", path = "../libcontainer" }
+liboci-cli = { version = "0.0.2", path = "../liboci-cli" }
 log = { version = "0.4", features = ["std"]}
 nix = "0.23.1"
 oci-spec = "0.5.3"


### PR DESCRIPTION
CVE-2022-21658 was announced today which affects the rust std::fs::remove_dir_all function, where due to a race condition, a non-privileged process can request a privileged process to delete a dir which they do not have permission to delete. More information on this can be found at https://blog.rust-lang.org/2022/01/20/cve-2022-21658.html

Youki uses this function in libcgroups and libcontainer, where it is used to either remove a cgroup or remove a container bundle dir. Thus this PR adds `rust-version` field to both of these, and sets it to `1.58.1` which has a patch for this CVE. Now to compile youki one must have rust compiler of version at least `1.58.1` or newer. If tried to compile with previous version, it will give a compile time error.

This also changes the rust versions in the CI rust matrix to be compatible with this.