### PR TITLE
Create device as 0666 and not 066

### DIFF
--- a/crates/libcontainer/src/rootfs/utils.rs
+++ b/crates/libcontainer/src/rootfs/utils.rs
@@ -11,7 +11,7 @@ pub fn default_devices() -> Vec<LinuxDevice> {
             .typ(LinuxDeviceType::C)
             .major(1)
             .minor(3)
-            .file_mode(0o066u32)
+            .file_mode(0o0666u32)
             .build()
             .unwrap(),
         LinuxDeviceBuilder::default()
@@ -19,7 +19,7 @@ pub fn default_devices() -> Vec<LinuxDevice> {
             .typ(LinuxDeviceType::C)
             .major(1)
             .minor(5)
-            .file_mode(0o066u32)
+            .file_mode(0o0666u32)
             .build()
             .unwrap(),
         LinuxDeviceBuilder::default()
@@ -27,7 +27,7 @@ pub fn default_devices() -> Vec<LinuxDevice> {
             .typ(LinuxDeviceType::C)
             .major(1)
             .minor(7)
-            .file_mode(0o066u32)
+            .file_mode(0o0666u32)
             .build()
             .unwrap(),
         LinuxDeviceBuilder::default()
@@ -35,7 +35,7 @@ pub fn default_devices() -> Vec<LinuxDevice> {
             .typ(LinuxDeviceType::C)
             .major(5)
             .minor(0)
-            .file_mode(0o066u32)
+            .file_mode(0o0666u32)
             .build()
             .unwrap(),
         LinuxDeviceBuilder::default()
@@ -43,7 +43,7 @@ pub fn default_devices() -> Vec<LinuxDevice> {
             .typ(LinuxDeviceType::C)
             .major(1)
             .minor(9)
-            .file_mode(0o066u32)
+            .file_mode(0o0666u32)
             .build()
             .unwrap(),
         LinuxDeviceBuilder::default()
@@ -51,7 +51,7 @@ pub fn default_devices() -> Vec<LinuxDevice> {
             .typ(LinuxDeviceType::C)
             .major(1)
             .minor(8)
-            .file_mode(0o066u32)
+            .file_mode(0o0666u32)
             .build()
             .unwrap(),
     ]


### PR DESCRIPTION
Devices created by utils.rs where not accessible by root and were
looking like this:

c---rw-rw-. 1 root root 1, 3 Dec 28 09:50 /dev/null

Setting it to 0666 gives me devices with `crw-rw-rw-`

See #623 