### PR TITLE
Initial checkpoint support

### DIFF
--- a/.github/workflows/integration_tests_validation.yaml
+++ b/.github/workflows/integration_tests_validation.yaml
@@ -36,9 +36,14 @@ jobs:
         uses: Swatinem/rust-cache@v1
       - run: sudo apt-get -y update
       - run: sudo apt-get install -y pkg-config libsystemd-dev libdbus-glib-1-dev libelf-dev libseccomp-dev
+      - name: Install runc 1.1.0
+        run: |
+          wget -q https://github.com/opencontainers/runc/releases/download/v1.1.0/runc.amd64
+          sudo mv runc.amd64 /usr/bin/runc
+          sudo chmod 755 /usr/bin/runc
       - name: Build
         run: ./build.sh
       - name: Validate tests on runc
-        run: cd ./crates/integration_test && sudo ./tests.sh run runc
+        run: runc --version && cd ./crates/integration_test && sudo ./tests.sh run runc
       - name: Validate tests on youki
         run: cd ./crates/integration_test && sudo ./tests.sh run ../../youki

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1052,6 +1052,7 @@ dependencies = [
  "procfs",
  "quickcheck",
  "rand",
+ "rust-criu",
  "serde",
  "serde_json",
  "serial_test",
@@ -1623,6 +1624,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "protobuf"
+version = "2.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47c327e191621a2158159df97cdbc2e7074bb4e940275e35abf38eb3d2595754"
+
+[[package]]
+name = "protobuf-codegen"
+version = "2.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3df8c98c08bd4d6653c2dbae00bd68c1d1d82a360265a5b0bbc73d48c63cb853"
+dependencies = [
+ "protobuf",
+]
+
+[[package]]
+name = "protobuf-codegen-pure"
+version = "2.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "394a73e2a819405364df8d30042c0f1174737a763e0170497ec9d36f8a2ea8f7"
+dependencies = [
+ "protobuf",
+ "protobuf-codegen",
+]
+
+[[package]]
 name = "ptr_meta"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1819,6 +1845,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "rust-criu"
+version = "0.1.0"
+source = "git+https://github.com/checkpoint-restore/rust-criu#6df305772205620bea3a1c0e70ba81cd38f8417c"
+dependencies = [
+ "libc",
+ "protobuf",
+ "protobuf-codegen-pure",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ youki is not at the practical stage yet. However, it is getting closer to practi
 |         Hooks         | Add custom processing during container creation |                                                 ✅                                                  |
 |       Rootless        |   Running a container without root privileges   |                                                 ✅                                                  |
 |    OCI Compliance     |        Compliance with OCI Runtime Spec         |                                 ✅ 50 out of 50 test cases passing                                  |
+|   CRIU Integration    | Functionality to checkpoint/restore containers  |                         Initial checkpoint support as described in #641                             |
 
 # Design and implementation of youki
 

--- a/crates/integration_test/src/tests/lifecycle/checkpoint.rs
+++ b/crates/integration_test/src/tests/lifecycle/checkpoint.rs
@@ -1,0 +1,168 @@
+use super::get_result_from_output;
+use crate::utils::get_runtime_path;
+use crate::utils::test_utils::State;
+use crate::utils::{create_temp_dir, generate_uuid};
+use anyhow::anyhow;
+use std::path::Path;
+use std::process::{Command, Stdio};
+use test_framework::TestResult;
+
+// Simple function to figure out the PID of the first container process
+fn get_container_pid(project_path: &Path, id: &str) -> Result<i32, TestResult> {
+    let res_state = match Command::new(get_runtime_path())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .arg("--root")
+        .arg(project_path.join("runtime"))
+        .arg("state")
+        .arg(id)
+        .spawn()
+        .expect("failed to execute state command")
+        .wait_with_output()
+    {
+        Ok(o) => o,
+        Err(e) => {
+            return Err(TestResult::Failed(anyhow!(
+                "error getting container state {}",
+                e
+            )))
+        }
+    };
+    let stdout = match String::from_utf8(res_state.stdout) {
+        Ok(s) => s,
+        Err(e) => {
+            return Err(TestResult::Failed(anyhow!(
+                "failed to parse container stdout {}",
+                e
+            )))
+        }
+    };
+    let state: State = match serde_json::from_str(&stdout) {
+        Ok(v) => v,
+        Err(e) => {
+            return Err(TestResult::Failed(anyhow!(
+                "error in parsing state of container: stdout : {}, parse error : {}",
+                stdout,
+                e
+            )))
+        }
+    };
+
+    Ok(match state.pid {
+        Some(p) => p,
+        _ => -1,
+    })
+}
+
+// CRIU requires a minimal network setup in the network namespace
+fn setup_network_namespace(project_path: &Path, id: &str) -> Result<(), TestResult> {
+    let pid = get_container_pid(project_path, id)?;
+
+    if let Err(e) = Command::new("nsenter")
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .arg("-t")
+        .arg(format!("{}", pid))
+        .arg("-a")
+        .args(vec!["/bin/ip", "link", "set", "up", "dev", "lo"])
+        .spawn()
+        .expect("failed to exec ip")
+        .wait_with_output()
+    {
+        return Err(TestResult::Failed(anyhow!(
+            "error setting up network namespace {}",
+            e
+        )));
+    }
+
+    Ok(())
+}
+
+fn checkpoint(
+    project_path: &Path,
+    id: &str,
+    args: Vec<&str>,
+    work_path: Option<&str>,
+) -> TestResult {
+    if let Err(e) = setup_network_namespace(project_path, id) {
+        return e;
+    }
+
+    let temp_dir = match create_temp_dir(&generate_uuid()) {
+        Ok(td) => td,
+        Err(e) => {
+            return TestResult::Failed(anyhow::anyhow!(
+                "failed creating temporary directory {:?}",
+                e
+            ))
+        }
+    };
+    let checkpoint_dir = temp_dir.as_ref().join("checkpoint");
+    if let Err(e) = std::fs::create_dir(&checkpoint_dir) {
+        return TestResult::Failed(anyhow::anyhow!(
+            "failed creating checkpoint directory ({:?}): {}",
+            &checkpoint_dir,
+            e
+        ));
+    }
+
+    let additional_args = match work_path {
+        Some(wp) => vec!["--work-path", wp],
+        _ => Vec::new(),
+    };
+
+    let runtime_path = get_runtime_path();
+
+    let checkpoint = Command::new(runtime_path)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .arg("--root")
+        .arg(project_path.join("runtime"))
+        .arg(match runtime_path {
+            _ if runtime_path.ends_with("youki") => "checkpointt",
+            _ => "checkpoint",
+        })
+        .arg("--image-path")
+        .arg(&checkpoint_dir)
+        .args(additional_args)
+        .args(args)
+        .arg(id)
+        .spawn()
+        .expect("failed to execute checkpoint command")
+        .wait_with_output();
+
+    let result = get_result_from_output(checkpoint);
+    if let TestResult::Failed(_) = result {
+        return result;
+    }
+
+    // Check for complete checkpoint
+    if !Path::new(&checkpoint_dir.join("inventory.img")).exists() {
+        return TestResult::Failed(anyhow::anyhow!(
+            "resulting checkpoint does not seem to be complete. {:?}/inventory.img is missing",
+            &checkpoint_dir,
+        ));
+    }
+
+    let dump_log = match work_path {
+        Some(wp) => Path::new(wp).join("dump.log"),
+        _ => checkpoint_dir.join("dump.log"),
+    };
+
+    if !dump_log.exists() {
+        return TestResult::Failed(anyhow::anyhow!(
+            "resulting checkpoint log file {:?} not found.",
+            &dump_log,
+        ));
+    }
+
+    TestResult::Passed
+}
+
+pub fn checkpoint_leave_running_work_path_tmp(project_path: &Path, id: &str) -> TestResult {
+    checkpoint(project_path, id, vec!["--leave-running"], Some("/tmp/"))
+}
+
+pub fn checkpoint_leave_running(project_path: &Path, id: &str) -> TestResult {
+    checkpoint(project_path, id, vec!["--leave-running"], None)
+}

--- a/crates/integration_test/src/tests/lifecycle/container_lifecycle.rs
+++ b/crates/integration_test/src/tests/lifecycle/container_lifecycle.rs
@@ -3,7 +3,7 @@ use std::thread::sleep;
 use std::time::Duration;
 use test_framework::{TestResult, TestableGroup};
 
-use super::{create, delete, exec, kill, start, state};
+use super::{checkpoint, create, delete, exec, kill, start, state};
 
 // By experimenting, somewhere around 50 is enough for youki process
 // to get the kill signal and shut down
@@ -59,6 +59,14 @@ impl ContainerLifecycle {
     pub fn delete(&self) -> TestResult {
         delete::delete(&self.project_path, &self.container_id)
     }
+
+    pub fn checkpoint_leave_running(&self) -> TestResult {
+        checkpoint::checkpoint_leave_running(&self.project_path, &self.container_id)
+    }
+
+    pub fn checkpoint_leave_running_work_path_tmp(&self) -> TestResult {
+        checkpoint::checkpoint_leave_running_work_path_tmp(&self.project_path, &self.container_id)
+    }
 }
 
 impl<'a> TestableGroup<'a> for ContainerLifecycle {
@@ -71,6 +79,14 @@ impl<'a> TestableGroup<'a> for ContainerLifecycle {
             ("create", self.create()),
             ("start", self.start()),
             // ("exec", self.exec(vec!["echo", "Hello"], Some("Hello\n"))),
+            (
+                "checkpoint and leave running with --work-path /tmp",
+                self.checkpoint_leave_running_work_path_tmp(),
+            ),
+            (
+                "checkpoint and leave running",
+                self.checkpoint_leave_running(),
+            ),
             ("kill", self.kill()),
             ("state", self.state()),
             ("delete", self.delete()),
@@ -83,6 +99,14 @@ impl<'a> TestableGroup<'a> for ContainerLifecycle {
             match *name {
                 "create" => ret.push(("create", self.create())),
                 "start" => ret.push(("start", self.start())),
+                "checkpoint_leave_running_work_path_tmp" => ret.push((
+                    "checkpoint and leave running with --work-path /tmp",
+                    self.checkpoint_leave_running_work_path_tmp(),
+                )),
+                "checkpoint_leave_running" => ret.push((
+                    "checkpoint and leave running",
+                    self.checkpoint_leave_running(),
+                )),
                 "kill" => ret.push(("kill", self.kill())),
                 "state" => ret.push(("state", self.state())),
                 "delete" => ret.push(("delete", self.delete())),

--- a/crates/integration_test/src/tests/lifecycle/create.rs
+++ b/crates/integration_test/src/tests/lifecycle/create.rs
@@ -10,6 +10,7 @@ use test_framework::TestResult;
 // which is why we pass null, and use wait instead of wait_with_output
 pub fn create(project_path: &Path, id: &str) -> TestResult {
     let res = Command::new(get_runtime_path())
+        .stdin(Stdio::null())
         .stdout(Stdio::null())
         .stderr(Stdio::null())
         .arg("--root")

--- a/crates/integration_test/src/tests/lifecycle/mod.rs
+++ b/crates/integration_test/src/tests/lifecycle/mod.rs
@@ -1,3 +1,4 @@
+mod checkpoint;
 mod container_create;
 mod container_lifecycle;
 mod create;

--- a/crates/libcontainer/Cargo.toml
+++ b/crates/libcontainer/Cargo.toml
@@ -31,6 +31,7 @@ libcgroups = { version = "0.0.2", path = "../libcgroups" }
 libseccomp = { version = "0.0.2", path = "../libseccomp" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+rust-criu = { git = "https://github.com/checkpoint-restore/rust-criu", version = "0.1.0" }
 wasmer = { version = "2.1.1", optional = true }
 wasmer-wasi = { version = "2.1.1", optional = true }
 

--- a/crates/libcontainer/src/container/container.rs
+++ b/crates/libcontainer/src/container/container.rs
@@ -198,6 +198,17 @@ impl Container {
     }
 }
 
+/// Checkpoint parameter structure
+pub struct CheckpointOptions {
+    pub ext_unix_sk: bool,
+    pub file_locks: bool,
+    pub image_path: PathBuf,
+    pub leave_running: bool,
+    pub shell_job: bool,
+    pub tcp_established: bool,
+    pub work_path: Option<PathBuf>,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/libcontainer/src/container/container_checkpoint.rs
+++ b/crates/libcontainer/src/container/container_checkpoint.rs
@@ -1,0 +1,126 @@
+use super::{Container, ContainerStatus};
+use crate::container::container::CheckpointOptions;
+use anyhow::{bail, Context, Result};
+
+use libcgroups::common::{
+    CgroupSetup::{Hybrid, Legacy},
+    DEFAULT_CGROUP_ROOT,
+};
+use oci_spec::runtime::Spec;
+use std::os::unix::io::AsRawFd;
+
+const CRIU_CHECKPOINT_LOG_FILE: &str = "dump.log";
+
+impl Container {
+    pub fn checkpoint(&mut self, opts: &CheckpointOptions) -> Result<()> {
+        self.refresh_status()
+            .context("failed to refresh container status")?;
+
+        // can_pause() checks if the container is running. That also works for
+        // checkpoitning. is_running() would make more sense here, but let's
+        // just reuse existing functions.
+        if !self.can_pause() {
+            bail!(
+                "{} could not be checkpointed because it was {:?}",
+                self.id(),
+                self.status()
+            );
+        }
+
+        let mut criu = rust_criu::Criu::new().unwrap();
+
+        // We need to tell CRIU that all bind mounts are external. CRIU will fail checkpointing
+        // if it does not know that these bind mounts are coming from the outside of the container.
+        // This information is needed during restore again. The external location of the bind
+        // mounts can change and CRIU will just mount whatever we tell it to mount based on
+        // information found in 'config.json'.
+        let source_spec_path = self.bundle().join("config.json");
+        let spec = Spec::load(&source_spec_path)?;
+        let mounts = spec.mounts().clone();
+        for m in mounts.unwrap() {
+            match m.typ().as_deref() {
+                Some("bind") => {
+                    let dest = m
+                        .destination()
+                        .clone()
+                        .into_os_string()
+                        .into_string()
+                        .expect("failed to convert mount destination");
+                    criu.set_external_mount(dest.clone(), dest);
+                }
+                Some("cgroup") => {
+                    match libcgroups::common::get_cgroup_setup()
+                        .context("failed to determine cgroup setup")?
+                    {
+                        // For v1 it is necessary to list all cgroup mounts as external mounts
+                        Legacy | Hybrid => {
+                            for mp in libcgroups::v1::util::list_subsystem_mount_points()
+                                .context("failed to get subsystem mount points")?
+                            {
+                                let cgroup_mount = mp
+                                    .clone()
+                                    .into_os_string()
+                                    .into_string()
+                                    .expect("failed to convert mount point");
+                                if cgroup_mount.starts_with(DEFAULT_CGROUP_ROOT) {
+                                    criu.set_external_mount(cgroup_mount.clone(), cgroup_mount);
+                                }
+                            }
+                        }
+                        _ => (),
+                    }
+                }
+                _ => (),
+            }
+        }
+
+        let directory = std::fs::File::open(&opts.image_path)
+            .with_context(|| format!("failed to open {:?}", opts.image_path))?;
+        criu.set_images_dir_fd(directory.as_raw_fd());
+
+        // It seems to be necessary to be defined outside of 'if' to
+        // keep the FD open until CRIU uses it.
+        let work_dir: std::fs::File;
+        if let Some(wp) = &opts.work_path {
+            work_dir = std::fs::File::open(wp)?;
+            criu.set_work_dir_fd(work_dir.as_raw_fd());
+        }
+
+        criu.set_log_file(CRIU_CHECKPOINT_LOG_FILE.to_string());
+        criu.set_log_level(4);
+        criu.set_pid(self.pid().unwrap().into());
+        criu.set_leave_running(opts.leave_running);
+        criu.set_ext_unix_sk(opts.ext_unix_sk);
+        criu.set_shell_job(opts.shell_job);
+        criu.set_tcp_established(opts.tcp_established);
+        criu.set_file_locks(opts.file_locks);
+        criu.set_orphan_pts_master(true);
+        criu.set_manage_cgroups(true);
+        criu.set_root(
+            self.bundle()
+                .clone()
+                .into_os_string()
+                .into_string()
+                .unwrap(),
+        );
+        if let Err(e) = criu.dump() {
+            bail!(
+                "checkpointing container {} failed with {:?}. Please check CRIU logfile {:}/{}",
+                self.id(),
+                e,
+                opts.work_path
+                    .as_ref()
+                    .unwrap_or(&opts.image_path)
+                    .display(),
+                CRIU_CHECKPOINT_LOG_FILE
+            );
+        }
+
+        if !opts.leave_running {
+            self.set_status(ContainerStatus::Stopped).save()?;
+        }
+
+        log::debug!("container {} checkpointed", self.id());
+        Ok(())
+    }
+}

--- a/crates/libcontainer/src/container/mod.rs
+++ b/crates/libcontainer/src/container/mod.rs
@@ -8,6 +8,7 @@ pub mod builder;
 mod builder_impl;
 #[allow(clippy::module_inception)]
 mod container;
+mod container_checkpoint;
 mod container_delete;
 mod container_events;
 mod container_kill;
@@ -17,5 +18,6 @@ mod container_start;
 pub mod init_builder;
 pub mod state;
 pub mod tenant_builder;
+pub use container::CheckpointOptions;
 pub use container::Container;
 pub use state::{ContainerProcessState, ContainerStatus, State};

--- a/crates/libcontainer/src/process/container_init_process.rs
+++ b/crates/libcontainer/src/process/container_init_process.rs
@@ -198,7 +198,7 @@ fn reopen_dev_null() -> Result<()> {
     let dev_null_fstat_info = nix::sys::stat::fstat(dev_null.as_raw_fd())?;
 
     // Check if stdin, stdout or stderr point to /dev/null
-    for fd in 0..2 {
+    for fd in 0..3 {
         let fstat_info = nix::sys::stat::fstat(fd)?;
 
         if dev_null_fstat_info.st_rdev == fstat_info.st_rdev {

--- a/crates/liboci-cli/src/checkpoint.rs
+++ b/crates/liboci-cli/src/checkpoint.rs
@@ -1,0 +1,30 @@
+use clap::Parser;
+use std::path::PathBuf;
+
+/// Checkpoint a running container
+#[derive(Parser, Debug)]
+pub struct Checkpoint {
+    #[clap(forbid_empty_values = true, required = true)]
+    pub container_id: String,
+    /// Allow external unix sockets
+    #[clap(long)]
+    pub ext_unix_sk: bool,
+    /// Allow file locks
+    #[clap(long)]
+    pub file_locks: bool,
+    /// Path for saving criu image files
+    #[clap(long, default_value = "checkpoint")]
+    pub image_path: PathBuf,
+    /// Leave the process running after checkpointing
+    #[clap(long)]
+    pub leave_running: bool,
+    /// Allow shell jobs
+    #[clap(long)]
+    pub shell_job: bool,
+    /// Allow open tcp connections
+    #[clap(long)]
+    pub tcp_established: bool,
+    /// Path for saving work files and logs
+    #[clap(long)]
+    pub work_path: Option<PathBuf>,
+}

--- a/crates/liboci-cli/src/lib.rs
+++ b/crates/liboci-cli/src/lib.rs
@@ -14,6 +14,7 @@ mod state;
 pub use {create::Create, delete::Delete, kill::Kill, start::Start, state::State};
 
 // Other common subcommands that aren't specified in the document
+mod checkpoint;
 mod events;
 mod exec;
 mod list;
@@ -25,8 +26,8 @@ mod spec;
 mod update;
 
 pub use {
-    events::Events, exec::Exec, list::List, pause::Pause, ps::Ps, resume::Resume, run::Run,
-    spec::Spec, update::Update,
+    checkpoint::Checkpoint, events::Events, exec::Exec, list::List, pause::Pause, ps::Ps,
+    resume::Resume, run::Run, spec::Spec, update::Update,
 };
 
 // Subcommands parsed by liboci-cli, based on the [OCI
@@ -48,6 +49,7 @@ pub enum StandardCmd {
 // and other runtimes.
 #[derive(Parser, Debug)]
 pub enum CommonCmd {
+    Checkpointt(Checkpoint),
     Events(Events),
     Exec(Exec),
     List(List),

--- a/crates/youki/src/commands/checkpoint.rs
+++ b/crates/youki/src/commands/checkpoint.rs
@@ -1,0 +1,24 @@
+//! Contains functionality of pause container command
+use crate::commands::load_container;
+use std::path::PathBuf;
+
+use anyhow::{Context, Result};
+
+use liboci_cli::Checkpoint;
+
+pub fn checkpoint(args: Checkpoint, root_path: PathBuf) -> Result<()> {
+    log::debug!("start checkpointing container {}", args.container_id);
+    let mut container = load_container(root_path, &args.container_id)?;
+    let opts = libcontainer::container::CheckpointOptions {
+        ext_unix_sk: args.ext_unix_sk,
+        file_locks: args.file_locks,
+        image_path: args.image_path,
+        leave_running: args.leave_running,
+        shell_job: args.shell_job,
+        tcp_established: args.tcp_established,
+        work_path: args.work_path,
+    };
+    container
+        .checkpoint(&opts)
+        .with_context(|| format!("failed to checkpoint container {}", args.container_id))
+}

--- a/crates/youki/src/commands/mod.rs
+++ b/crates/youki/src/commands/mod.rs
@@ -7,6 +7,7 @@ use std::{
 use libcgroups::common::CgroupManager;
 use libcontainer::container::Container;
 
+pub mod checkpoint;
 pub mod completion;
 pub mod create;
 pub mod delete;

--- a/crates/youki/src/main.rs
+++ b/crates/youki/src/main.rs
@@ -108,6 +108,9 @@ fn main() -> Result<()> {
             StandardCmd::State(state) => commands::state::state(state, root_path),
         },
         SubCommand::Common(cmd) => match cmd {
+            CommonCmd::Checkpointt(checkpoint) => {
+                commands::checkpoint::checkpoint(checkpoint, root_path)
+            }
             CommonCmd::Events(events) => commands::events::events(events, root_path),
             CommonCmd::Exec(exec) => commands::exec::exec(exec, root_path),
             CommonCmd::List(list) => commands::list::list(list, root_path),


### PR DESCRIPTION
This is the initial draft for checkpoint support. No restore support yet.

Tests are still missing and it relies on the not yet officially release Rust CRIU bindings. For now it is just a draft.

It depends on #632

I called the checkpoint command ´checkpointt' with two `t`s so that Podman does not think youki already fully supports checkpoint/restore. Once everything works I will rename it.

<a href="https://gitpod.io/#https://github.com/containers/youki/pull/641"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

