### PR TITLE
Remove duplication from commands execution in Integration tests

### DIFF
--- a/crates/integration_test/src/tests/lifecycle/delete.rs
+++ b/crates/integration_test/src/tests/lifecycle/delete.rs
@@ -1,5 +1,5 @@
 use super::get_result_from_output;
-use crate::utils::{delete_container};
+use crate::utils::delete_container;
 use std::path::Path;
 use test_framework::TestResult;
 

--- a/crates/integration_test/src/tests/lifecycle/delete.rs
+++ b/crates/integration_test/src/tests/lifecycle/delete.rs
@@ -1,18 +1,10 @@
 use super::get_result_from_output;
-use crate::utils::get_runtime_path;
+use crate::utils::{delete_container};
 use std::path::Path;
-use std::process::{Command, Stdio};
 use test_framework::TestResult;
 
 pub fn delete(project_path: &Path, id: &str) -> TestResult {
-    let res = Command::new(get_runtime_path())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .arg("--root")
-        .arg(project_path.join("runtime"))
-        .arg("delete")
-        .arg(id)
-        .spawn()
+    let res = delete_container(id, project_path)
         .expect("failed to execute delete command")
         .wait_with_output();
     get_result_from_output(res)

--- a/crates/integration_test/src/tests/lifecycle/kill.rs
+++ b/crates/integration_test/src/tests/lifecycle/kill.rs
@@ -1,19 +1,10 @@
 use super::get_result_from_output;
-use crate::utils::get_runtime_path;
+use crate::utils::{kill_container};
 use std::path::Path;
-use std::process::{Command, Stdio};
 use test_framework::TestResult;
 
 pub fn kill(project_path: &Path, id: &str) -> TestResult {
-    let res = Command::new(get_runtime_path())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .arg("--root")
-        .arg(project_path.join("runtime"))
-        .arg("kill")
-        .arg(id)
-        .arg("9")
-        .spawn()
+    let res = kill_container(id, project_path)
         .expect("failed to execute kill command")
         .wait_with_output();
     get_result_from_output(res)

--- a/crates/integration_test/src/tests/lifecycle/kill.rs
+++ b/crates/integration_test/src/tests/lifecycle/kill.rs
@@ -1,5 +1,5 @@
 use super::get_result_from_output;
-use crate::utils::{kill_container};
+use crate::utils::kill_container;
 use std::path::Path;
 use test_framework::TestResult;
 

--- a/crates/integration_test/src/tests/lifecycle/start.rs
+++ b/crates/integration_test/src/tests/lifecycle/start.rs
@@ -1,7 +1,7 @@
 use super::get_result_from_output;
+use crate::utils::test_utils::start_container;
 use std::path::Path;
 use test_framework::TestResult;
-use crate::utils::test_utils::start_container;
 
 pub fn start(project_path: &Path, id: &str) -> TestResult {
     let res = start_container(id, project_path)

--- a/crates/integration_test/src/tests/lifecycle/start.rs
+++ b/crates/integration_test/src/tests/lifecycle/start.rs
@@ -1,18 +1,10 @@
 use super::get_result_from_output;
-use crate::utils::get_runtime_path;
 use std::path::Path;
-use std::process::{Command, Stdio};
 use test_framework::TestResult;
+use crate::utils::test_utils::start_container;
 
 pub fn start(project_path: &Path, id: &str) -> TestResult {
-    let res = Command::new(get_runtime_path())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .arg("--root")
-        .arg(project_path.join("runtime"))
-        .arg("start")
-        .arg(id)
-        .spawn()
+    let res = start_container(id, project_path)
         .expect("failed to execute start command")
         .wait_with_output();
     get_result_from_output(res)

--- a/crates/integration_test/src/tests/lifecycle/state.rs
+++ b/crates/integration_test/src/tests/lifecycle/state.rs
@@ -1,18 +1,10 @@
-use crate::utils::get_runtime_path;
 use std::io;
 use std::path::Path;
-use std::process::{Command, Stdio};
 use test_framework::TestResult;
+use crate::utils::test_utils::get_state;
 
 pub fn state(project_path: &Path, id: &str) -> TestResult {
-    let res = Command::new(get_runtime_path())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .arg("--root")
-        .arg(project_path.join("runtime"))
-        .arg("state")
-        .arg(id)
-        .spawn()
+    let res = get_state(id, project_path)
         .expect("failed to execute state command")
         .wait_with_output();
     match res {

--- a/crates/integration_test/src/tests/lifecycle/state.rs
+++ b/crates/integration_test/src/tests/lifecycle/state.rs
@@ -1,7 +1,7 @@
+use crate::utils::test_utils::get_state;
 use std::io;
 use std::path::Path;
 use test_framework::TestResult;
-use crate::utils::test_utils::get_state;
 
 pub fn state(project_path: &Path, id: &str) -> TestResult {
     let res = get_state(id, project_path)

--- a/crates/integration_test/src/tests/pidfile/pidfile_test.rs
+++ b/crates/integration_test/src/tests/pidfile/pidfile_test.rs
@@ -1,6 +1,6 @@
 use crate::utils::{
-    create_temp_dir, delete_container, generate_uuid, get_runtime_path, get_state_output,
-    kill_container, prepare_bundle, State, TempDir,
+    create_temp_dir, delete_container, generate_uuid, get_runtime_path, get_state, kill_container,
+    prepare_bundle, State, TempDir,
 };
 use anyhow::anyhow;
 use std::process::{Command, Stdio};
@@ -43,7 +43,7 @@ fn test_pidfile() -> TestResult {
         .wait()
         .unwrap();
 
-    let (out, err) = get_state_output(&container_id.to_string(), &bundle).unwrap();
+    let (out, err) = get_state(&container_id.to_string(), &bundle).unwrap();
 
     if !err.is_empty() {
         cleanup(&container_id, &bundle);

--- a/crates/integration_test/src/tests/pidfile/pidfile_test.rs
+++ b/crates/integration_test/src/tests/pidfile/pidfile_test.rs
@@ -1,6 +1,6 @@
 use crate::utils::{
-    create_temp_dir, delete_container, generate_uuid, get_runtime_path, get_state_output, kill_container,
-    prepare_bundle, State, TempDir,
+    create_temp_dir, delete_container, generate_uuid, get_runtime_path, get_state_output,
+    kill_container, prepare_bundle, State, TempDir,
 };
 use anyhow::anyhow;
 use std::process::{Command, Stdio};

--- a/crates/integration_test/src/tests/pidfile/pidfile_test.rs
+++ b/crates/integration_test/src/tests/pidfile/pidfile_test.rs
@@ -1,5 +1,5 @@
 use crate::utils::{
-    create_temp_dir, delete_container, generate_uuid, get_runtime_path, get_state, kill_container,
+    create_temp_dir, delete_container, generate_uuid, get_runtime_path, get_state_output, kill_container,
     prepare_bundle, State, TempDir,
 };
 use anyhow::anyhow;
@@ -9,8 +9,9 @@ use uuid::Uuid;
 
 #[inline]
 fn cleanup(id: &Uuid, bundle: &TempDir) {
-    kill_container(id, bundle).unwrap().wait().unwrap();
-    delete_container(id, bundle).unwrap().wait().unwrap();
+    let str_id = id.to_string();
+    kill_container(&str_id, bundle).unwrap().wait().unwrap();
+    delete_container(&str_id, bundle).unwrap().wait().unwrap();
 }
 
 // here we have to manually create and manage the container
@@ -42,7 +43,7 @@ fn test_pidfile() -> TestResult {
         .wait()
         .unwrap();
 
-    let (out, err) = get_state(&container_id, &bundle).unwrap();
+    let (out, err) = get_state_output(&container_id.to_string(), &bundle).unwrap();
 
     if !err.is_empty() {
         cleanup(&container_id, &bundle);

--- a/crates/integration_test/src/utils/mod.rs
+++ b/crates/integration_test/src/utils/mod.rs
@@ -7,6 +7,6 @@ pub use support::{
 };
 pub use temp_dir::{create_temp_dir, TempDir};
 pub use test_utils::{
-    create_container, delete_container, get_state, get_state_output, kill_container,
-    test_inside_container, test_outside_container, ContainerData, State,
+    create_container, delete_container, get_state, kill_container, test_inside_container,
+    test_outside_container, ContainerData, State,
 };

--- a/crates/integration_test/src/utils/mod.rs
+++ b/crates/integration_test/src/utils/mod.rs
@@ -7,6 +7,6 @@ pub use support::{
 };
 pub use temp_dir::{create_temp_dir, TempDir};
 pub use test_utils::{
-    create_container, delete_container, get_state, kill_container, test_inside_container,
+    create_container, delete_container, get_state, get_state_output, kill_container, test_inside_container,
     test_outside_container, ContainerData, State,
 };

--- a/crates/integration_test/src/utils/mod.rs
+++ b/crates/integration_test/src/utils/mod.rs
@@ -7,6 +7,6 @@ pub use support::{
 };
 pub use temp_dir::{create_temp_dir, TempDir};
 pub use test_utils::{
-    create_container, delete_container, get_state, get_state_output, kill_container, test_inside_container,
-    test_outside_container, ContainerData, State,
+    create_container, delete_container, get_state, get_state_output, kill_container,
+    test_inside_container, test_outside_container, ContainerData, State,
 };

--- a/crates/integration_test/src/utils/support.rs
+++ b/crates/integration_test/src/utils/support.rs
@@ -78,7 +78,7 @@ pub fn prepare_bundle(id: &Uuid) -> Result<TempDir> {
 
     let mut spec = Spec::default();
     let mut process = Process::default();
-    process.set_args(Some(vec!["sleep".into(), "5".into()]));
+    process.set_args(Some(vec!["sleep".into(), "10".into()]));
     spec.set_process(Some(process));
     set_config(&temp_dir, &spec).unwrap();
 

--- a/crates/integration_test/src/utils/test_utils.rs
+++ b/crates/integration_test/src/utils/test_utils.rs
@@ -64,60 +64,63 @@ pub fn create_container<P: AsRef<Path>>(id: &Uuid, dir: P) -> Result<Child> {
 }
 
 /// Sends a kill command to the given container process
-pub fn kill_container<P: AsRef<Path>>(id: &Uuid, dir: P) -> Result<Child> {
-    let res = Command::new(get_runtime_path())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .arg("--root")
-        .arg(dir.as_ref().join("runtime"))
+pub fn kill_container<P: AsRef<Path>>(id: &str, dir: P) -> Result<Child> {
+    let res = runtime_command(dir)
         .arg("kill")
-        .arg(id.to_string())
+        .arg(id)
         .arg("9")
         .spawn()
         .context("could not kill container")?;
     Ok(res)
 }
 
-pub fn delete_container<P: AsRef<Path>>(id: &Uuid, dir: P) -> Result<Child> {
-    let res = Command::new(get_runtime_path())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .arg("--root")
-        .arg(dir.as_ref().join("runtime"))
+pub fn delete_container<P: AsRef<Path>>(id: &str, dir: P) -> Result<Child> {
+    let res = runtime_command(dir)
         .arg("delete")
-        .arg(id.to_string())
+        .arg(id)
         .spawn()
         .context("could not delete container")?;
     Ok(res)
 }
 
-pub fn get_state<P: AsRef<Path>>(id: &Uuid, dir: P) -> Result<(String, String)> {
-    sleep(SLEEP_TIME);
-    let output = Command::new(get_runtime_path())
+pub fn get_state<P: AsRef<Path>>(id: &str, dir: P) -> Result<Child> {
+    let res = Command::new(get_runtime_path())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .arg("--root")
         .arg(dir.as_ref().join("runtime"))
         .arg("state")
         .arg(id.to_string())
-        .spawn()?
+        .spawn()
+        .context("could not get container state")?;
+    Ok(res)
+}
+
+pub fn get_state_output<P: AsRef<Path>>(id: &str, dir: P) -> Result<(String, String)> {
+    sleep(SLEEP_TIME);
+    let output = get_state(id, dir)?
         .wait_with_output()?;
     let stderr = String::from_utf8(output.stderr).context("failed to parse std error stream")?;
     let stdout = String::from_utf8(output.stdout).context("failed to parse std output stream")?;
     Ok((stdout, stderr))
 }
 
-pub fn start_container<P: AsRef<Path>>(id: &Uuid, dir: P) -> Result<Child> {
-    let res = Command::new(get_runtime_path())
-        .stderr(Stdio::piped())
-        .stdout(Stdio::piped())
-        .arg("--root")
-        .arg(dir.as_ref().join("runtime"))
+pub fn start_container<P: AsRef<Path>>(id: &str, dir: P) -> Result<Child> {
+    let res = runtime_command(dir)
         .arg("start")
         .arg(id.to_string())
         .spawn()
         .context("could not start container")?;
     Ok(res)
+}
+
+fn runtime_command<P: AsRef<Path>>(dir: P) -> Command {
+    let mut command = Command::new(get_runtime_path());
+    command.stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .arg("--root")
+        .arg(dir.as_ref().join("runtime"));
+    command
 }
 
 pub fn test_outside_container(
@@ -128,7 +131,7 @@ pub fn test_outside_container(
     let bundle = prepare_bundle(&id).unwrap();
     set_config(&bundle, &spec).unwrap();
     let create_result = create_container(&id, &bundle).unwrap().wait();
-    let (out, err) = get_state(&id, &bundle).unwrap();
+    let (out, err) = get_state_output(&id.to_string(), &bundle).unwrap();
     let state: Option<State> = match serde_json::from_str(&out) {
         Ok(v) => Some(v),
         Err(_) => None,
@@ -140,8 +143,8 @@ pub fn test_outside_container(
         create_result,
     };
     let test_result = execute_test(data);
-    kill_container(&id, &bundle).unwrap().wait().unwrap();
-    delete_container(&id, &bundle).unwrap().wait().unwrap();
+    kill_container(&id.to_string(), &bundle).unwrap().wait().unwrap();
+    delete_container(&id.to_string(), &bundle).unwrap().wait().unwrap();
     test_result
 }
 
@@ -180,7 +183,7 @@ pub fn test_inside_container(
             .join("bin")
             .join("runtimetest"),
     )
-    .unwrap();
+        .unwrap();
     let create_process = create_container(&id, &bundle).unwrap();
     // here we do not wait for the process by calling wait() as in the test_outside_container
     // function because we need the output of the runtimetest. If we call wait, it will return
@@ -189,7 +192,7 @@ pub fn test_inside_container(
     // assume that the create command was successful. If it wasn't we can catch that error
     // in the start_container, as we can not start a non-created container anyways
     std::thread::sleep(std::time::Duration::from_millis(1000));
-    match start_container(&id, &bundle).unwrap().wait_with_output() {
+    match start_container(&id.to_string(), &bundle).unwrap().wait_with_output() {
         Ok(c) => c,
         Err(e) => return TestResult::Failed(anyhow!("container start failed : {:?}", e)),
     };
@@ -207,7 +210,7 @@ pub fn test_inside_container(
         ));
     }
 
-    let (out, err) = get_state(&id, &bundle).unwrap();
+    let (out, err) = get_state_output(&id.to_string(), &bundle).unwrap();
     if !err.is_empty() {
         return TestResult::Failed(anyhow!(
             "error in getting state after starting the container : {}",
@@ -215,15 +218,15 @@ pub fn test_inside_container(
         ));
     }
 
-    let state:State = match serde_json::from_str(&out) {
+    let state: State = match serde_json::from_str(&out) {
         Ok(v) => v,
         Err(e) => return TestResult::Failed(anyhow!("error in parsing state of container after start in test_inside_container : stdout : {}, parse error : {}",out,e)),
     };
     if state.status != "stopped" {
         return TestResult::Failed(anyhow!("error : unexpected container status in test_inside_runtime : expected stopped, got {}, container state : {:?}",state.status,state));
     }
-    kill_container(&id, &bundle).unwrap().wait().unwrap();
-    delete_container(&id, &bundle).unwrap().wait().unwrap();
+    kill_container(&id.to_string(), &bundle).unwrap().wait().unwrap();
+    delete_container(&id.to_string(), &bundle).unwrap().wait().unwrap();
     TestResult::Passed
 }
 

--- a/crates/integration_test/src/utils/test_utils.rs
+++ b/crates/integration_test/src/utils/test_utils.rs
@@ -98,8 +98,7 @@ pub fn get_state<P: AsRef<Path>>(id: &str, dir: P) -> Result<Child> {
 
 pub fn get_state_output<P: AsRef<Path>>(id: &str, dir: P) -> Result<(String, String)> {
     sleep(SLEEP_TIME);
-    let output = get_state(id, dir)?
-        .wait_with_output()?;
+    let output = get_state(id, dir)?.wait_with_output()?;
     let stderr = String::from_utf8(output.stderr).context("failed to parse std error stream")?;
     let stdout = String::from_utf8(output.stdout).context("failed to parse std output stream")?;
     Ok((stdout, stderr))
@@ -116,7 +115,8 @@ pub fn start_container<P: AsRef<Path>>(id: &str, dir: P) -> Result<Child> {
 
 fn runtime_command<P: AsRef<Path>>(dir: P) -> Command {
     let mut command = Command::new(get_runtime_path());
-    command.stdout(Stdio::piped())
+    command
+        .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .arg("--root")
         .arg(dir.as_ref().join("runtime"));
@@ -143,8 +143,14 @@ pub fn test_outside_container(
         create_result,
     };
     let test_result = execute_test(data);
-    kill_container(&id.to_string(), &bundle).unwrap().wait().unwrap();
-    delete_container(&id.to_string(), &bundle).unwrap().wait().unwrap();
+    kill_container(&id.to_string(), &bundle)
+        .unwrap()
+        .wait()
+        .unwrap();
+    delete_container(&id.to_string(), &bundle)
+        .unwrap()
+        .wait()
+        .unwrap();
     test_result
 }
 
@@ -183,7 +189,7 @@ pub fn test_inside_container(
             .join("bin")
             .join("runtimetest"),
     )
-        .unwrap();
+    .unwrap();
     let create_process = create_container(&id, &bundle).unwrap();
     // here we do not wait for the process by calling wait() as in the test_outside_container
     // function because we need the output of the runtimetest. If we call wait, it will return
@@ -192,7 +198,10 @@ pub fn test_inside_container(
     // assume that the create command was successful. If it wasn't we can catch that error
     // in the start_container, as we can not start a non-created container anyways
     std::thread::sleep(std::time::Duration::from_millis(1000));
-    match start_container(&id.to_string(), &bundle).unwrap().wait_with_output() {
+    match start_container(&id.to_string(), &bundle)
+        .unwrap()
+        .wait_with_output()
+    {
         Ok(c) => c,
         Err(e) => return TestResult::Failed(anyhow!("container start failed : {:?}", e)),
     };
@@ -225,8 +234,14 @@ pub fn test_inside_container(
     if state.status != "stopped" {
         return TestResult::Failed(anyhow!("error : unexpected container status in test_inside_runtime : expected stopped, got {}, container state : {:?}",state.status,state));
     }
-    kill_container(&id.to_string(), &bundle).unwrap().wait().unwrap();
-    delete_container(&id.to_string(), &bundle).unwrap().wait().unwrap();
+    kill_container(&id.to_string(), &bundle)
+        .unwrap()
+        .wait()
+        .unwrap();
+    delete_container(&id.to_string(), &bundle)
+        .unwrap()
+        .wait()
+        .unwrap();
     TestResult::Passed
 }
 


### PR DESCRIPTION
Hey 👋 
I am looking into trying to add/extend integration tests and notice some duplication around commands execution code.

I did not find any reason why not to reuse some of the code from `test_utils.rs`, but in case I missed something and duplication was intentional let me know 🙂 