### PR TITLE
Use buffered io for reading state file

### DIFF
--- a/crates/libcontainer/src/container/state.rs
+++ b/crates/libcontainer/src/container/state.rs
@@ -2,6 +2,7 @@
 use std::collections::HashMap;
 use std::fmt::Display;
 use std::fs;
+use std::io::BufReader;
 use std::path::PathBuf;
 use std::{fs::File, path::Path};
 
@@ -137,10 +138,11 @@ impl State {
 
     pub fn load(container_root: &Path) -> Result<Self> {
         let state_file_path = Self::file_path(container_root);
-        let file = File::open(&state_file_path).with_context(|| {
+        let state_file = File::open(&state_file_path).with_context(|| {
             format!("failed to open container state file {:?}", state_file_path)
         })?;
-        let state: Self = serde_json::from_reader(&file)?;
+
+        let state: Self = serde_json::from_reader(BufReader::new(state_file))?;
         Ok(state)
     }
 


### PR DESCRIPTION
Deserializing the state file triggers dozens of small reads. With this only one read is performed.