### PR TITLE
Add tests to crates/libcgroups/src/v2/devices/controller.rs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -484,10 +484,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "difflib"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
 name = "discard"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "212d0f5754cb6769937f4501cc0e67f4f4483c8d2c3e1e922ee9edbe4ab4c7c0"
+
+[[package]]
+name = "downcast"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
 
 [[package]]
 name = "either"
@@ -626,6 +638,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "float-cmp"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -640,6 +661,12 @@ dependencies = [
  "matches",
  "percent-encoding",
 ]
+
+[[package]]
+name = "fragile"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8da1b8f89c5b5a5b7e59405cfcf0bb9588e5ed19f0b57a4cd542bbba3f164a6d"
 
 [[package]]
 name = "futures"
@@ -912,6 +939,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9a9d19fa1e79b6215ff29b9d6880b706147f16e9b1dbb1e4e5947b5b02bc5e3"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -976,6 +1012,7 @@ dependencies = [
  "libbpf-sys",
  "libc",
  "log",
+ "mockall",
  "nix",
  "oci-spec 0.5.3",
  "procfs",
@@ -1183,6 +1220,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "mockall"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d4d70639a72f972725db16350db56da68266ca368b2a1fe26724a903ad3d6b8"
+dependencies = [
+ "cfg-if 1.0.0",
+ "downcast",
+ "fragile",
+ "lazy_static",
+ "mockall_derive",
+ "predicates",
+ "predicates-tree",
+]
+
+[[package]]
+name = "mockall_derive"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79ef208208a0dea3f72221e26e904cdc6db2e481d9ade89081ddd494f1dbaa6b"
+dependencies = [
+ "cfg-if 1.0.0",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "more-asserts"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1200,6 +1264,12 @@ dependencies = [
  "libc",
  "memoffset",
 ]
+
+[[package]]
+name = "normalize-line-endings"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
 
 [[package]]
 name = "ntapi"
@@ -1458,6 +1528,36 @@ checksum = "059a34f111a9dee2ce1ac2826a68b24601c4298cfeb1a587c3cb493d5ab46f52"
 dependencies = [
  "libc",
  "nix",
+]
+
+[[package]]
+name = "predicates"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5aab5be6e4732b473071984b3164dbbfb7a3674d30ea5ff44410b6bcd960c3c"
+dependencies = [
+ "difflib",
+ "float-cmp",
+ "itertools",
+ "normalize-line-endings",
+ "predicates-core",
+ "regex",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da1c2388b1513e1b605fcec39a95e0a9e8ef088f71443ef37099fa9ae6673fcb"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d86de6de25020a36c6d3643a86d9a6a9f552107c0559c60ea03551b5e16c032"
+dependencies = [
+ "predicates-core",
+ "termtree",
 ]
 
 [[package]]
@@ -2030,6 +2130,12 @@ checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
 dependencies = [
  "winapi-util",
 ]
+
+[[package]]
+name = "termtree"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507e9898683b6c43a9aa55b64259b721b52ba226e0f3779137e50ad114a4c90b"
 
 [[package]]
 name = "test_framework"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1020,6 +1020,7 @@ dependencies = [
  "rbpf",
  "serde",
  "serde_json",
+ "serial_test",
 ]
 
 [[package]]

--- a/crates/libcgroups/Cargo.toml
+++ b/crates/libcgroups/Cargo.toml
@@ -34,3 +34,4 @@ clap = "3.0.0-beta.5"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 env_logger = "0.9"
+serial_test = "0.5.1"

--- a/crates/libcgroups/Cargo.toml
+++ b/crates/libcgroups/Cargo.toml
@@ -29,6 +29,7 @@ libc = { version = "0.2.117", optional = true }
 [dev-dependencies]
 oci-spec = { version = "0.5.3", features = ["proptests"] }
 quickcheck = "1"
+mockall = { version = "0.11.0", features = [] }
 clap = "3.0.0-beta.5"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/crates/libcgroups/src/lib.rs
+++ b/crates/libcgroups/src/lib.rs
@@ -4,6 +4,11 @@
 #[cfg(test)]
 #[macro_use]
 extern crate quickcheck;
+
+#[cfg(test)]
+#[macro_use]
+extern crate mockall;
+
 mod test;
 
 pub mod common;

--- a/crates/libcgroups/src/v2/devices/bpf.rs
+++ b/crates/libcgroups/src/v2/devices/bpf.rs
@@ -1,117 +1,124 @@
-use anyhow::{bail, Result};
-use std::os::unix::io::RawFd;
-use std::ptr;
-
-// FIXME: add tests
-
-pub fn prog_load(license: &str, insns: &[u8]) -> Result<RawFd> {
-    let insns_cnt = insns.len() / std::mem::size_of::<libbpf_sys::bpf_insn>();
-    let insns = insns as *const _ as *const libbpf_sys::bpf_insn;
-
-    let prog_fd = unsafe {
-        libbpf_sys::bpf_load_program(
-            libbpf_sys::BPF_PROG_TYPE_CGROUP_DEVICE,
-            insns,
-            insns_cnt as u64,
-            license as *const _ as *const i8,
-            0,
-            ptr::null_mut::<i8>(),
-            0,
-        )
-    };
-
-    if prog_fd < 0 {
-        return Err(errno::errno().into());
-    }
-    Ok(prog_fd)
-}
-
+#[derive(Clone)]
 pub struct ProgramInfo {
     pub id: u32,
     pub fd: i32,
 }
 
-pub fn prog_query(cgroup_fd: RawFd) -> Result<Vec<ProgramInfo>> {
-    let mut prog_ids: Vec<u32> = vec![0_u32; 64];
-    let mut attach_flags = 0_u32;
-    for _ in 0..10 {
-        let mut prog_cnt = prog_ids.len() as u32;
-        let ret = unsafe {
-            libbpf_sys::bpf_prog_query(
-                cgroup_fd,
-                libbpf_sys::BPF_CGROUP_DEVICE,
+#[cfg_attr(test, automock)]
+pub mod prog {
+    use super::ProgramInfo;
+    use anyhow::{bail, Result};
+    use std::os::unix::io::RawFd;
+    use std::ptr;
+
+    pub fn load(license: &str, insns: &[u8]) -> Result<RawFd> {
+        let insns_cnt = insns.len() / std::mem::size_of::<libbpf_sys::bpf_insn>();
+        let insns = insns as *const _ as *const libbpf_sys::bpf_insn;
+
+        let prog_fd = unsafe {
+            libbpf_sys::bpf_load_program(
+                libbpf_sys::BPF_PROG_TYPE_CGROUP_DEVICE,
+                insns,
+                insns_cnt as u64,
+                license as *const _ as *const i8,
                 0,
-                &mut attach_flags,
-                &prog_ids[0] as *const u32 as *mut u32,
-                &mut prog_cnt,
+                ptr::null_mut::<i8>(),
+                0,
             )
         };
-        if ret != 0 {
-            let err = errno::errno();
-            if err.0 == libc::ENOSPC {
-                assert!(prog_cnt as usize > prog_ids.len());
 
-                // allocate more space and try again
-                prog_ids.resize(prog_cnt as usize, 0);
-                continue;
+        if prog_fd < 0 {
+            return Err(errno::errno().into());
+        }
+        Ok(prog_fd)
+    }
+
+    /// Given a fd for a cgroup, collect the programs associated with it
+    pub fn query(cgroup_fd: RawFd) -> Result<Vec<ProgramInfo>> {
+        let mut prog_ids: Vec<u32> = vec![0_u32; 64];
+        let mut attach_flags = 0_u32;
+        for _ in 0..10 {
+            let mut prog_cnt = prog_ids.len() as u32;
+            let ret = unsafe {
+                // collect ids for bpf programs
+                libbpf_sys::bpf_prog_query(
+                    cgroup_fd,
+                    libbpf_sys::BPF_CGROUP_DEVICE,
+                    0,
+                    &mut attach_flags,
+                    &prog_ids[0] as *const u32 as *mut u32,
+                    &mut prog_cnt,
+                )
+            };
+            if ret != 0 {
+                let err = errno::errno();
+                if err.0 == libc::ENOSPC {
+                    assert!(prog_cnt as usize > prog_ids.len());
+
+                    // allocate more space and try again
+                    prog_ids.resize(prog_cnt as usize, 0);
+                    continue;
+                }
+
+                return Err(err.into());
             }
 
-            return Err(err.into());
+            prog_ids.resize(prog_cnt as usize, 0);
+            break;
         }
 
-        prog_ids.resize(prog_cnt as usize, 0);
-        break;
-    }
-
-    let mut prog_fds = Vec::with_capacity(prog_ids.len());
-    for prog_id in &prog_ids {
-        let prog_fd = unsafe { libbpf_sys::bpf_prog_get_fd_by_id(*prog_id) };
-        if prog_fd < 0 {
-            log::debug!("bpf_prog_get_fd_by_id failed: {}", errno::errno());
-            continue;
+        let mut prog_fds = Vec::with_capacity(prog_ids.len());
+        for prog_id in &prog_ids {
+            // collect fds for programs by getting their ids
+            let prog_fd = unsafe { libbpf_sys::bpf_prog_get_fd_by_id(*prog_id) };
+            if prog_fd < 0 {
+                log::debug!("bpf_prog_get_fd_by_id failed: {}", errno::errno());
+                continue;
+            }
+            prog_fds.push(ProgramInfo {
+                id: *prog_id,
+                fd: prog_fd,
+            });
         }
-        prog_fds.push(ProgramInfo {
-            id: *prog_id,
-            fd: prog_fd,
-        });
-    }
-    Ok(prog_fds)
-}
-
-pub fn prog_detach2(prog_fd: RawFd, cgroup_fd: RawFd) -> Result<()> {
-    let ret =
-        unsafe { libbpf_sys::bpf_prog_detach2(prog_fd, cgroup_fd, libbpf_sys::BPF_CGROUP_DEVICE) };
-    if ret != 0 {
-        return Err(errno::errno().into());
-    }
-    Ok(())
-}
-
-pub fn prog_attach(prog_fd: RawFd, cgroup_fd: RawFd) -> Result<()> {
-    let ret = unsafe {
-        libbpf_sys::bpf_prog_attach(
-            prog_fd,
-            cgroup_fd,
-            libbpf_sys::BPF_CGROUP_DEVICE,
-            libbpf_sys::BPF_F_ALLOW_MULTI,
-        )
-    };
-
-    if ret != 0 {
-        return Err(errno::errno().into());
-    }
-    Ok(())
-}
-
-pub fn bump_memlock_rlimit() -> Result<()> {
-    let rlimit = libc::rlimit {
-        rlim_cur: 128 << 20,
-        rlim_max: 128 << 20,
-    };
-
-    if unsafe { libc::setrlimit(libc::RLIMIT_MEMLOCK, &rlimit) } != 0 {
-        bail!("Failed to increase rlimit");
+        Ok(prog_fds)
     }
 
-    Ok(())
+    pub fn detach2(prog_fd: RawFd, cgroup_fd: RawFd) -> Result<()> {
+        let ret = unsafe {
+            libbpf_sys::bpf_prog_detach2(prog_fd, cgroup_fd, libbpf_sys::BPF_CGROUP_DEVICE)
+        };
+        if ret != 0 {
+            return Err(errno::errno().into());
+        }
+        Ok(())
+    }
+
+    pub fn attach(prog_fd: RawFd, cgroup_fd: RawFd) -> Result<()> {
+        let ret = unsafe {
+            libbpf_sys::bpf_prog_attach(
+                prog_fd,
+                cgroup_fd,
+                libbpf_sys::BPF_CGROUP_DEVICE,
+                libbpf_sys::BPF_F_ALLOW_MULTI,
+            )
+        };
+
+        if ret != 0 {
+            return Err(errno::errno().into());
+        }
+        Ok(())
+    }
+
+    pub fn bump_memlock_rlimit() -> Result<()> {
+        let rlimit = libc::rlimit {
+            rlim_cur: 128 << 20,
+            rlim_max: 128 << 20,
+        };
+
+        if unsafe { libc::setrlimit(libc::RLIMIT_MEMLOCK, &rlimit) } != 0 {
+            bail!("Failed to increase rlimit");
+        }
+
+        Ok(())
+    }
 }

--- a/crates/libcgroups/src/v2/devices/controller.rs
+++ b/crates/libcgroups/src/v2/devices/controller.rs
@@ -103,12 +103,15 @@ impl Devices {
 mod tests {
     use super::*;
     use crate::test::setup;
+    use serial_test::serial;
+
     use oci_spec::runtime::{LinuxDeviceCgroupBuilder, LinuxDeviceType};
     use std::os::unix::io::RawFd;
 
     use bpf::mock_prog;
 
     #[test]
+    #[serial(bpf)] // mock contexts are shared
     fn test_apply_devices() {
         // arrange
         let (tmp, _) = setup("test_apply_devices", "some.value");
@@ -137,6 +140,7 @@ mod tests {
     }
 
     #[test]
+    #[serial(bpf)] // mock contexts are shared
     fn test_existing_programs() {
         // arrange
         let (tmp, _) = setup("test_existing_programs", "some.value");


### PR DESCRIPTION
In order to add these tests, I added `mockall` to the dev dependencies.

There are some things that could be cleaner, eg using mockall's `double`
or `cfg_if` but I did not want to bloat the release dependencies with extra crates.

This required some changes to the v2/devices/bpf module, introducing an
intermediate module `prog` to wrap the various `prog_*` functions inside.
Those functions were then renamed to remove the `prog_` prefix.
The addition of this intermediate module allowed us to use the `automock`
macro to automatically generate mocked functions. This is a useful
testing pattern that can be used in the future on the bpf module itself.

Signed-off-by: Christian Burke <cr0ax64@gmail.com>