### PR TITLE
Add a description to 'create daemon.json' in Basic Usage in docs

### DIFF
--- a/docs/src/user/basic_usage.md
+++ b/docs/src/user/basic_usage.md
@@ -61,7 +61,7 @@ sudo systemctl start docker
 With newer versions of docker, you can update file `/etc/docker/daemon.json` to
 let docker know youki
 ([source](https://docs.docker.com/engine/reference/commandline/dockerd/#on-linux)).
-A sample content of it:
+You may need to create this file, if it does not yet exist. A sample content of it:
 ```
 {
   "default-runtime": "runc",


### PR DESCRIPTION
Awesome project!

While going through the docs I noticed diff from [docker docs](https://docs.docker.com/config/daemon/#enable-debugging), so I tried to add description. Hope it is somewhat useful.


<a href="https://gitpod.io/#https://github.com/containers/youki/pull/707"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

