### PR TITLE
remove cargo config

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,2 +1,0 @@
-[build]
-target = "x86_64-unknown-linux-gnu"


### PR DESCRIPTION
Signed-off-by: ye.sijun <junnplus@gmail.com>

I build youki in arm linux, but build failed. `.cargo/config` sets a specific target.

Discussion from https://github.com/containers/youki/issues/617, I think we should delete them.