### PR TITLE
Remove caching of OCI tests in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -107,12 +107,6 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: recursive
-      - name: Cache runtime-tools
-        id: cache-runtime-tools
-        uses: actions/cache@v2
-        with:
-          path: integration_test
-          key: ${{ runner.os }}-${{ matrix.rust }}-primes
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: ${{ matrix.rust }}
@@ -125,6 +119,6 @@ jobs:
         run: ./build.sh --release
       - uses: actions/setup-go@v2
         with:
-          go-version: "1.11.0"
+          go-version: "1.17.6"
       - name: Run integration tests
         run: ./integration_test.sh

--- a/crates/libcontainer/src/syscall/linux.rs
+++ b/crates/libcontainer/src/syscall/linux.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 use std::{any::Any, mem, path::Path, ptr};
 
 use anyhow::{anyhow, bail, Result};
-use caps::{CapSet, Capability, CapsHashSet};
+use caps::{CapSet, CapsHashSet};
 use libc::{c_char, uid_t};
 use nix::{
     errno::Errno,
@@ -132,15 +132,7 @@ impl Syscall for LinuxSyscall {
                 // for each such =, drop that capability
                 // after this, only those which are to be set will remain set
                 for c in all.difference(value) {
-                    match c {
-                        Capability::CAP_PERFMON
-                        | Capability::CAP_CHECKPOINT_RESTORE
-                        | Capability::CAP_BPF => {
-                            log::warn!("{:?} is not supported.", c);
-                            continue;
-                        }
-                        _ => caps::drop(None, CapSet::Bounding, *c)?,
-                    }
+                    caps::drop(None, CapSet::Bounding, *c)?
                 }
             }
             _ => {


### PR DESCRIPTION
This removes caching of OCI tests in CI. This is regarding to #721 , and should work as a temporary solution to it. This will increase the CI time, but will always use the latest commit version. There might be some work-around such that we can cache and invalidate cache when new commits are added to OCi repo, but this does not address it, it can be done in a separate PR.

<a href="https://gitpod.io/#https://github.com/containers/youki/pull/727"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

