### PR TITLE
Fix Cargo.lock file that gets generated after build

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1026,7 +1026,7 @@ dependencies = [
  "rbpf",
  "serde",
  "serde_json",
- "serial_test",
+ "serial_test 0.5.1",
 ]
 
 [[package]]
@@ -1054,7 +1054,7 @@ dependencies = [
  "rand",
  "serde",
  "serde_json",
- "serial_test",
+ "serial_test 0.6.0",
  "wasmer",
  "wasmer-wasi",
 ]
@@ -1938,13 +1938,35 @@ dependencies = [
 
 [[package]]
 name = "serial_test"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0bccbcf40c8938196944a3da0e133e031a33f4d6b72db3bda3cc556e361905d"
+dependencies = [
+ "lazy_static",
+ "parking_lot",
+ "serial_test_derive 0.5.1",
+]
+
+[[package]]
+name = "serial_test"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5bcc41d18f7a1d50525d080fd3e953be87c4f9f1a974f3c21798ca00d54ec15"
 dependencies = [
  "lazy_static",
  "parking_lot",
- "serial_test_derive",
+ "serial_test_derive 0.6.0",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2acd6defeddb41eb60bb468f8825d0cfd0c2a76bc03bfd235b6a1dc4f6a1ad5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2746,7 +2768,7 @@ dependencies = [
  "procfs",
  "serde",
  "serde_json",
- "serial_test",
+ "serial_test 0.6.0",
  "tabwriter",
  "vergen",
 ]


### PR DESCRIPTION
Running `cargo build` on the `main` branch generates a diff in `Cargo.lock` file. 

Signed-off-by: Harshal Patil <harpatil@redhat.com>

<a href="https://gitpod.io/#https://github.com/containers/youki/pull/734"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

