### PR TITLE
Handle relative paths

### DIFF
--- a/crates/libcontainer/src/container/builder.rs
+++ b/crates/libcontainer/src/container/builder.rs
@@ -106,10 +106,10 @@ impl<'a> ContainerBuilder<'a> {
     /// .with_root_path("/run/containers/youki").expect("invalid root path");
     /// ```
     pub fn with_root_path<P: Into<PathBuf>>(mut self, path: P) -> Result<Self> {
+        let path = path.into();
         self.root_path = path
-            .into()
             .canonicalize()
-            .context("failed to canonicalize root path")?;
+            .with_context(|| format!("failed to canonicalize root path {:?}", path))?;
         Ok(self)
     }
 
@@ -126,10 +126,10 @@ impl<'a> ContainerBuilder<'a> {
     /// ```
     pub fn with_pid_file<P: Into<PathBuf>>(mut self, path: Option<P>) -> Result<Self> {
         self.pid_file = if let Some(p) = path {
+            let path = p.into();
             Some(
-                p.into()
-                    .canonicalize()
-                    .context("failed canonicalize pid file path")?,
+                path.canonicalize()
+                    .with_context(|| format!("failed to canonicalize pid file path {:?}", path))?,
             )
         } else {
             None

--- a/crates/libcontainer/src/container/init_builder.rs
+++ b/crates/libcontainer/src/container/init_builder.rs
@@ -39,10 +39,14 @@ impl<'a> InitContainerBuilder<'a> {
 
     /// Creates a new container
     pub fn build(self) -> Result<Container> {
-        let spec = self.load_spec()?;
-        let container_dir = self.create_container_dir()?;
+        let spec = self.load_spec().context("failed to load spec")?;
+        let container_dir = self
+            .create_container_dir()
+            .context("failed to create container dir")?;
 
-        let mut container = self.create_container_state(&container_dir)?;
+        let mut container = self
+            .create_container_state(&container_dir)
+            .context("failed to create container state")?;
         container
             .set_systemd(self.use_systemd)
             .set_annotations(spec.annotations().clone());
@@ -66,7 +70,9 @@ impl<'a> InitContainerBuilder<'a> {
 
         let rootless = Rootless::new(&spec)?;
         let config = YoukiConfig::from_spec(&spec, container.id(), rootless.is_some())?;
-        config.save(&container_dir)?;
+        config
+            .save(&container_dir)
+            .context("failed to save config")?;
 
         let mut builder_impl = ContainerBuilderImpl {
             init: true,
@@ -97,7 +103,8 @@ impl<'a> InitContainerBuilder<'a> {
             bail!("container {} already exists", self.base.container_id);
         }
 
-        utils::create_dir_all(&container_dir)?;
+        utils::create_dir_all(&container_dir).context("failed to create container dir")?;
+
         Ok(container_dir)
     }
 

--- a/crates/youki/src/commands/create.rs
+++ b/crates/youki/src/commands/create.rs
@@ -13,9 +13,9 @@ use liboci_cli::Create;
 pub fn create(args: Create, root_path: PathBuf, systemd_cgroup: bool) -> Result<()> {
     let syscall = create_syscall();
     ContainerBuilder::new(args.container_id.clone(), syscall.as_ref())
-        .with_pid_file(args.pid_file.as_ref())
+        .with_pid_file(args.pid_file.as_ref())?
         .with_console_socket(args.console_socket.as_ref())
-        .with_root_path(root_path)
+        .with_root_path(root_path)?
         .with_preserved_fds(args.preserve_fds)
         .as_init(&args.bundle)
         .with_systemd(systemd_cgroup)

--- a/crates/youki/src/commands/exec.rs
+++ b/crates/youki/src/commands/exec.rs
@@ -7,9 +7,9 @@ use liboci_cli::Exec;
 pub fn exec(args: Exec, root_path: PathBuf) -> Result<()> {
     let syscall = create_syscall();
     ContainerBuilder::new(args.container_id.clone(), syscall.as_ref())
-        .with_root_path(root_path)
+        .with_root_path(root_path)?
         .with_console_socket(args.console_socket.as_ref())
-        .with_pid_file(args.pid_file.as_ref())
+        .with_pid_file(args.pid_file.as_ref())?
         .as_tenant()
         .with_cwd(args.cwd.as_ref())
         .with_env(args.env.clone().into_iter().collect())

--- a/crates/youki/src/commands/run.rs
+++ b/crates/youki/src/commands/run.rs
@@ -7,9 +7,9 @@ use liboci_cli::Run;
 pub fn run(args: Run, root_path: PathBuf, systemd_cgroup: bool) -> Result<()> {
     let syscall = create_syscall();
     let mut container = ContainerBuilder::new(args.container_id.clone(), syscall.as_ref())
-        .with_pid_file(args.pid_file.as_ref())
+        .with_pid_file(args.pid_file.as_ref())?
         .with_console_socket(args.console_socket.as_ref())
-        .with_root_path(root_path)
+        .with_root_path(root_path)?
         .with_preserved_fds(args.preserve_fds)
         .as_init(&args.bundle)
         .with_systemd(systemd_cgroup)

--- a/crates/youki/src/commands/state.rs
+++ b/crates/youki/src/commands/state.rs
@@ -1,15 +1,12 @@
-use std::fs;
 use std::path::PathBuf;
 
 use anyhow::Result;
 
-use libcontainer::container::Container;
+use crate::commands::load_container;
 use liboci_cli::State;
 
 pub fn state(args: State, root_path: PathBuf) -> Result<()> {
-    let root_path = fs::canonicalize(root_path)?;
-    let container_root = root_path.join(&args.container_id);
-    let container = Container::load(container_root)?;
+    let container = load_container(root_path, &args.container_id)?;
     println!("{}", serde_json::to_string_pretty(&container.state)?);
     std::process::exit(0);
 }

--- a/crates/youki/src/main.rs
+++ b/crates/youki/src/main.rs
@@ -216,16 +216,14 @@ mod tests {
         // Make sure directory does not exist.
         remove_dir(&specified_path)?;
         let non_abs_path = specified_path.join("../provided_path");
-        let path = determine_root_path(Some(non_abs_path))
-            .context("failed with specified path")?;
+        let path = determine_root_path(Some(non_abs_path)).context("failed with specified path")?;
         assert_eq!(path, specified_path);
 
         // Return absolute path if directory exists.
         let specified_path = get_temp_dir_path("provided_path2");
         let _temp_dir = TempDir::new(&specified_path).context("failed to create temp dir")?;
         let non_abs_path = specified_path.join("../provided_path2");
-        let path = determine_root_path(Some(non_abs_path))
-            .context("failed with specified path")?;
+        let path = determine_root_path(Some(non_abs_path)).context("failed with specified path")?;
         assert_eq!(path, specified_path);
 
         Ok(())

--- a/crates/youki/src/main.rs
+++ b/crates/youki/src/main.rs
@@ -207,7 +207,7 @@ mod tests {
     use std::fs;
     use std::fs::Permissions;
     use std::os::unix::fs::PermissionsExt;
-    use std::path::PathBuf;
+    use std::path::{Path, PathBuf};
 
     #[test]
     fn test_determine_root_path_use_specified_by_user() -> Result<()> {
@@ -216,7 +216,7 @@ mod tests {
         // Make sure directory does not exist.
         remove_dir(&specified_path)?;
         let non_abs_path = specified_path.join("../provided_path");
-        let path = determine_root_path(Some(non_abs_path.clone()))
+        let path = determine_root_path(Some(non_abs_path))
             .context("failed with specified path")?;
         assert_eq!(path, specified_path);
 
@@ -224,7 +224,7 @@ mod tests {
         let specified_path = get_temp_dir_path("provided_path2");
         let _temp_dir = TempDir::new(&specified_path).context("failed to create temp dir")?;
         let non_abs_path = specified_path.join("../provided_path2");
-        let path = determine_root_path(Some(non_abs_path.clone()))
+        let path = determine_root_path(Some(non_abs_path))
             .context("failed with specified path")?;
         assert_eq!(path, specified_path);
 
@@ -316,7 +316,7 @@ mod tests {
         Ok(())
     }
 
-    fn remove_dir(path: &PathBuf) -> Result<()> {
+    fn remove_dir(path: &Path) -> Result<()> {
         if path.exists() {
             fs::remove_dir(path).context("failed to remove directory")?;
         }


### PR DESCRIPTION
This PR improves the handling of relative paths for `root_path` and `pid_file`. I decided to create the specified directory early in `determine_root_path` if it does not exist, as this seems to be the only way to `canonicalize` path prior to creating container dir (path needs to exist otherwise `canonicalize` will fail). This results in the directory being created for other commands like `list` or `delete` also which might not be ideal, but `runc` seems to work this way either so decided to stick with it.

Also not sure about canonicalizing those paths in `ContainerBuilder` as it disrupts the interface slightly by introducing `Result<Self>` as a return type to some methods, however, I did not find a better place for that so if anyone has some suggestions please let me know.

Additionally, I have added context to a few errors that made it easier to initially troubleshoot.

Fixes #720

<a href="https://gitpod.io/#https://github.com/containers/youki/pull/740"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

