### PR TITLE
Update oci-spec-rs to v0.5.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -925,7 +925,7 @@ dependencies = [
  "log",
  "nix",
  "num_cpus",
- "oci-spec 0.5.2",
+ "oci-spec",
  "once_cell",
  "pnet",
  "procfs",
@@ -1023,7 +1023,7 @@ dependencies = [
  "log",
  "mockall",
  "nix",
- "oci-spec 0.5.4",
+ "oci-spec",
  "procfs",
  "quickcheck",
  "rbpf",
@@ -1049,7 +1049,7 @@ dependencies = [
  "log",
  "mio",
  "nix",
- "oci-spec 0.5.4",
+ "oci-spec",
  "path-clean",
  "prctl",
  "procfs",
@@ -1120,9 +1120,9 @@ checksum = "9a7cbbd4ad467251987c6e5b47d53b11a5a05add08f2447a9e2d70aef1e0d138"
 
 [[package]]
 name = "libz-sys"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de5435b8549c16d423ed0c03dbaafe57cf6c3344744f1242520d59c9d8ecec66"
+checksum = "df2bf61678a0a521c3f7daf815d2e6717d85a272a7dcd02c9768272b32bd1e2a"
 dependencies = [
  "cc",
  "libc",
@@ -1353,21 +1353,9 @@ dependencies = [
 
 [[package]]
 name = "oci-spec"
-version = "0.5.2"
-source = "git+https://github.com/containers/oci-spec-rs?rev=54c5e386f01ab37c9305cc4a83404eb157e42440#54c5e386f01ab37c9305cc4a83404eb157e42440"
-dependencies = [
- "derive_builder",
- "getset",
- "serde",
- "serde_json",
- "thiserror",
-]
-
-[[package]]
-name = "oci-spec"
-version = "0.5.4"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b409d52fff741f330914aa6b8ab73e9113607bb13fbc09f95cdb04d16c8dd5d"
+checksum = "71a85b9f9654fe5c3eab8907369250c05aeda9d807b76bd06c740601f881dc02"
 dependencies = [
  "derive_builder",
  "getset",
@@ -2684,9 +2672,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-wasi"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c2b1d981ad312dac6e74a41a35b9bca41a6d1157c3e6a575fb1041e4b516610"
+checksum = "df791d89498c2a4288f89a5807e67248c1c75924316f67b9edcfc89198fd1711"
 dependencies = [
  "cfg-if 1.0.0",
  "generational-arena",
@@ -2802,7 +2790,7 @@ dependencies = [
  "liboci-cli",
  "log",
  "nix",
- "oci-spec 0.5.4",
+ "oci-spec",
  "once_cell",
  "pentacle",
  "procfs",

--- a/crates/integration_test/Cargo.toml
+++ b/crates/integration_test/Cargo.toml
@@ -12,7 +12,7 @@ libcontainer = { path = "../libcontainer" }
 log = { version = "0.4", features = ["std"] }
 nix = "0.23.1"
 num_cpus = "1.13"
-oci-spec = { git = "https://github.com/containers/oci-spec-rs", rev = "54c5e386f01ab37c9305cc4a83404eb157e42440" }
+oci-spec = "0.5.5"
 once_cell = "1.10.0"
 pnet = "0.29.0"
 procfs = "0.12.0"

--- a/crates/libcgroups/Cargo.toml
+++ b/crates/libcgroups/Cargo.toml
@@ -25,7 +25,7 @@ nix = "0.23.1"
 procfs = "0.12.0"
 log = "0.4"
 anyhow = "1.0"
-oci-spec = "0.5.3"
+oci-spec = "0.5.5"
 dbus = { version = "0.9.5", optional = true }
 fixedbitset = "0.4.1"
 serde = { version = "1.0", features = ["derive"] }
@@ -35,7 +35,7 @@ errno = { version = "0.2.8", optional = true }
 libc = { version = "0.2.119", optional = true }
 
 [dev-dependencies]
-oci-spec = { version = "0.5.3", features = ["proptests"] }
+oci-spec = { version = "0.5.5", features = ["proptests"] }
 quickcheck = "1"
 mockall = { version = "0.11.0", features = [] }
 clap = "3.0.0-beta.5"

--- a/crates/libcontainer/Cargo.toml
+++ b/crates/libcontainer/Cargo.toml
@@ -29,7 +29,7 @@ libc = "0.2.119"
 log = "0.4"
 mio = { version = "0.8.0", features = ["os-ext", "os-poll"] }
 nix = "0.23.1"
-oci-spec = "0.5.3"
+oci-spec = "0.5.5"
 path-clean = "0.1.0"
 procfs = "0.12.0"
 prctl = "1.0.0"
@@ -42,7 +42,7 @@ wasmer = { version = "2.2.0", optional = true }
 wasmer-wasi = { version = "2.1.1", optional = true }
 
 [dev-dependencies]
-oci-spec = { version = "0.5.3", features = ["proptests"] }
+oci-spec = { version = "0.5.5", features = ["proptests"] }
 quickcheck = "1"
 serial_test = "0.6.0"
 rand = "0.8.5"

--- a/crates/youki/Cargo.toml
+++ b/crates/youki/Cargo.toml
@@ -26,7 +26,7 @@ libcontainer = { version = "0.0.2", path = "../libcontainer" }
 liboci-cli = { version = "0.0.2", path = "../liboci-cli" }
 log = { version = "0.4", features = ["std"]}
 nix = "0.23.1"
-oci-spec = "0.5.3"
+oci-spec = "0.5.5"
 once_cell = "1.10.0"
 pentacle = "1.0.0"
 procfs = "0.12.0"

--- a/runtimetest/Cargo.toml
+++ b/runtimetest/Cargo.toml
@@ -10,5 +10,5 @@ members = []
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-oci-spec = "0.5.3"
+oci-spec = "0.5.5"
 nix = "0.23.1"


### PR DESCRIPTION
This means we can now use the filter types to enforce tighter type checks.


<a href="https://gitpod.io/#https://github.com/containers/youki/pull/744"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

