### PR TITLE
Bump anyhow from 1.0.55 to 1.0.56 and fix warnings

### DIFF
--- a/crates/integration_test/src/tests/cgroups/network.rs
+++ b/crates/integration_test/src/tests/cgroups/network.rs
@@ -73,9 +73,8 @@ fn get_network_interfaces() -> Option<(String, String)> {
 fn test_network_cgroups() -> TestResult {
     let cgroup_name = "test_network_cgroups";
 
-    let interfaces = test_result!(get_network_interfaces().ok_or(anyhow!(
-        "Could not find network interfaces required for test"
-    )));
+    let interfaces = test_result!(get_network_interfaces()
+        .ok_or_else(|| anyhow!("Could not find network interfaces required for test")));
 
     let lo_if_name = &interfaces.0;
     let eth_if_name = &interfaces.1;

--- a/crates/libcgroups/src/systemd/manager.rs
+++ b/crates/libcgroups/src/systemd/manager.rs
@@ -215,7 +215,7 @@ impl Manager {
         }
         for component in slice_name.split('-') {
             if component.is_empty() {
-                anyhow!("invalid slice name: {}", slice);
+                bail!("invalid slice name: {}", slice);
             }
             // Append the component to the path and to the prefix.
             path = format!("{}/{}{}{}", path, prefix, component, suffix);

--- a/crates/test_framework/Cargo.toml
+++ b/crates/test_framework/Cargo.toml
@@ -6,5 +6,5 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow = "1.0.55"
+anyhow = "1.0.56"
 crossbeam = "0.8.1"

--- a/crates/youki/Cargo.toml
+++ b/crates/youki/Cargo.toml
@@ -17,9 +17,8 @@ version = "3.0.0-beta.5"
 default-features = false
 features = ["std", "suggestions", "derive", "cargo"]
 
-
 [dependencies]
-anyhow = "1.0.55"
+anyhow = "1.0.56"
 chrono = { version="0.4", features = ["serde"] }
 libcgroups = { version = "0.0.2", path = "../libcgroups" }
 libcontainer = { version = "0.0.2", path = "../libcontainer" }
@@ -39,5 +38,5 @@ clap_generate = { version = "3.0.0-beta.5" }
 serial_test = "0.6.0"
 
 [build-dependencies]
-anyhow = "1.0.55"
+anyhow = "1.0.56"
 vergen = "6.0"


### PR DESCRIPTION
Supersedes [#2217](https://github.com/containers/youki/pull/766)

<a href="https://gitpod.io/#https://github.com/containers/youki/pull/767"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

