### PR TITLE
Update the install instructions for Fedora

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,8 @@ $ sudo dnf install   \
       systemd-devel  \
       dbus-devel     \
       elfutils-libelf-devel \
-      libseccomp-devel
+      libseccomp-devel \
+      glibc-static
 ```
 
 ## Build


### PR DESCRIPTION
For some reason, when installing the build tools, the static glibc was
not installed.

Fixes https://github.com/containers/youki/issues/772


<a href="https://gitpod.io/#https://github.com/containers/youki/pull/773"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

