### PR TITLE
Fix a comment explaining that `seccom_rule_add` requires multiple args to be broken into multiple rules.

### DIFF
--- a/crates/libcontainer/src/seccomp/mod.rs
+++ b/crates/libcontainer/src/seccomp/mod.rs
@@ -321,11 +321,20 @@ pub fn initialize_seccomp(seccomp: &LinuxSeccomp) -> Result<Option<io::RawFd>> {
                         continue;
                     }
                 };
-                // Not clear why but if there are multiple arg attached to one
-                // syscall rule, we have to add them seperatly. add_rule will
-                // return EINVAL. runc does the same but doesn't explain why.
                 match syscall.args() {
                     Some(args) => {
+                        // The `seccomp_rule_add` requires us to break multiple
+                        // args attaching to the same rules into multiple rules.
+                        // Breaking this rule will cause `seccomp_rule_add` to
+                        // return EINVAL.
+                        //
+                        // From the man page: when adding syscall argument
+                        // comparisons to the filter it is important to remember
+                        // that while it is possible to have multiple
+                        // comparisons in a single rule, you can only compare
+                        // each argument once in a single rule.  In other words,
+                        // you can not have multiple comparisons of the 3rd
+                        // syscall argument in a single rule.
                         for arg in args {
                             let mut rule = Rule::new(action, syscall_number);
                             let cmp = Compare::new(arg.index() as u32)


### PR DESCRIPTION
Credit to comments from here. https://github.com/containers/youki/commit/052ba25769500e2a2a1a0a3f9be41a80b7d0090d#r68527694