### PR TITLE
Resolve deprecation warnings from clap

### DIFF
--- a/.github/workflows/integration_tests_validation.yaml
+++ b/.github/workflows/integration_tests_validation.yaml
@@ -42,7 +42,9 @@ jobs:
           wget -q https://github.com/opencontainers/runc/releases/download/v1.1.0/runc.amd64
           sudo mv runc.amd64 /usr/bin/runc
           sudo chmod 755 /usr/bin/runc
+      - name: Build youki and tests
+        run: ./scripts/build.sh -o "$(git rev-parse --show-toplevel)"/scripts -r
       - name: Validate tests on runc
-        run: cd scripts && ./rust_integration_tests.sh runc
+        run: make validate-rust-tests
       - name: Validate tests on youki
         run: make integration-test

--- a/Makefile
+++ b/Makefile
@@ -17,5 +17,8 @@ oci-integration-test: release-build
 integration-test: release-build
 	./scripts/rust_integration_tests.sh $(ROOT)/youki
 
+validate-rust-tests: release-build
+	./scripts/rust_integration_tests.sh runc
+
 clean:
 	./scripts/clean.sh $(ROOT)

--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -212,16 +212,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "clap_generate"
-version = "3.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e1b28c4a802ac3628604fd267cac62aaea74dc61af3410db6b1c44c03b42599"
-dependencies = [
- "clap",
- "clap_complete",
-]
-
-[[package]]
 name = "combine"
 version = "2.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2598,7 +2588,7 @@ dependencies = [
  "anyhow",
  "chrono",
  "clap",
- "clap_generate",
+ "clap_complete",
  "libcgroups",
  "libcontainer",
  "liboci-cli",

--- a/crates/liboci-cli/src/lib.rs
+++ b/crates/liboci-cli/src/lib.rs
@@ -54,7 +54,7 @@ pub enum CommonCmd {
     Exec(Exec),
     List(List),
     Pause(Pause),
-    #[clap(setting = clap::AppSettings::AllowLeadingHyphen)]
+    #[clap(setting = clap::AppSettings::AllowHyphenValues)]
     Ps(Ps),
     Resume(Resume),
     Run(Run),

--- a/crates/liboci-cli/src/lib.rs
+++ b/crates/liboci-cli/src/lib.rs
@@ -54,7 +54,7 @@ pub enum CommonCmd {
     Exec(Exec),
     List(List),
     Pause(Pause),
-    #[clap(setting = clap::AppSettings::AllowHyphenValues)]
+    #[clap(allow_hyphen_values = true)]
     Ps(Ps),
     Resume(Resume),
     Run(Run),

--- a/crates/liboci-cli/src/ps.rs
+++ b/crates/liboci-cli/src/ps.rs
@@ -9,6 +9,6 @@ pub struct Ps {
     #[clap(forbid_empty_values = true, required = true)]
     pub container_id: String,
     /// options will be passed to the ps utility
-    #[clap(setting = clap::ArgSettings::Last)]
+    #[clap(last = true)]
     pub ps_options: Vec<String>,
 }

--- a/crates/youki/Cargo.toml
+++ b/crates/youki/Cargo.toml
@@ -32,7 +32,7 @@ procfs = "0.12.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tabwriter = "1"
-clap_generate = { version = "3.0.0-beta.5" }
+clap_complete = "3.1.1"
 
 [dev-dependencies]
 serial_test = "0.6.0"

--- a/crates/youki/src/commands/completion.rs
+++ b/crates/youki/src/commands/completion.rs
@@ -1,6 +1,7 @@
 use anyhow::Result;
-use clap::{App, Parser};
-use clap_generate::{generate, Shell};
+use clap::{Command, Parser};
+
+use clap_complete::{generate, Shell};
 use std::io;
 
 #[derive(Debug, Parser)]
@@ -10,7 +11,7 @@ pub struct Completion {
     pub shell: Shell,
 }
 
-pub fn completion(args: Completion, app: &mut App) -> Result<()> {
+pub fn completion(args: Completion, app: &mut Command) -> Result<()> {
     generate(
         args.shell,
         app,

--- a/crates/youki/src/main.rs
+++ b/crates/youki/src/main.rs
@@ -82,7 +82,7 @@ fn main() -> Result<()> {
     pentacle::ensure_sealed().context("failed to seal /proc/self/exe")?;
 
     let opts = Opts::parse();
-    let mut app = Opts::into_app();
+    let mut app = Opts::command();
 
     if let Err(e) = crate::logger::init(opts.global.debug, opts.global.log, opts.global.log_format)
     {

--- a/tests/rust-integration-tests/integration_test/Cargo.lock
+++ b/tests/rust-integration-tests/integration_test/Cargo.lock
@@ -430,7 +430,7 @@ checksum = "418d37c8b1d42553c93648be529cb70f920d3baf8ef469b74b9638df426e0b4c"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.10.2+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -556,9 +556,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.119"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bf2e165bb3457c8e098ea76f3e3bc9db55f87aa90d52d0e6be741470916aaa4"
+checksum = "efaa7b300f3b5fe8eb6bf21ce3895e1751d9665086af2d64b42f19701015ff4f"
 
 [[package]]
 name = "libcgroups"
@@ -664,14 +664,15 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba272f85fa0b41fc91872be579b3bbe0f56b792aa361a380eb669469f68dafb2"
+checksum = "52da4364ffb0e4fe33a9841a98a3f3014fb964045ce4f7a45a398243c8d6b0c9"
 dependencies = [
  "libc",
  "log",
  "miow",
  "ntapi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "winapi",
 ]
 
@@ -1205,6 +1206,12 @@ name = "wasi"
 version = "0.10.2+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
+
+[[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "which"


### PR DESCRIPTION
This resolves some of the clap deprecation warnings. This is part of resolving #771 .

<a href="https://gitpod.io/#https://github.com/containers/youki/pull/798"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

