### PR TITLE
chore(rustdoc): Fix `rustdoc` warnings

### DIFF
--- a/crates/libcontainer/src/capabilities.rs
+++ b/crates/libcontainer/src/capabilities.rs
@@ -123,7 +123,7 @@ impl CapabilityExt for SpecCapability {
 
 /// reset capabilities of process calling this to effective capabilities
 /// effective capability set is set of capabilities used by kernel to perform checks
-/// see https://man7.org/linux/man-pages/man7/capabilities.7.html for more information
+/// see <https://man7.org/linux/man-pages/man7/capabilities.7.html> for more information
 pub fn reset_effective<S: Syscall + ?Sized>(syscall: &S) -> Result<()> {
     log::debug!("reset all caps");
     syscall.set_capability(CapSet::Effective, &caps::all())?;

--- a/crates/libcontainer/src/syscall/linux.rs
+++ b/crates/libcontainer/src/syscall/linux.rs
@@ -94,7 +94,7 @@ impl LinuxSyscall {
 
 impl Syscall for LinuxSyscall {
     /// To enable dynamic typing,
-    /// see https://doc.rust-lang.org/std/any/index.html for more information
+    /// see <https://doc.rust-lang.org/std/any/index.html> for more information
     fn as_any(&self) -> &dyn Any {
         self
     }


### PR DESCRIPTION
Fix `bare_urls` warnings from `rustdoc`

<a href="https://gitpod.io/#https://github.com/containers/youki/pull/833"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

