### PR TITLE
Update CI coverage to use native option instead of action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -77,28 +77,23 @@ jobs:
       - name: Toolchain setup
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly-2022-01-14
+          toolchain: 1.60.0
           override: true
           profile: minimal
           components: llvm-tools-preview
       - name: Cache youki
         uses: Swatinem/rust-cache@v1
-      - name: install cargo-llvm-cov
-        env:
-          CARGO_LLVM_COV_VERSION: 0.1.5
-        run: |
-          wget https://github.com/taiki-e/cargo-llvm-cov/releases/download/v${CARGO_LLVM_COV_VERSION}/cargo-llvm-cov-x86_64-unknown-linux-gnu.tar.gz -qO- | tar -xzvf -
-          mv cargo-llvm-cov ~/.cargo/bin
       - name: Update System Libraries
         run: sudo apt-get -y update
       - name: Install System Libraries
         run: sudo apt-get install -y pkg-config libsystemd-dev libdbus-glib-1-dev libelf-dev libseccomp-dev
+      - name: Install grcov
+        run: cargo install grcov
       - name: Run Test Coverage for youki
         run: |
-          cd ./crates
-          cargo llvm-cov clean --workspace
-          cargo llvm-cov --no-report
-          cargo llvm-cov --no-run --lcov --ignore-filename-regex "libcgroups/src/systemd/dbus/systemd_api.rs" --output-path ./coverage.lcov
+          cargo clean
+          LLVM_PROFILE_FILE="coverage.profraw" RUSTFLAGS="-Cinstrument-coverage" cargo build 
+          grcov . --binary-path ./target/debug -s . -t lcov --branch --ignore-not-existing -o ./coverage.lcov
       - name: Upload Youki Code Coverage Results
         uses: codecov/codecov-action@v2
         with:


### PR DESCRIPTION
This updates the CI to use native coverage generation option introduced in rust 1.60 instead of using CI action.
Test PR for https://github.com/containers/youki/issues/316#issuecomment-1119155913

DO NOT MERGE

<a href="https://gitpod.io/#https://github.com/containers/youki/pull/897"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

