### PR TITLE
Add integration tests into code coverage generation

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -77,18 +77,16 @@ jobs:
       - name: Toolchain setup
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly-2022-01-14
+          toolchain: nightly-2022-05-06
           override: true
           profile: minimal
           components: llvm-tools-preview
       - name: Cache youki
         uses: Swatinem/rust-cache@v1
       - name: install cargo-llvm-cov
-        env:
-          CARGO_LLVM_COV_VERSION: 0.1.5
-        run: |
-          wget https://github.com/taiki-e/cargo-llvm-cov/releases/download/v${CARGO_LLVM_COV_VERSION}/cargo-llvm-cov-x86_64-unknown-linux-gnu.tar.gz -qO- | tar -xzvf -
-          mv cargo-llvm-cov ~/.cargo/bin
+        uses: taiki-e/install-action@v1
+        with:
+          tool: cargo-llvm-cov@0.3.2
       - name: Update System Libraries
         run: sudo apt-get -y update
       - name: Install System Libraries

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -77,7 +77,7 @@ jobs:
       - name: Toolchain setup
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly-2022-05-06
+          toolchain: 1.60.0
           override: true
           profile: minimal
           components: llvm-tools-preview

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -86,7 +86,7 @@ jobs:
       - name: install cargo-llvm-cov
         uses: taiki-e/install-action@v1
         with:
-          tool: cargo-llvm-cov@0.3.2
+          tool: cargo-llvm-cov@0.3.3
       - name: Update System Libraries
         run: sudo apt-get -y update
       - name: Install System Libraries

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -74,6 +74,8 @@ jobs:
     name: Run test coverage
     steps:
       - uses: actions/checkout@v2
+        with:
+          submodules: recursive
       - name: Toolchain setup
         uses: actions-rs/toolchain@v1
         with:
@@ -93,9 +95,10 @@ jobs:
         run: sudo apt-get install -y pkg-config libsystemd-dev libdbus-glib-1-dev libelf-dev libseccomp-dev
       - name: Run Test Coverage for youki
         run: |
-          cd ./crates
+          source <(cargo llvm-cov show-env --export-prefix)
           cargo llvm-cov clean --workspace
-          cargo llvm-cov --no-report
+          cargo test
+          make oci-test-cov
           cargo llvm-cov --no-run --lcov --ignore-filename-regex "libcgroups/src/systemd/dbus/systemd_api.rs" --output-path ./coverage.lcov
       - name: Upload Youki Code Coverage Results
         uses: codecov/codecov-action@v2

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,9 @@ test: build
 oci-integration-test: release-build
 	./scripts/oci_integration_tests.sh $(ROOT)
 
+oci-test-cov: build
+	./scripts/oci_integration_tests.sh $(ROOT)
+
 integration-test: release-build
 	./scripts/rust_integration_tests.sh $(ROOT)/youki
 

--- a/crates/libcgroups/src/v2/devices/mod.rs
+++ b/crates/libcgroups/src/v2/devices/mod.rs
@@ -5,7 +5,6 @@ pub mod program;
 
 #[cfg(test)]
 #[allow(clippy::too_many_arguments)]
-#[cfg_attr(coverage, feature(no_coverage))]
 pub mod mocks;
 
 pub use controller::Devices;

--- a/crates/libcontainer/src/lib.rs
+++ b/crates/libcontainer/src/lib.rs
@@ -1,4 +1,3 @@
-#![cfg_attr(coverage, feature(no_coverage))]
 pub mod apparmor;
 pub mod capabilities;
 pub mod config;

--- a/crates/libcontainer/src/syscall/linux.rs
+++ b/crates/libcontainer/src/syscall/linux.rs
@@ -1,5 +1,4 @@
 //! Implements Command trait for Linux systems
-#[cfg_attr(coverage, no_coverage)]
 use std::ffi::{CStr, OsStr};
 use std::fs;
 use std::os::unix::ffi::OsStrExt;


### PR DESCRIPTION
This extends on #898 , and adds a commit after the commits in that PR.
That one should be first taken into consideration before this one.

This adds OCI integration tests when running tests to generate coverage info.
Based on https://github.com/containers/youki/issues/316#issuecomment-1119924328

<a href="https://gitpod.io/#https://github.com/containers/youki/pull/899"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

