### PR TITLE
Remove the build dependency from some tests.

### DIFF
--- a/.github/workflows/benchmark_execution_time.yml
+++ b/.github/workflows/benchmark_execution_time.yml
@@ -27,7 +27,7 @@ jobs:
           profile: minimal
 
       - name: Building PR branch
-        run: ./build.sh --release
+        run: make release-build
 
       - name: Uploading PR build to artifact
         uses: actions/upload-artifact@v2

--- a/.github/workflows/integration_tests_validation.yaml
+++ b/.github/workflows/integration_tests_validation.yaml
@@ -44,5 +44,7 @@ jobs:
           sudo chmod 755 /usr/bin/runc
       - name: Validate tests on runc
         run: make validate-rust-tests
+      - name: Build
+        run: make release-build
       - name: Validate tests on youki
         run: make integration-test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -124,5 +124,7 @@ jobs:
       - uses: actions/setup-go@v2
         with:
           go-version: "1.17.6"
+      - name: Build
+        run: make release-build
       - name: Run integration tests
         run: make oci-integration-test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,8 @@ jobs:
         with:
           toolchain: stable
           override: true
+      - name: Build
+        run: make release-build
       - name: test
         run: make test-all
 

--- a/Makefile
+++ b/Makefile
@@ -11,13 +11,13 @@ test-all: test oci-integration-test integration-test
 test: build
 	cd crates && cargo test
 
-oci-integration-test: release-build
+oci-integration-test:
 	./scripts/oci_integration_tests.sh $(ROOT)
 
-integration-test: release-build
+integration-test:
 	./scripts/rust_integration_tests.sh $(ROOT)/youki
 
-validate-rust-tests: release-build
+validate-rust-tests:
 	./scripts/rust_integration_tests.sh runc
 
 clean:

--- a/scripts/oci_integration_tests.sh
+++ b/scripts/oci_integration_tests.sh
@@ -86,6 +86,13 @@ check_environment() {
   fi
 }
 
+if [[ ! -e $RUNTIME ]]; then
+  if ! which $RUNTIME ; then
+    echo "$RUNTIME not found"
+    exit 1
+  fi
+fi
+
 for case in "${test_cases[@]}"; do
   if [[ ! -e "${OCI_TEST_DIR}/validation/$case" ]]; then
     GO111MODULE=auto GOPATH=${ROOT}/tests/oci-runtime-tests make runtimetest validation-executables

--- a/scripts/rust_integration_tests.sh
+++ b/scripts/rust_integration_tests.sh
@@ -1,11 +1,20 @@
 #! /bin/sh -eu
 
 ROOT=$(git rev-parse --show-toplevel)
+RUNTIME=$1
 
-if [ "$1" = "" ]; then
+if [ "$RUNTIME" = "" ]; then
     echo "please specify runtime"
     exit 1
 fi
+
+if [ ! -e $RUNTIME ]; then
+  if ! which $RUNTIME ; then
+    echo "$RUNTIME not found"
+    exit 1
+  fi
+fi
+
 ROOT=${2-$(git rev-parse --show-toplevel)}
 
 LOGFILE="${ROOT}/test.log"
@@ -15,7 +24,7 @@ if [ ! -f ${ROOT}/bundle.tar.gz ]; then
 fi
 touch ${LOGFILE}
 
-sudo YOUKI_LOG_LEVEL="error" ${ROOT}/integration_test run --runtime "$1" --runtimetest ${ROOT}/runtimetest > $LOGFILE
+sudo YOUKI_LOG_LEVEL="error" ${ROOT}/integration_test run --runtime "$RUNTIME" --runtimetest ${ROOT}/runtimetest > $LOGFILE
 
 if [ 0 -ne $(grep "not ok" $LOGFILE | wc -l ) ]; then
     cat $LOGFILE


### PR DESCRIPTION
Remove the build dependency from some tests because it was inconvenient that we could always test only the latest builds. Instead, check in advance if the runtime is presents