### PR TITLE
Fix CI compilation issues

### DIFF
--- a/.github/workflows/integration_tests_validation.yaml
+++ b/.github/workflows/integration_tests_validation.yaml
@@ -26,7 +26,7 @@ jobs:
     timeout-minutes: 15
     strategy:
       matrix:
-        rust: [1.59.0, 1.61.0]
+        rust: [1.60.0, 1.61.0]
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
@@ -42,9 +42,9 @@ jobs:
           wget -q https://github.com/opencontainers/runc/releases/download/v1.1.0/runc.amd64
           sudo mv runc.amd64 /usr/bin/runc
           sudo chmod 755 /usr/bin/runc
-      - name: Validate tests on runc
-        run: make validate-rust-tests
       - name: Build
         run: make release-build
+      - name: Validate tests on runc
+        run: make validate-rust-tests
       - name: Validate tests on youki
         run: make integration-test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,7 +31,7 @@ jobs:
     timeout-minutes: 15
     strategy:
       matrix:
-        rust: [1.59.0, 1.61.0]
+        rust: [1.60.0, 1.61.0]
         dirs: ${{ fromJSON(needs.changes.outputs.dirs) }}
     steps:
       - uses: actions/checkout@v2
@@ -55,7 +55,7 @@ jobs:
     timeout-minutes: 15
     strategy:
       matrix:
-        rust: [1.59.0, 1.61.0]
+        rust: [1.60.0, 1.61.0]
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
@@ -77,7 +77,7 @@ jobs:
       - name: Toolchain setup
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.60.0
+          toolchain: 1.61.0
           override: true
           profile: minimal
           components: llvm-tools-preview
@@ -105,7 +105,7 @@ jobs:
     timeout-minutes: 15
     strategy:
       matrix:
-        rust: [1.59.0, 1.61.0]
+        rust: [1.60.0, 1.61.0]
     steps:
       - uses: actions/checkout@v2
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -953,6 +953,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipnetwork"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f84f1612606f3753f205a4e9a2efd6fe5b4c573a6269b2cc6c3003d44a0d127"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "itertools"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1283,6 +1292,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "no-std-net"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43794a0ace135be66a25d3ae77d41b91615fb68ae937f904090203e81f755b65"
+
+[[package]]
 name = "normalize-line-endings"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1445,11 +1460,11 @@ checksum = "1df8c4ec4b0627e53bdf214615ad287367e482558cf84b109250b37464dc03ae"
 
 [[package]]
 name = "pnet"
-version = "0.29.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8750e073f82219c01e771133c64718d7685aef922da8a0d430a46aed05b6341a"
+checksum = "d5cc57672f576f6b95370277fb445738d4887195c6cf4192bdf4f44697e2389b"
 dependencies = [
- "ipnetwork",
+ "ipnetwork 0.19.0",
  "pnet_base",
  "pnet_datalink",
  "pnet_packet",
@@ -1459,17 +1474,20 @@ dependencies = [
 
 [[package]]
 name = "pnet_base"
-version = "0.29.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8205fe084bd43a3af79b3155c19feddd62e733640498842e631a2ffe107d1538"
+checksum = "2e88341c6c842f89bdc7287f7b1e26b6fa64fa11c7ea3756971e6f18cd2510c4"
+dependencies = [
+ "no-std-net",
+]
 
 [[package]]
 name = "pnet_datalink"
-version = "0.29.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f85aef5e52e22ff06b1b11f2eb6d52959a9e0ecad3cb3f5cc2d78cadc077f0e"
+checksum = "bc6e55d71c51db73372db35bc54f43abd8460adff1c3a9b717804ca6416d5df2"
 dependencies = [
- "ipnetwork",
+ "ipnetwork 0.18.0",
  "libc",
  "pnet_base",
  "pnet_sys",
@@ -1478,9 +1496,9 @@ dependencies = [
 
 [[package]]
 name = "pnet_macros"
-version = "0.29.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98cc3af95fed6dc318dfede3e81320f96ad5e237c6f7c4688108b19c8e67432d"
+checksum = "ebfcdc9c072966723026b3596a1f655fb8bbfe0142f9770f8d481aee4459d6b9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1490,18 +1508,18 @@ dependencies = [
 
 [[package]]
 name = "pnet_macros_support"
-version = "0.29.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "feaba58ba96abb218ec584d6caf0d3ff48922df05dbbeb1560553c197091b29e"
+checksum = "bba532f5a4b320c029d89e612671fb621851b3b07e972c53850d34130033a5cd"
 dependencies = [
  "pnet_base",
 ]
 
 [[package]]
 name = "pnet_packet"
-version = "0.29.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f246edaaf1aaf82072d4cd38ee18bcc5dfc0464093f9ca39e4ac5962d68cf9d4"
+checksum = "7009716ac86091c1b6e2cdec95a2b028c880f516054c1ec11edd02f9f463cbde"
 dependencies = [
  "glob",
  "pnet_base",
@@ -1511,9 +1529,9 @@ dependencies = [
 
 [[package]]
 name = "pnet_sys"
-version = "0.29.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "028c87a5e3a48fc07df099a2025f2ef16add5993712e1494ba69a6707ee7ed06"
+checksum = "8e2a05efbc55c22f664c0ea475fbc4ffc4d09346aff9068438279d7e3d431f6f"
 dependencies = [
  "libc",
  "winapi",
@@ -1521,9 +1539,9 @@ dependencies = [
 
 [[package]]
 name = "pnet_transport"
-version = "0.29.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "950f2a7961e19d22e19e84ff0a6e0955013185fe149673499662633d02b41b7a"
+checksum = "75b8ff06f37863f7590183f7044ab2e8d4dae991ecea0c791e3c6dd61ed2913d"
 dependencies = [
  "libc",
  "pnet_base",

--- a/tests/rust-integration-tests/integration_test/Cargo.toml
+++ b/tests/rust-integration-tests/integration_test/Cargo.toml
@@ -14,7 +14,7 @@ nix = "0.24.1"
 num_cpus = "1.13"
 oci-spec = { git = "https://github.com/containers/oci-spec-rs", rev = "6df620e" }
 once_cell = "1.12.0"
-pnet = "0.29.0"
+pnet = "0.30.0"
 procfs = "0.12.0"
 rand = "0.8.5"
 serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION
- Update test matrix to 1.60 so that dependencies can be resolved
- Ensure that test binary is build and available in path
- Fix code coverage by updating to rust 1.61