### PR TITLE
chore: update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,3 @@
-
-
 /tutorial
 .idea/
 
@@ -10,16 +8,13 @@ tags
 tags.lock
 tags.temp
 
-youki
-!youki/
-integration_test
-runtimetest_tool
-runtimetest
-!runtimetest/
+/youki
+/integration_test
+/runtimetest
 
 .vscode
 
 *~
 
-bundle.tar.gz
-test.log
+/bundle.tar.gz
+/test.log


### PR DESCRIPTION
prefixes some rules with slash (/) to make it only ignores
files/directories at the root directory

Fixes #958 

Signed-off-by: Tony Duan <tony84727@gmail.com>