### PR TITLE
chore: a separate target directory for runtimetest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .idea/
 
 **/target
+/runtimetest-target
 .vagrant/
 
 tags

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -11,6 +11,7 @@ usage_exit() {
 
 VERSION=debug
 TARGET=x86_64-unknown-linux-gnu
+RUNTIMETEST_TARGET="$ROOT/runtimetest-target"
 while getopts ro:h OPT; do
     case $OPT in
         o) output=${OPTARG}
@@ -36,8 +37,9 @@ OUTPUT=${output:-$ROOT/bin}
 
 cargo build --target ${TARGET} ${OPTION} --bin youki
 cargo build --target ${TARGET} ${OPTION} --bin integration_test
-RUSTFLAGS="-Ctarget-feature=+crt-static" cargo build --target ${TARGET} ${OPTION} --bin runtimetest
+CARGO_TARGET_DIR=${RUNTIMETEST_TARGET} RUSTFLAGS="-Ctarget-feature=+crt-static" cargo build --target ${TARGET} ${OPTION} --bin runtimetest
 
-mv ${ROOT}/target/${TARGET}/${VERSION}/{youki,integration_test,runtimetest} ${OUTPUT}/
+mv ${ROOT}/target/${TARGET}/${VERSION}/{youki,integration_test} ${OUTPUT}/
+mv ${RUNTIMETEST_TARGET}/${TARGET}/${VERSION}/runtimetest ${OUTPUT}/
 
 exit 0


### PR DESCRIPTION
building static-linked runtimetest requires additional RUSTFLAGS env
var. Unfortunately, the additional env var invalids the build cache,
leading cargo rebuilding everytime.

See https://github.com/rust-lang/cargo/issues/8716

A temporary solution is to build runtimetest in a seperate
`runtimetest-target` directory.

Signed-off-by: Tony Duan <tony84727@gmail.com>

<a href="https://gitpod.io/#https://github.com/containers/youki/pull/981"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

