### PR TITLE
Remove duplicated assignment

### DIFF
--- a/crates/youki/src/commands/exec.rs
+++ b/crates/youki/src/commands/exec.rs
@@ -15,7 +15,6 @@ pub fn exec(args: Exec, root_path: PathBuf) -> Result<()> {
         .with_env(args.env.clone().into_iter().collect())
         .with_process(args.process.as_ref())
         .with_no_new_privs(args.no_new_privs)
-        .with_process(args.process.as_ref())
         .with_container_args(args.command.clone())
         .build()
 }


### PR DESCRIPTION
In `exec` command, `process` field will be assigned twice when creating `TenantContainerBuilder`. I think it's unnecessary.


<a href="https://gitpod.io/#https://github.com/containers/youki/pull/993"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

