### PR TITLE
Added podman local system tests

### DIFF
--- a/.github/workflows/podman_tests.yaml
+++ b/.github/workflows/podman_tests.yaml
@@ -1,0 +1,36 @@
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+
+jobs:
+  podman-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: sudo apt-get -y update
+      - run: sudo apt-get install -y pkg-config libsystemd-dev libdbus-glib-1-dev libelf-dev libseccomp-dev libgpgme-dev
+      - run: make build 
+      - run: sudo cp youki /usr/local/bin
+      - name: Clone podman repository
+        uses: actions/checkout@v2
+        with:
+          repository: containers/podman
+      - uses: actions/setup-go@v2
+        with:
+          go-version: '1.18'
+      - name: Build podman
+        run: make binaries 
+      - name: Install tools
+        run: make install.tools
+      - name: Install bats
+        run: sudo ./hack/install_bats.sh
+      - name: Run podman test
+        run: sudo OCI_RUNTIME=/usr/local/bin/youki ./hack/bats 2>&1 | tee build.log 
+      - name: Adding Summary
+        run: |
+          echo "Total tests: 360 Failed tests: $(cat build.log | grep " ok " | wc -l)" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/podman_tests.yaml
+++ b/.github/workflows/podman_tests.yaml
@@ -1,11 +1,6 @@
 on:
-  push:
-    branches:
-      - main
-  pull_request:
-    branches:
-      - main
-
+  schedule:
+  - cron: "0 0 * * *"
 
 jobs:
   podman-tests:


### PR DESCRIPTION
Hi,

This PR adds podman's local system tests to the CI and produces the summary like [this](https://github.com/stefins/youki/actions/runs/2560345607).

As of now 134 tests out of 360 fails to run as of using `youki` as the runtime opposed to `crun`

Related to #902
Thanks :)

<a href="https://gitpod.io/#https://github.com/containers/youki/pull/1009"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

