### PR TITLE
Update ID of rust-analyzer extension in gitpod.yml

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -9,4 +9,4 @@ github:
     addBadge: true
 vscode:
   extensions:
-    - matklad.rust-analyzer
+    - rust-lang.rust-analyzer


### PR DESCRIPTION
This extension is now known as `rust-lang.rust-analyzer`

<a href="https://gitpod.io/#https://github.com/containers/youki/pull/1038"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

