### PR TITLE
Fix bug that attempts is always 0 in delete_with_retry

### DIFF
--- a/crates/libcgroups/src/common.rs
+++ b/crates/libcgroups/src/common.rs
@@ -420,7 +420,7 @@ pub(crate) fn delete_with_retry<P: AsRef<Path>, L: Into<Option<Duration>>>(
         }
 
         std::thread::sleep(delay);
-        attempts += attempts;
+        attempts += 1;
         delay *= attempts;
         if delay > limit {
             delay = limit;


### PR DESCRIPTION
In `delete_with_retry`, `attempts ` is initialized as 0 and add itself every time `remove_dir` fails. It makes `attempts` always 0 and `retries` has no effect here.

Signed-off-by: Chen Yiyang <cyyzero@qq.com>

<a href="https://gitpod.io/#https://github.com/containers/youki/pull/1128"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

