### PR TITLE
Canonicalize the bundle path when storing in the new container data

### DIFF
--- a/crates/libcontainer/src/container/container.rs
+++ b/crates/libcontainer/src/container/container.rs
@@ -42,7 +42,8 @@ impl Container {
         container_root: &Path,
     ) -> Result<Self> {
         let container_root = fs::canonicalize(container_root)?;
-        let state = State::new(container_id, status, pid, bundle.to_path_buf());
+
+        let state = State::new(container_id, status, pid, fs::canonicalize(bundle)?);
         Ok(Self {
             state,
             root: container_root,
@@ -238,7 +239,10 @@ mod tests {
         // testing id
         assert_eq!(container.id(), "container_id");
         // testing bundle path
-        assert_eq!(container.bundle(), &PathBuf::from("."));
+        assert_eq!(
+            container.bundle(),
+            &fs::canonicalize(PathBuf::from(".")).unwrap()
+        );
         // testing root path
         assert_eq!(container.root, fs::canonicalize(PathBuf::from("."))?);
         // testing created


### PR DESCRIPTION
This attempts to solve issue stated in #1153 
As stated in the issue, this is still open for discussion, so this PR might be closed. 
Comments are welcome!

<a href="https://gitpod.io/#https://github.com/containers/youki/pull/1154"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

