### PR TITLE
[WIP] Allow youki to run with podman in rootless

### DIFF
--- a/crates/libcontainer/src/rootless.rs
+++ b/crates/libcontainer/src/rootless.rs
@@ -1,5 +1,6 @@
 use crate::{namespaces::Namespaces, utils};
 use anyhow::{bail, Context, Result};
+use libcgroups::common::rootless_required;
 use nix::unistd::Pid;
 use oci_spec::runtime::{Linux, LinuxIdMapping, LinuxNamespace, LinuxNamespaceType, Mount, Spec};
 use std::fs;
@@ -115,15 +116,6 @@ fn get_gid_path(pid: &Pid) -> PathBuf {
 #[cfg(test)]
 pub fn get_gid_path(pid: &Pid) -> PathBuf {
     utils::get_temp_dir_path(format!("{pid}_mapping_path").as_str()).join("gid_map")
-}
-
-/// Checks if rootless mode should be used
-pub fn rootless_required() -> bool {
-    if !nix::unistd::geteuid().is_root() {
-        return true;
-    }
-
-    matches!(std::env::var("YOUKI_USE_ROOTLESS").as_deref(), Ok("true"))
 }
 
 pub fn unprivileged_user_ns_enabled() -> Result<bool> {

--- a/crates/youki/src/main.rs
+++ b/crates/youki/src/main.rs
@@ -14,7 +14,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 use crate::commands::info;
-use libcontainer::rootless::rootless_required;
+use libcgroups::common::rootless_required;
 use libcontainer::utils::create_dir_all_with_mode;
 use nix::sys::stat::Mode;
 use nix::unistd::getuid;


### PR DESCRIPTION
This is a work in progress PR addressing #719.
I created this for discussion purpose, please don't merge.

This patch resolves the initial error (`Error: failed to create directory /run/youki`), but still does not allow youki to run rootless in Podman.

Now I got another error: `Error: failed to create session dbus client`

```
$ podman --runtime /home/ori/devel/src/github.com/orimanabu/youki/youki run --userns=auto --name hello hello
[DEBUG crates/youki/src/main.rs:92] 2022-09-04T12:10:03.798359979+09:00 started by user 0 with ArgsOs { inner: ["/home/ori/devel/src/github.com/orimanabu/youki/youki", "delete", "--force", "50cd9d798f3f2a2e496e503c4012e7fabe22e69b1bfa29c96245bf1b8b4ec5e7"] }
[DEBUG crates/youki/src/commands/delete.rs:8] 2022-09-04T12:10:03.798781906+09:00 start deleting 50cd9d798f3f2a2e496e503c4012e7fabe22e69b1bfa29c96245bf1b8b4ec5e7
[DEBUG crates/libcontainer/src/container/container_delete.rs:36] 2022-09-04T12:10:03.799043441+09:00 container status: Stopped
[DEBUG crates/libcontainer/src/container/container_delete.rs:42] 2022-09-04T12:10:03.799120496+09:00 config: YoukiConfig { hooks: None, cgroup_path: "user.slice:libpod:50cd9d798f3f2a2e496e503c4012e7fabe22e69b1bfa29c96245bf1b8b4ec5e7" }
[DEBUG crates/libcontainer/src/container/container_delete.rs:45] 2022-09-04T12:10:03.799144175+09:00 remove dir "/run/user/1000/youki/50cd9d798f3f2a2e496e503c4012e7fabe22e69b1bfa29c96245bf1b8b4ec5e7"
Error: failed to delete container 50cd9d798f3f2a2e496e503c4012e7fabe22e69b1bfa29c96245bf1b8b4ec5e7

Caused by:
    container state does not contain cgroup manager
ERRO[0000] Removing container 50cd9d798f3f2a2e496e503c4012e7fabe22e69b1bfa29c96245bf1b8b4ec5e7 from runtime after creation failed 
Error: OCI runtime error: /home/ori/devel/src/github.com/orimanabu/youki/youki: [DEBUG crates/youki/src/main.rs:92] 2022-09-04T12:10:03.736189722+09:00 started by user 0 with ArgsOs { inner: ["/home/ori/devel/src/github.com/orimanabu/youki/youki", "--systemd-cgroup", "create", "--bundle", "/home/ori/.local/share/containers/storage/overlay-containers/50cd9d798f3f2a2e496e503c4012e7fabe22e69b1bfa29c96245bf1b8b4ec5e7/userdata", "--pid-file", "/run/user/1000/containers/overlay-containers/50cd9d798f3f2a2e496e503c4012e7fabe22e69b1bfa29c96245bf1b8b4ec5e7/userdata/pidfile", "50cd9d798f3f2a2e496e503c4012e7fabe22e69b1bfa29c96245bf1b8b4ec5e7"] }
[DEBUG crates/libcontainer/src/container/init_builder.rs:100] 2022-09-04T12:10:03.740451839+09:00 container directory will be "/run/user/1000/youki/50cd9d798f3f2a2e496e503c4012e7fabe22e69b1bfa29c96245bf1b8b4ec5e7"
[DEBUG crates/libcontainer/src/container/container.rs:192] 2022-09-04T12:10:03.740514780+09:00 Save container status: Container { state: State { oci_version: "v1.0.2", id: "50cd9d798f3f2a2e496e503c4012e7fabe22e69b1bfa29c96245bf1b8b4ec5e7", status: Creating, pid: None, bundle: "/home/ori/.local/share/containers/storage/overlay-containers/50cd9d798f3f2a2e496e503c4012e7fabe22e69b1bfa29c96245bf1b8b4ec5e7/userdata", annotations: Some({}), created: None, creator: None, use_systemd: None }, root: "/run/user/1000/youki/50cd9d798f3f2a2e496e503c4012e7fabe22e69b1bfa29c96245bf1b8b4ec5e7" } in "/run/user/1000/youki/50cd9d798f3f2a2e496e503c4012e7fabe22e69b1bfa29c96245bf1b8b4ec5e7"
[DEBUG crates/libcontainer/src/rootless.rs:40] 2022-09-04T12:10:03.740661343+09:00 rootless container should be created
[INFO crates/libcgroups/src/common.rs:247] 2022-09-04T12:10:03.740881325+09:00 systemd cgroup manager with system bus false will be used
[INFO crates/libcgroups/src/common.rs:247] 2022-09-04T12:10:03.741338885+09:00 systemd cgroup manager with system bus false will be used
Error: failed to create session dbus client

Caused by:
    0: failed to create container
    1: failed to create session dbus client
    2: Did not receive a reply. Possible causes include: the remote application did not send a reply, the message bus security policy blocked the reply, the reply timeout expired, or the network connection was broken.
```

It seems that CgroupPath in config.json is empty, I'll look into it later.

```
$ podman inspect hello | jq '.[].State'
{
  "OciVersion": "1.0.2-dev",
  "Status": "created",
  "Running": false,
  "Paused": false,
  "Restarting": false,
  "OOMKilled": false,
  "Dead": false,
  "Pid": 0,
  "ExitCode": 0,
  "Error": "",
  "StartedAt": "0001-01-01T00:00:00Z",
  "FinishedAt": "0001-01-01T00:00:00Z",
  "Health": {
    "Status": "",
    "FailingStreak": 0,
    "Log": null
  },
  "CheckpointedAt": "0001-01-01T00:00:00Z",
  "RestoredAt": "0001-01-01T00:00:00Z"
}
```

Signed-off-by: Manabu Ori <manabu.ori@gmail.com>

<a href="https://gitpod.io/#https://github.com/containers/youki/pull/1171"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

