### PR TITLE
Thaw a paused container in cgroup v1 when it is forcely deleted.

### DIFF
--- a/crates/libcontainer/src/container/container_delete.rs
+++ b/crates/libcontainer/src/container/container_delete.rs
@@ -28,9 +28,7 @@ impl Container {
         self.refresh_status()
             .context("failed to refresh container status")?;
         if self.can_kill() && force {
-            let sig = signal::Signal::SIGKILL;
-            log::debug!("kill signal {} to {}", sig, self.pid().unwrap());
-            signal::kill(self.pid().unwrap(), sig)?;
+            self.do_kill(signal::Signal::SIGKILL, true, true)?;
             self.set_status(ContainerStatus::Stopped).save()?;
         }
         log::debug!("container status: {:?}", self.status());

--- a/crates/libcontainer/src/container/container_delete.rs
+++ b/crates/libcontainer/src/container/container_delete.rs
@@ -28,7 +28,7 @@ impl Container {
         self.refresh_status()
             .context("failed to refresh container status")?;
         if self.can_kill() && force {
-            self.do_kill(signal::Signal::SIGKILL, true, true)?;
+            self.do_kill(signal::Signal::SIGKILL, true)?;
             self.set_status(ContainerStatus::Stopped).save()?;
         }
         log::debug!("container status: {:?}", self.status());
@@ -66,7 +66,7 @@ impl Container {
                         .with_context(|| "failed to run post stop hooks")?;
                 }
             }
-            std::process::exit(0)
+            Ok(())
         } else {
             bail!(
                 "{} could not be deleted because it was {:?}",

--- a/crates/libcontainer/src/container/container_kill.rs
+++ b/crates/libcontainer/src/container/container_kill.rs
@@ -1,7 +1,7 @@
 use super::{Container, ContainerStatus};
 use crate::signal::Signal;
 use anyhow::{bail, Context, Result};
-use libcgroups::common::create_cgroup_manager;
+use libcgroups::common::{create_cgroup_manager, get_cgroup_setup};
 use nix::sys::signal::{self};
 
 impl Container {
@@ -24,29 +24,10 @@ impl Container {
     /// # }
     /// ```
     pub fn kill<S: Into<Signal>>(&mut self, signal: S, all: bool) -> Result<()> {
-        let signal = signal.into().into_raw();
-
-        let pids = if all {
-            let cgroups_path = self.spec()?.cgroup_path;
-            let use_systemd = self
-                .systemd()
-                .context("container state does not contain cgroup manager")?;
-            let cmanger = create_cgroup_manager(&cgroups_path, use_systemd, self.id())?;
-            cmanger.get_all_pids()?
-        } else {
-            vec![self
-                .pid()
-                .context("failed to get the pid of the container")?]
-        };
-
         self.refresh_status()
             .context("failed to refresh container status")?;
         if self.can_kill() {
-            pids.into_iter().try_for_each(|pid| {
-                log::debug!("kill signal {} to {}", signal, pid);
-                signal::kill(pid, signal)
-            })?;
-
+            self.do_kill(signal, all, false)?;
             self.set_status(ContainerStatus::Stopped).save()?;
             std::process::exit(0)
         } else {
@@ -56,5 +37,57 @@ impl Container {
                 self.status()
             )
         }
+    }
+
+    pub(crate) fn do_kill<S: Into<Signal>>(
+        &mut self,
+        signal: S,
+        all: bool,
+        force: bool,
+    ) -> Result<()> {
+        let signal = signal.into().into_raw();
+        let mut manger: Option<Box<dyn libcgroups::common::CgroupManager>> = None;
+        let pids = if all {
+            let cgroups_path = self.spec()?.cgroup_path;
+            let use_systemd = self
+                .systemd()
+                .context("container state does not contain cgroup manager")?;
+            let cmanger = create_cgroup_manager(&cgroups_path, use_systemd, self.id())?;
+            let all_pids = cmanger.get_all_pids()?;
+            manger = Some(cmanger);
+            all_pids
+        } else {
+            vec![self
+                .pid()
+                .context("failed to get the pid of the container")?]
+        };
+        if self.status() == ContainerStatus::Paused {
+            // In cgroup V1, paused processes cannot respond to signals,
+            // so if we want to kill a process forcely, we need to thaw it.
+            match get_cgroup_setup()? {
+                libcgroups::common::CgroupSetup::Legacy
+                | libcgroups::common::CgroupSetup::Hybrid => {
+                    if !force {
+                        bail!("in cgroup v1, frozon container can't be killed until it is thawed")
+                    }
+                    let cmanger = if let Some(cmanger) = manger {
+                        cmanger
+                    } else {
+                        let cgroups_path = self.spec()?.cgroup_path;
+                        let use_systemd = self
+                            .systemd()
+                            .context("container state does not contain cgroup manager")?;
+                        create_cgroup_manager(&cgroups_path, use_systemd, self.id())?
+                    };
+                    cmanger.freeze(libcgroups::common::FreezerState::Thawed)?;
+                }
+                libcgroups::common::CgroupSetup::Unified => {}
+            }
+        }
+        pids.into_iter().try_for_each(|pid| {
+            log::debug!("kill signal {} to {}", signal, pid);
+            signal::kill(pid, signal)
+        })?;
+        Ok(())
     }
 }

--- a/crates/libcontainer/src/container/container_kill.rs
+++ b/crates/libcontainer/src/container/container_kill.rs
@@ -27,67 +27,84 @@ impl Container {
         self.refresh_status()
             .context("failed to refresh container status")?;
         if self.can_kill() {
-            self.do_kill(signal, all, false)?;
-            self.set_status(ContainerStatus::Stopped).save()?;
-            std::process::exit(0)
+            self.do_kill(signal, all)?;
         } else {
-            bail!(
-                "{} could not be killed because it was {:?}",
-                self.id(),
-                self.status()
-            )
+            // just like runc, allow kill --all even if the container is stopped
+            if all && self.status() == ContainerStatus::Stopped {
+                self.do_kill(signal, all)?;
+            } else {
+                bail!(
+                    "{} could not be killed because it was {:?}",
+                    self.id(),
+                    self.status()
+                )
+            }
+        }
+        self.set_status(ContainerStatus::Stopped).save()?;
+        Ok(())
+    }
+
+    pub(crate) fn do_kill<S: Into<Signal>>(&self, signal: S, all: bool) -> Result<()> {
+        if all {
+            self.kill_all_processes(signal)
+        } else {
+            self.kill_one_process(signal)
         }
     }
 
-    pub(crate) fn do_kill<S: Into<Signal>>(
-        &mut self,
-        signal: S,
-        all: bool,
-        force: bool,
-    ) -> Result<()> {
+    fn kill_one_process<S: Into<Signal>>(&self, signal: S) -> Result<()> {
         let signal = signal.into().into_raw();
-        let mut manger: Option<Box<dyn libcgroups::common::CgroupManager>> = None;
-        let pids = if all {
-            let cgroups_path = self.spec()?.cgroup_path;
-            let use_systemd = self
-                .systemd()
-                .context("container state does not contain cgroup manager")?;
-            let cmanger = create_cgroup_manager(&cgroups_path, use_systemd, self.id())?;
-            let all_pids = cmanger.get_all_pids()?;
-            manger = Some(cmanger);
-            all_pids
-        } else {
-            vec![self
-                .pid()
-                .context("failed to get the pid of the container")?]
-        };
-        if self.status() == ContainerStatus::Paused {
-            // In cgroup V1, paused processes cannot respond to signals,
-            // so if we want to kill a process forcely, we need to thaw it.
+        let pid = self.pid().unwrap();
+
+        log::debug!("kill signal {} to {}", signal, pid);
+        signal::kill(pid, signal)?;
+        // For cgroup V1, a frozon process cannot respond to signals,
+        // so we need to thaw it. Only thaw the cgroup for SIGKILL.
+        if self.status() == ContainerStatus::Paused && signal == signal::Signal::SIGKILL {
             match get_cgroup_setup()? {
                 libcgroups::common::CgroupSetup::Legacy
                 | libcgroups::common::CgroupSetup::Hybrid => {
-                    if !force {
-                        bail!("in cgroup v1, frozon container can't be killed until it is thawed")
-                    }
-                    let cmanger = if let Some(cmanger) = manger {
-                        cmanger
-                    } else {
-                        let cgroups_path = self.spec()?.cgroup_path;
-                        let use_systemd = self
-                            .systemd()
-                            .context("container state does not contain cgroup manager")?;
-                        create_cgroup_manager(&cgroups_path, use_systemd, self.id())?
-                    };
+                    let cgroups_path = self.spec()?.cgroup_path;
+                    let use_systemd = self
+                        .systemd()
+                        .context("container state does not contain cgroup manager")?;
+                    let cmanger = create_cgroup_manager(&cgroups_path, use_systemd, self.id())?;
                     cmanger.freeze(libcgroups::common::FreezerState::Thawed)?;
                 }
                 libcgroups::common::CgroupSetup::Unified => {}
             }
         }
-        pids.into_iter().try_for_each(|pid| {
+        Ok(())
+    }
+
+    fn kill_all_processes<S: Into<Signal>>(&self, signal: S) -> Result<()> {
+        let signal = signal.into().into_raw();
+        let cgroups_path = self.spec()?.cgroup_path;
+        let use_systemd = self
+            .systemd()
+            .context("container state does not contain cgroup manager")?;
+        let cmanger = create_cgroup_manager(&cgroups_path, use_systemd, self.id())?;
+        let ret = cmanger.freeze(libcgroups::common::FreezerState::Frozen);
+        if ret.is_err() {
+            log::warn!(
+                "failed to freeze container {}, error: {}",
+                self.id(),
+                ret.unwrap_err()
+            );
+        }
+        let pids = cmanger.get_all_pids()?;
+        pids.iter().try_for_each(|&pid| {
             log::debug!("kill signal {} to {}", signal, pid);
             signal::kill(pid, signal)
         })?;
+        let ret = cmanger.freeze(libcgroups::common::FreezerState::Thawed);
+        if ret.is_err() {
+            log::warn!(
+                "failed to thaw container {}, error: {}",
+                self.id(),
+                ret.unwrap_err()
+            );
+        }
         Ok(())
     }
 }


### PR DESCRIPTION
If force is not given, and cgroups is v1 and container is frozen, display error saying could not be killed as it was forzen. If force option is given, and cgroups is v1 and container is frozen, thaw it and send the kill signal. If cgroups is v2 , nothing special needs to be done.

Fix: #1129

Signed-off-by: Chen Yiyang <cyyzero@qq.com>

<a href="https://gitpod.io/#https://github.com/containers/youki/pull/1204"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

