### PR TITLE
Add git commit sha placeholder if .git not found

### DIFF
--- a/crates/youki/build.rs
+++ b/crates/youki/build.rs
@@ -4,5 +4,7 @@ use vergen::{vergen, Config, ShaKind};
 fn main() -> Result<()> {
     let mut config = Config::default();
     *config.git_mut().sha_kind_mut() = ShaKind::Short;
+    *config.git_mut().skip_if_error_mut() = true;
+    println!("cargo:rustc-env=VERGEN_GIT_SHA_SHORT=unknown");
     vergen(config)
 }


### PR DESCRIPTION
Related to #1212 
Not sure if we actively support building through nix, and as the issue discussion states, it is not fully working either even with this change.
This will emit a placeholder sha of `unknown` and add continue-on-error option for vergen. Currently the only place we are using sha is in info and version cli commands. If .git is found, vergen overrides the `unknown` by actual sha. I have verified this, but if possible, someone else also verify once. 

<a href="https://gitpod.io/#https://github.com/containers/youki/pull/1251"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

