### PR TITLE
Make exec behaviour consistent with runc's exec

### DIFF
--- a/crates/libcontainer/src/container/builder_impl.rs
+++ b/crates/libcontainer/src/container/builder_impl.rs
@@ -38,6 +38,8 @@ pub(super) struct ContainerBuilderImpl<'a> {
     pub container: Option<Container>,
     /// File descriptos preserved/passed to the container init process.
     pub preserve_fds: i32,
+
+    pub exec_fd:Option<RawFd>
 }
 
 impl<'a> ContainerBuilderImpl<'a> {
@@ -120,6 +122,7 @@ impl<'a> ContainerBuilderImpl<'a> {
             container: &self.container,
             rootless: &self.rootless,
             cgroup_manager: cmanager,
+            exec_fd:self.exec_fd
         };
 
         let (intermediate, init_pid) =

--- a/crates/libcontainer/src/container/builder_impl.rs
+++ b/crates/libcontainer/src/container/builder_impl.rs
@@ -41,6 +41,8 @@ pub(super) struct ContainerBuilderImpl<'a> {
     pub container: Option<Container>,
     /// File descriptos preserved/passed to the container init process.
     pub preserve_fds: i32,
+    /// If the container is to be run in detached mode
+    pub detached: bool,
 }
 
 impl<'a> ContainerBuilderImpl<'a> {
@@ -123,6 +125,7 @@ impl<'a> ContainerBuilderImpl<'a> {
             container: &self.container,
             rootless: &self.rootless,
             cgroup_manager: cmanager,
+            detached: self.detached,
         };
 
         let (intermediate, init_pid) =

--- a/crates/libcontainer/src/container/builder_impl.rs
+++ b/crates/libcontainer/src/container/builder_impl.rs
@@ -39,7 +39,7 @@ pub(super) struct ContainerBuilderImpl<'a> {
     /// File descriptos preserved/passed to the container init process.
     pub preserve_fds: i32,
 
-    pub exec_fd:Option<RawFd>
+    pub exec_fd: Option<RawFd>,
 }
 
 impl<'a> ContainerBuilderImpl<'a> {
@@ -122,7 +122,7 @@ impl<'a> ContainerBuilderImpl<'a> {
             container: &self.container,
             rootless: &self.rootless,
             cgroup_manager: cmanager,
-            exec_fd:self.exec_fd
+            exec_fd: self.exec_fd,
         };
 
         let (intermediate, init_pid) =

--- a/crates/libcontainer/src/container/init_builder.rs
+++ b/crates/libcontainer/src/container/init_builder.rs
@@ -90,6 +90,7 @@ impl<'a> InitContainerBuilder<'a> {
             notify_path,
             container: Some(container.clone()),
             preserve_fds: self.base.preserve_fds,
+            detached: false, // TODO this should be set properly based on how the command is given
         };
 
         builder_impl.create()?;

--- a/crates/libcontainer/src/container/init_builder.rs
+++ b/crates/libcontainer/src/container/init_builder.rs
@@ -87,6 +87,7 @@ impl<'a> InitContainerBuilder<'a> {
             notify_path,
             container: Some(container.clone()),
             preserve_fds: self.base.preserve_fds,
+            exec_fd:None
         };
 
         builder_impl.create()?;

--- a/crates/libcontainer/src/container/init_builder.rs
+++ b/crates/libcontainer/src/container/init_builder.rs
@@ -7,7 +7,10 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use crate::{apparmor, config::YoukiConfig, notify_socket::NOTIFY_FILE, rootless, tty, utils};
+use crate::{
+    apparmor, config::YoukiConfig, notify_socket::NOTIFY_FILE, process::args::ContainerType,
+    rootless, tty, utils,
+};
 
 use super::{
     builder::ContainerBuilder, builder_impl::ContainerBuilderImpl, Container, ContainerStatus,
@@ -75,7 +78,7 @@ impl<'a> InitContainerBuilder<'a> {
             .context("failed to save config")?;
 
         let mut builder_impl = ContainerBuilderImpl {
-            init: true,
+            container_type: ContainerType::InitContainer,
             syscall: self.base.syscall,
             container_id: self.base.container_id,
             pid_file: self.base.pid_file,
@@ -87,7 +90,6 @@ impl<'a> InitContainerBuilder<'a> {
             notify_path,
             container: Some(container.clone()),
             preserve_fds: self.base.preserve_fds,
-            exec_fd: None,
         };
 
         builder_impl.create()?;

--- a/crates/libcontainer/src/container/init_builder.rs
+++ b/crates/libcontainer/src/container/init_builder.rs
@@ -87,7 +87,7 @@ impl<'a> InitContainerBuilder<'a> {
             notify_path,
             container: Some(container.clone()),
             preserve_fds: self.base.preserve_fds,
-            exec_fd:None
+            exec_fd: None,
         };
 
         builder_impl.create()?;

--- a/crates/libcontainer/src/container/tenant_builder.rs
+++ b/crates/libcontainer/src/container/tenant_builder.rs
@@ -92,7 +92,7 @@ impl<'a> TenantContainerBuilder<'a> {
         self
     }
 
-    pub fn detached(mut self, detached: bool) -> Self {
+    pub fn with_detach(mut self, detached: bool) -> Self {
         self.detached = detached;
         self
     }

--- a/crates/libcontainer/src/container/tenant_builder.rs
+++ b/crates/libcontainer/src/container/tenant_builder.rs
@@ -1,7 +1,7 @@
 use anyhow::{bail, Context, Result};
 use caps::Capability;
-use nix::unistd::{self, Pid,pipe2,read,close};
 use nix::fcntl::OFlag;
+use nix::unistd::{self, close, pipe2, read, Pid};
 use oci_spec::runtime::{
     Capabilities as SpecCapabilities, Capability as SpecCapability, LinuxBuilder,
     LinuxCapabilities, LinuxCapabilitiesBuilder, LinuxNamespace, LinuxNamespaceBuilder,
@@ -117,7 +117,7 @@ impl<'a> TenantContainerBuilder<'a> {
         let use_systemd = self.should_use_systemd(&container);
         let rootless = Rootless::new(&spec)?;
 
-        let (read_end,write_end) = pipe2(OFlag::O_CLOEXEC)?;
+        let (read_end, write_end) = pipe2(OFlag::O_CLOEXEC)?;
 
         let mut builder_impl = ContainerBuilderImpl {
             init: false,
@@ -132,10 +132,8 @@ impl<'a> TenantContainerBuilder<'a> {
             notify_path: notify_path.clone(),
             container: None,
             preserve_fds: self.base.preserve_fds,
-            exec_fd:Some(write_end)
+            exec_fd: Some(write_end),
         };
-        
-        
 
         let pid = builder_impl.create()?;
 
@@ -143,11 +141,11 @@ impl<'a> TenantContainerBuilder<'a> {
         notify_socket.notify_container_start()?;
 
         close(write_end)?;
-        
-        let mut buf = [0;1024];
-        match read(read_end, &mut buf)?{
-            0 =>Ok(pid),
-            _=>bail!("{}",String::from_utf8_lossy(&buf).to_string())
+
+        let mut buf = [0; 1024];
+        match read(read_end, &mut buf)? {
+            0 => Ok(pid),
+            _ => bail!("{}", String::from_utf8_lossy(&buf).to_string()),
         }
     }
 

--- a/crates/libcontainer/src/process/args.rs
+++ b/crates/libcontainer/src/process/args.rs
@@ -6,9 +6,18 @@ use std::path::PathBuf;
 use crate::rootless::Rootless;
 use crate::{container::Container, notify_socket::NotifyListener, syscall::Syscall};
 
+#[derive(Debug, Copy, Clone)]
+pub enum ContainerType {
+    InitContainer,
+    TenantContainer {
+        detached: bool,
+        exec_notify_fd: RawFd,
+    },
+}
+
 pub struct ContainerArgs<'a> {
-    /// Flag indicating if an init or a tenant container should be created
-    pub init: bool,
+    /// Indicates if an init or a tenant container should be created
+    pub container_type: ContainerType,
     /// Interface to operating system primitives
     pub syscall: &'a dyn Syscall,
     /// OCI complient runtime spec
@@ -27,6 +36,4 @@ pub struct ContainerArgs<'a> {
     pub rootless: &'a Option<Rootless<'a>>,
     /// Cgroup Manager
     pub cgroup_manager: Box<dyn CgroupManager>,
-
-    pub exec_fd: Option<RawFd>,
 }

--- a/crates/libcontainer/src/process/args.rs
+++ b/crates/libcontainer/src/process/args.rs
@@ -28,5 +28,5 @@ pub struct ContainerArgs<'a> {
     /// Cgroup Manager
     pub cgroup_manager: Box<dyn CgroupManager>,
 
-    pub exec_fd:Option<RawFd>
+    pub exec_fd: Option<RawFd>,
 }

--- a/crates/libcontainer/src/process/args.rs
+++ b/crates/libcontainer/src/process/args.rs
@@ -27,4 +27,6 @@ pub struct ContainerArgs<'a> {
     pub rootless: &'a Option<Rootless<'a>>,
     /// Cgroup Manager
     pub cgroup_manager: Box<dyn CgroupManager>,
+
+    pub exec_fd:Option<RawFd>
 }

--- a/crates/libcontainer/src/process/args.rs
+++ b/crates/libcontainer/src/process/args.rs
@@ -9,10 +9,7 @@ use crate::{container::Container, notify_socket::NotifyListener, syscall::Syscal
 #[derive(Debug, Copy, Clone)]
 pub enum ContainerType {
     InitContainer,
-    TenantContainer {
-        detached: bool,
-        exec_notify_fd: RawFd,
-    },
+    TenantContainer { exec_notify_fd: RawFd },
 }
 
 pub struct ContainerArgs<'a> {
@@ -36,4 +33,6 @@ pub struct ContainerArgs<'a> {
     pub rootless: &'a Option<Rootless<'a>>,
     /// Cgroup Manager
     pub cgroup_manager: Box<dyn CgroupManager>,
+    /// If the container is to be run in detached mode
+    pub detached: bool,
 }

--- a/crates/libcontainer/src/process/channel.rs
+++ b/crates/libcontainer/src/process/channel.rs
@@ -62,7 +62,7 @@ impl MainSender {
         Ok(())
     }
 
-    pub fn exec_failed(&mut self,err:String)->Result<()>{
+    pub fn exec_failed(&mut self, err: String) -> Result<()> {
         self.sender.send(Message::ExecFailed(err))?;
         Ok(())
     }
@@ -87,7 +87,7 @@ impl MainReceiver {
 
         match msg {
             Message::IntermediateReady(pid) => Ok(Pid::from_raw(pid)),
-            Message::ExecFailed(err)=>bail!("exec process failed with error {}",err),
+            Message::ExecFailed(err) => bail!("exec process failed with error {}", err),
             _ => bail!(
                 "receive unexpected message {:?} waiting for intermediate ready",
                 msg

--- a/crates/libcontainer/src/process/channel.rs
+++ b/crates/libcontainer/src/process/channel.rs
@@ -62,6 +62,11 @@ impl MainSender {
         Ok(())
     }
 
+    pub fn exec_failed(&mut self,err:String)->Result<()>{
+        self.sender.send(Message::ExecFailed(err))?;
+        Ok(())
+    }
+
     pub fn close(&self) -> Result<()> {
         self.sender.close()
     }
@@ -82,6 +87,7 @@ impl MainReceiver {
 
         match msg {
             Message::IntermediateReady(pid) => Ok(Pid::from_raw(pid)),
+            Message::ExecFailed(err)=>bail!("exec process failed with error {}",err),
             _ => bail!(
                 "receive unexpected message {:?} waiting for intermediate ready",
                 msg

--- a/crates/libcontainer/src/process/container_init_process.rs
+++ b/crates/libcontainer/src/process/container_init_process.rs
@@ -1,4 +1,4 @@
-use super::args::ContainerArgs;
+use super::args::{ContainerArgs, ContainerType};
 use crate::apparmor;
 use crate::syscall::Syscall;
 use crate::workload::ExecutorManager;
@@ -186,7 +186,7 @@ pub fn container_init_process(
         let _ = prctl::set_no_new_privileges(true);
     }
 
-    if args.init {
+    if matches!(args.container_type, ContainerType::InitContainer) {
         // create_container hook needs to be called after the namespace setup, but
         // before pivot_root is called. This runs in the container namespaces.
         if let Some(hooks) = hooks {
@@ -409,7 +409,7 @@ pub fn container_init_process(
 
     // create_container hook needs to be called after the namespace setup, but
     // before pivot_root is called. This runs in the container namespaces.
-    if args.init {
+    if matches!(args.container_type, ContainerType::InitContainer) {
         if let Some(hooks) = hooks {
             hooks::run_hooks(hooks.start_container().as_ref(), container)?
         }

--- a/crates/libcontainer/src/process/container_intermediate_process.rs
+++ b/crates/libcontainer/src/process/container_intermediate_process.rs
@@ -99,11 +99,7 @@ pub fn container_intermediate_process(
         match container_init_process(args, main_sender, init_receiver) {
             Ok(_) => unreachable!("successful exec should never reach here"),
             Err(e) => {
-                if let ContainerType::TenantContainer {
-                    detached: _,
-                    exec_notify_fd,
-                } = args.container_type
-                {
+                if let ContainerType::TenantContainer { exec_notify_fd } = args.container_type {
                     let buf = format!("{}", e);
                     write(exec_notify_fd, buf.as_bytes())?;
                     close(exec_notify_fd)?;
@@ -114,11 +110,7 @@ pub fn container_intermediate_process(
     })?;
 
     // close the  exec_notify_fd in this process
-    if let ContainerType::TenantContainer {
-        detached: _,
-        exec_notify_fd,
-    } = args.container_type
-    {
+    if let ContainerType::TenantContainer { exec_notify_fd } = args.container_type {
         close(exec_notify_fd)?;
     }
 

--- a/crates/libcontainer/src/process/container_intermediate_process.rs
+++ b/crates/libcontainer/src/process/container_intermediate_process.rs
@@ -111,6 +111,11 @@ pub fn container_intermediate_process(
         }
     })?;
 
+    // close the fd here, otherwise the  main/interacting process hangs
+    if let Some(fd) = args.exec_fd{
+        close(fd)?;
+    }
+    
     main_sender
         .intermediate_ready(pid)
         .context("failed to send child ready from intermediate process")?;

--- a/crates/libcontainer/src/process/container_main_process.rs
+++ b/crates/libcontainer/src/process/container_main_process.rs
@@ -38,11 +38,9 @@ pub fn container_main_process(container_args: &ContainerArgs) -> Result<(Pid, Pi
 
         if matches!(
             container_args.container_type,
-            ContainerType::TenantContainer {
-                detached: false,
-                exec_notify_fd: _
-            }
-        ) {
+            ContainerType::TenantContainer { exec_notify_fd: _ }
+        ) && !container_args.detached
+        {
             match waitpid(container_pid, None)? {
                 WaitStatus::Exited(_, s) => Ok(s),
                 WaitStatus::Signaled(_, sig, _) => Ok(sig as i32),

--- a/crates/libcontainer/src/process/message.rs
+++ b/crates/libcontainer/src/process/message.rs
@@ -9,4 +9,5 @@ pub enum Message {
     MappingWritten,
     SeccompNotify,
     SeccompNotifyDone,
+    ExecFailed(String)
 }

--- a/crates/libcontainer/src/process/message.rs
+++ b/crates/libcontainer/src/process/message.rs
@@ -9,5 +9,5 @@ pub enum Message {
     MappingWritten,
     SeccompNotify,
     SeccompNotifyDone,
-    ExecFailed(String)
+    ExecFailed(String),
 }

--- a/crates/youki/src/commands/exec.rs
+++ b/crates/youki/src/commands/exec.rs
@@ -19,10 +19,10 @@ pub fn exec(args: Exec, root_path: PathBuf) -> Result<i32> {
         .with_container_args(args.command.clone())
         .build()?;
 
-    // do not wait if detach is given, 
+    // do not wait if detach is given,
     // although will still report exec errors from above '?'
     // TODO add better explanation here
-    if args.detach{
+    if args.detach {
         return Ok(0);
     }
 

--- a/crates/youki/src/commands/exec.rs
+++ b/crates/youki/src/commands/exec.rs
@@ -12,6 +12,7 @@ pub fn exec(args: Exec, root_path: PathBuf) -> Result<i32> {
         .with_console_socket(args.console_socket.as_ref())
         .with_pid_file(args.pid_file.as_ref())?
         .as_tenant()
+        .with_detach(args.detach)
         .with_cwd(args.cwd.as_ref())
         .with_env(args.env.clone().into_iter().collect())
         .with_process(args.process.as_ref())

--- a/crates/youki/src/commands/exec.rs
+++ b/crates/youki/src/commands/exec.rs
@@ -20,9 +20,10 @@ pub fn exec(args: Exec, root_path: PathBuf) -> Result<i32> {
         .with_container_args(args.command.clone())
         .build()?;
 
-    // do not wait if detach is given,
-    // although will still report exec errors from above '?'
-    // TODO add better explanation here
+    // See https://github.com/containers/youki/pull/1252 for a detailed explanation
+    // basically, if there is any error in starting exec, the build above will return error
+    // however, if the process does start, and detach is given, we do not wait for it
+    // if not detached, then we wait for it using waitpid below
     if args.detach {
         return Ok(0);
     }

--- a/crates/youki/src/commands/exec.rs
+++ b/crates/youki/src/commands/exec.rs
@@ -19,6 +19,13 @@ pub fn exec(args: Exec, root_path: PathBuf) -> Result<i32> {
         .with_container_args(args.command.clone())
         .build()?;
 
+    // do not wait if detach is given, 
+    // although will still report exec errors from above '?'
+    // TODO add better explanation here
+    if args.detach{
+        return Ok(0);
+    }
+
     match waitpid(pid, None)? {
         WaitStatus::Exited(_, status) => Ok(status),
         WaitStatus::Signaled(_, sig, _) => Ok(sig as i32),

--- a/crates/youki/src/main.rs
+++ b/crates/youki/src/main.rs
@@ -112,15 +112,13 @@ fn main() -> Result<()> {
                 commands::checkpoint::checkpoint(checkpoint, root_path)
             }
             CommonCmd::Events(events) => commands::events::events(events, root_path),
-            CommonCmd::Exec(exec) => {
-                match commands::exec::exec(exec, root_path){
-                    Ok(exit_code)=>std::process::exit(exit_code),
-                    Err(e)=>{
-                        eprintln!("exec failed : {}",e);
-                        std::process::exit(-1);
-                    }
+            CommonCmd::Exec(exec) => match commands::exec::exec(exec, root_path) {
+                Ok(exit_code) => std::process::exit(exit_code),
+                Err(e) => {
+                    eprintln!("exec failed : {}", e);
+                    std::process::exit(-1);
                 }
-            }
+            },
             CommonCmd::List(list) => commands::list::list(list, root_path),
             CommonCmd::Pause(pause) => commands::pause::pause(pause, root_path),
             CommonCmd::Ps(ps) => commands::ps::ps(ps, root_path),

--- a/crates/youki/src/main.rs
+++ b/crates/youki/src/main.rs
@@ -113,8 +113,13 @@ fn main() -> Result<()> {
             }
             CommonCmd::Events(events) => commands::events::events(events, root_path),
             CommonCmd::Exec(exec) => {
-                let exit_code = commands::exec::exec(exec, root_path)?;
-                std::process::exit(exit_code)
+                match commands::exec::exec(exec, root_path){
+                    Ok(exit_code)=>std::process::exit(exit_code),
+                    Err(e)=>{
+                        eprintln!("exec failed : {}",e);
+                        std::process::exit(-1);
+                    }
+                }
             }
             CommonCmd::List(list) => commands::list::list(list, root_path),
             CommonCmd::Pause(pause) => commands::pause::pause(pause, root_path),


### PR DESCRIPTION
related : #531 

NOTE : even though this does solve the issue, I'm not particularly happy with the way this is implemented. Comments and suggestions for improvements are most welcome.

This helps in passing following containerd's integration tests which were previously failing :
- TestContainerExec
- TestContaienrExecNoBinaryExists
- TestContainerExecLargeTTY (not sure if it was passing before and then broke, or was not passing from start, this PR will pass it)
- TestContainerLargeExecArgs
- TestContainerAttachProcess
- TestContainerMetrics
:tada: 

## Background
runc's exec has 4 distinct outcomes in terms of return value:
- when run without `--detach` and with a valid commannd, it waits and exits with the command's exit code
- when run without `--detach` and with an invalid command, it exits with and error, 255 exit code
- when run with `--detach` and with a valid command, it exits immediately after launching the process (tenant) and exits with a 0
- when run with `--detach` and with an invalid command, it exits with and error and exit code of 255

The 4rth case is subtle and made the main difference of why youki was not originally passing containerd's tests. 

On a sidde note, originally youki's exec did not respect the `--detach` flag and that was observed by the failing of TestContaienrExec after #1018 . This PR also fixes that.

Now, the reason behind the 4rth case exiting with error and not 0 like the 3rd, even though both are given detach flags, is runc executes the exec command similar to using process::spawn in Rust. Thus the exec occurs in two steps :
- First the exec process is spawned, and if there is any error in spawning the process, such as invalid command, invalid operation or OOM errors, it is checked at this stage, and immediately returned.
- If there was no error in spawning the command, then after doing some other work, runc checks if detach flag is given, if given immediately exits with 0, else waits for the exec'ed process to exit , and exits with its exit code.

Unlike it, youki uses fork-exec, which makes it difficult to do similar two-step exec as runc, because unlike process::spawn we do not really have a "handle" on the fork-exec'ed  process, at best we have parent-child waitpid relationship.

## This PR

This PR solves the issue by making sure the exec invocation done by youki binary gets the status of exec, AND add conditionality for waiting. 

The issue with the implementation is that the only way I could make it work was to open a pipe with O_CLOEXEC flag, and in the intermediate's fork for init process, _if_ the start_init_process returns, treat it as error (as the exec call should change process image and start the actual exec command, thus never returning). If the error occurs write the error message to the pipe. If exec succeeds, then the pipe is closed by OS. The tenant builder, after notifying start blocks by read-ing on this pipe, and if the read returns 0, indicating all write ends are closed, then the exec call has succeeded, otherwise, the buffer given to error contains the error message written by the init_process.
For this I had to drill down the RawFd from the tenant builder to the init process, and as the final `.build` uses the same implementation for init process and exec process, I had to introduce an enum to indicate the type AND pass the Fd. The problem is I don't feel this is much intuitive, and we have to make sure that the extra duplicated write-end fds are closed, for eg the intermediate process, after  forking from main process contains the duplicated write-end fd. If not closed, the read end blocks until the intermediate process has also exited. This took me a day to debug, and can be tricky to maintain.

Also, currently the exec-failed case always exits with 255, even though we might know the exact error code, as I couldn't find a way to downcast the anyhow error to specific type. The buffer size  is also hard-coded to 1024, so in case the error message is longer, it will be cut -off.

Personally I would have preferred a solution like notify-socket or main/intermediate sender-receiver  channels, but not sure if that supports O_CLOEXEC, and would work the same. Another issue preventing using main/intermediate channels is that they are created in the main_process which exists inside the `.build` call, however, the exec call is done only after notify_start is done, which is after the `.build` . This means that any other solution that is used will need some kind of parameter either being hard-coded or drilled down in a similar way RawFd is currently done.

Finally, one more thing to note is not only the youki cli invocation should not block/hand for exec if the detach flag is given, for some reason the containerd tests also monitor the intermediate process(?) which before this waited unconditionally on the init process. This PR thus also drills down the detach status, and both the cli and intermediate wait conditionally. I'm not sure why the test blocks on the exit of intermediate process , need to check if this is because we are leaking the pid of it somehow by incorrectly giving it instead of the init process. I have manually verified that the pid written to pid file is of the actual init process in case of create-start.

---

As mentioned in the start, not sure if this is the best approach, might be some better way to do this, comments and suggestion welcome. Thanks :)

cc: @utam0k @Furisto @yihuaf 


<a href="https://gitpod.io/#https://github.com/containers/youki/pull/1252"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

