### PR TITLE
chore(actions): upgrade to checkout action to v3

### DIFF
--- a/.github/workflows/benchmark_execution_time.yml
+++ b/.github/workflows/benchmark_execution_time.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout to PR branch
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup Linux env
         run: |
@@ -42,7 +42,7 @@ jobs:
 
     steps:
       - name: Checkout to main branch
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: main
 
@@ -82,7 +82,7 @@ jobs:
           sudo apt install jq podman
 
       - name: Checkout to PR branch
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Downloading PR build from artifact
         uses: actions/download-artifact@v2

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -10,7 +10,7 @@ jobs:
     outputs:
       dirs: ${{ steps.filter.outputs.changes }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: dorny/paths-filter@v2
         id: filter
         with:
@@ -24,7 +24,7 @@ jobs:
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Setup mdBook
         uses: peaceiris/actions-mdbook@v1
         with:

--- a/.github/workflows/integration_tests_validation.yaml
+++ b/.github/workflows/integration_tests_validation.yaml
@@ -13,7 +13,7 @@ jobs:
     outputs:
       dirs: ${{ steps.filter.outputs.changes }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: dorny/paths-filter@v2
         id: filter
         with:
@@ -28,7 +28,7 @@ jobs:
       matrix:
         rust: [1.63.0, 1.64.0]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: ${{ matrix.rust }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
     outputs:
       dirs: ${{ steps.filter.outputs.changes }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: dorny/paths-filter@v2
         id: filter
         with:
@@ -34,7 +34,7 @@ jobs:
         rust: [1.63.0, 1.64.0]
         dirs: ${{ fromJSON(needs.changes.outputs.dirs) }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: ${{ matrix.rust }}
@@ -57,7 +57,7 @@ jobs:
       matrix:
         rust: [1.63.0, 1.64.0]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: ${{ matrix.rust }}
@@ -73,7 +73,7 @@ jobs:
     timeout-minutes: 15
     name: Run test coverage
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Toolchain setup
         uses: actions-rs/toolchain@v1
         with:
@@ -107,7 +107,7 @@ jobs:
       matrix:
         rust: [1.63.0, 1.64.0]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: recursive
       - uses: actions-rs/toolchain@v1

--- a/.github/workflows/podman_tests.yaml
+++ b/.github/workflows/podman_tests.yaml
@@ -6,13 +6,13 @@ jobs:
   podman-tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - run: sudo apt-get -y update
       - run: sudo apt-get install -y pkg-config libsystemd-dev libdbus-glib-1-dev libelf-dev libseccomp-dev libgpgme-dev bats
       - run: make build 
       - run: sudo cp youki /usr/local/bin
       - name: Clone podman repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: containers/podman
       - uses: actions/setup-go@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ jobs:
     name: Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: recursive
       - run: sudo apt-get -y update
@@ -29,7 +29,7 @@ jobs:
     needs: check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - run: sudo apt-get -y update
       - run: sudo apt-get install -y pkg-config libsystemd-dev libdbus-glib-1-dev libelf-dev libseccomp-dev
       - name: Set up cargo
@@ -60,7 +60,7 @@ jobs:
     outputs:
       version: ${{ steps.info.outputs.version }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Determine Release Info
         id: info
@@ -117,7 +117,7 @@ jobs:
     env:
       CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up cargo
         uses: actions-rs/toolchain@v1
         with:


### PR DESCRIPTION
Upgrade checkout action to v3 which uses Node 16, following Node 12 deprecation.

Besides the Node version upgrade, the new action version doesn't seem to bring any breaking changes:

https://github.com/actions/checkout/releases/tag/v3.0.0

Closes #1259 

<a href="https://gitpod.io/#https://github.com/containers/youki/pull/1263"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

