### PR TITLE
Update libbpf to 1.0.3+v1.0.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1099,9 +1099,9 @@ checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
 
 [[package]]
 name = "libbpf-sys"
-version = "0.8.3+v0.8.1"
+version = "1.0.3+v1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31a75b565b9fa61e0ca3b5bf7b7af09d8f794f66e0cfce982d44f10e81aa010c"
+checksum = "376d23644bd8f7ec2ebf1b07f9d8e6a46989bae201c6ee378b0cd486fafc0624"
 dependencies = [
  "cc",
  "pkg-config",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2223,9 +2223,9 @@ dependencies = [
 
 [[package]]
 name = "syscalls"
-version = "0.6.6"
+version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9148c90637a79c6b331f80914a78816358bff6ca69c8af8f6fbbda9869bb2a39"
+checksum = "535e4a480d47370482f8251117cba053e32067862c439dcd4c9ea4026d08f88e"
 dependencies = [
  "cc",
  "serde",

--- a/crates/libcgroups/Cargo.toml
+++ b/crates/libcgroups/Cargo.toml
@@ -29,7 +29,7 @@ dbus = { version = "0.9.6", optional = true }
 fixedbitset = "0.4.2"
 serde = { version = "1.0", features = ["derive"] }
 rbpf = {version = "0.1.0", optional = true }
-libbpf-sys = { version = "0.8.3+v0.7.0", optional = true }
+libbpf-sys = { version = "1.0.3+v1.0.1", optional = true }
 errno = { version = "0.2.8", optional = true }
 libc = { version = "0.2.127", optional = true }
 

--- a/crates/libcgroups/src/v2/devices/mocks.rs
+++ b/crates/libcgroups/src/v2/devices/mocks.rs
@@ -14,14 +14,13 @@ pub mod libc {
 
 #[cfg_attr(test, automock())]
 pub mod libbpf_sys {
-    pub fn bpf_load_program(
+    pub fn bpf_prog_load(
         _type_: libbpf_sys::bpf_prog_type,
+        _name: *const i8,
+        _license: *const ::std::os::raw::c_char,
         _insns: *const libbpf_sys::bpf_insn,
         _insns_cnt: libbpf_sys::size_t,
-        _license: *const ::std::os::raw::c_char,
-        _kern_version: libbpf_sys::__u32,
-        _log_buf: *mut ::std::os::raw::c_char,
-        _log_buf_sz: libbpf_sys::size_t,
+        _opts: *const libbpf_sys::bpf_prog_load_opts,
     ) -> ::std::os::raw::c_int {
         unimplemented!();
     }

--- a/crates/libcontainer/Cargo.toml
+++ b/crates/libcontainer/Cargo.toml
@@ -36,7 +36,7 @@ libcgroups = { version = "0.0.3", path = "../libcgroups" }
 libseccomp = { version = "0.3.0" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-syscalls = "0.6.5"
+syscalls = "0.6.7"
 rust-criu = "0.2.0"
 wasmer = { version = "2.2.0", optional = true }
 wasmer-wasi = { version = "2.3.0", optional = true }


### PR DESCRIPTION
This makes the relevant changes for the major release of libbpf-sys. Apart from a function name and signature difference, there is no visible breakage in the behavior.

Signed-off-by: Yashodhan Joshi <yjdoc2@gmail.com>

<a href="https://gitpod.io/#https://github.com/containers/youki/pull/1265"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

