### PR TITLE
Fix how cgroup manager is created based on cgroups path

### DIFF
--- a/crates/libcgroups/src/common.rs
+++ b/crates/libcgroups/src/common.rs
@@ -182,11 +182,11 @@ pub fn create_cgroup_manager<P: Into<PathBuf>>(
     match cgroup_setup {
         CgroupSetup::Legacy | CgroupSetup::Hybrid => create_v1_cgroup_manager(cgroup_path),
         CgroupSetup::Unified => {
-            if systemd_cgroup {
-                return create_systemd_cgroup_manager(cgroup_path, container_name);
+            // ref https://github.com/opencontainers/runtime-spec/blob/main/config-linux.md#cgroups-path
+            if cgroup_path.is_absolute() || !systemd_cgroup {
+                return create_v2_cgroup_manager(cgroup_path);
             }
-
-            create_v2_cgroup_manager(cgroup_path)
+            create_systemd_cgroup_manager(cgroup_path, container_name)
         }
     }
 }


### PR DESCRIPTION
This aims to fix some issues with how cgroup manager is selected currently, and  ultimately fix #1277 .

The issue with  current implementation is that if we have to use systemd, i.e. when user namespace is set or running rootless, then we simply fallback to systemd manager, which expects the cgroup path to be either absent or of the form `[slice]:[scope_prefix]:[name]` .

However, the oci spec does not have any such restriction, and for cgroup path it simply states [here](https://github.com/opencontainers/runtime-spec/blob/main/config-linux.md#cgroups-path) that :

>cgroupsPath (string, OPTIONAL) path to the cgroups. It can be used to either control the cgroups hierarchy for containers or to run a new process in an existing container.

> The value of cgroupsPath MUST be either an absolute path or a relative path.

> -   In the case of an absolute path (starting with /), the runtime MUST take the path to be relative to the cgroups mount point.
> -   In the case of a relative path (not starting with /), the runtime MAY interpret the path relative to a runtime-determined location in the cgroups hierarchy.


Now I checked with runc and crun, with the same config as given to TestUserNamespace test, and as the path given is `/testing/TestUserNamespaces-WritableRootFS` , both of them create the cgroups at path `/sys/fs/cgroup//testing/TestUserNamespaces-WritableRootFS` , which is to say they use v2 amanger instead of systemd (?)

Thus, in this PR I have added check if the path is absolute and use v2 instead of systemd.

However, this is still not complete, as if the path given is relative, then this will still fail as systemd parsing will fail as before ; in which case the question is what is the correct thing to do in all cases?

Please take a look. Thanks.

Signed-off-by: Yashodhan Joshi <yjdoc2@gmail.com>