### PR TITLE
[libcontainer] Integrate WasmEdge Runtime

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -67,7 +67,9 @@ jobs:
       - run: sudo apt-get -y update
       - run: sudo apt-get install -y pkg-config libsystemd-dev libdbus-glib-1-dev libelf-dev libseccomp-dev
       - name: Run tests
-        run: cd ./crates && cargo test --all --all-features --no-fail-fast
+        run: |
+          export LD_LIBRARY_PATH=$HOME/.wasmedge/lib
+          cd ./crates && cargo test --all --all-features --no-fail-fast
   coverage:
     runs-on: ubuntu-latest
     timeout-minutes: 15

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -97,6 +97,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cbbc9d0964165b47557570cce6c952866c2678457aca742aafc9fb771d30270"
 
 [[package]]
+name = "bindgen"
+version = "0.60.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "062dddbc1ba4aca46de6338e2bf87771414c335f7b2f2036e8f3e9befebf88e6"
+dependencies = [
+ "bitflags",
+ "cexpr",
+ "clang-sys",
+ "lazy_static",
+ "lazycell",
+ "peeking_take_while",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -155,6 +174,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "cfg-if"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -180,6 +208,17 @@ dependencies = [
  "time 0.1.44",
  "wasm-bindgen",
  "winapi",
+]
+
+[[package]]
+name = "clang-sys"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa2e27ae6ab525c3d369ded447057bca5438d86dc3a68f6faafb8269ba82ebf3"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
 ]
 
 [[package]]
@@ -241,6 +280,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
 dependencies = [
  "os_str_bytes",
+]
+
+[[package]]
+name = "cmake"
+version = "0.1.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8ad8cef104ac57b68b89df3208164d228503abbdce70f6880ffa3d970e7443a"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -906,6 +954,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
+
+[[package]]
 name = "hashbrown"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1092,6 +1146,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
+name = "lazycell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
+
+[[package]]
 name = "leb128"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1165,6 +1225,9 @@ dependencies = [
  "serde_json",
  "serial_test",
  "syscalls",
+ "wasmedge-sdk",
+ "wasmedge-sys",
+ "wasmedge-types",
  "wasmer",
  "wasmer-wasi",
 ]
@@ -1209,11 +1272,10 @@ dependencies = [
 
 [[package]]
 name = "libseccomp"
-version = "0.3.0"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21c57fd8981a80019807b7b68118618d29a87177c63d704fc96e6ecd003ae5b3"
+checksum = "49bda1fbf25c42ac8942ff7df1eb6172a3bc36299e84be0dba8c888a7db68c80"
 dependencies = [
- "bitflags",
  "libc",
  "libseccomp-sys",
  "pkg-config",
@@ -1333,6 +1395,10 @@ checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
 dependencies = [
  "autocfg",
 ]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
@@ -1407,6 +1473,16 @@ name = "no-std-net"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43794a0ace135be66a25d3ae77d41b91615fb68ae937f904090203e81f755b65"
+
+[[package]]
+name = "nom"
+version = "7.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8903e5a29a317527874d0402f867152a3d21c908bb0b933e416c65e301d4c36"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
 
 [[package]]
 name = "normalize-line-endings"
@@ -1532,10 +1608,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "paste"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1de2e551fb905ac83f73f7aedf2f0cb4a0da7e35efa24a202a936269f1f18e1"
+
+[[package]]
 name = "path-clean"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ecba01bf2678719532c5e3059e0b5f0811273d94b397088b82e3bd0a78c78fdd"
+
+[[package]]
+name = "peeking_take_while"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "pentacle"
@@ -2133,6 +2221,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae1a47186c03a32177042e55dbc5fd5aee900b8e0069a8d70fba96a9375cd012"
 
 [[package]]
+name = "shlex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
+
+[[package]]
 name = "slab"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2597,6 +2691,59 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05632e0a66a6ed8cca593c24223aabd6262f256c3693ad9822c315285f010614"
 dependencies = [
  "leb128",
+]
+
+[[package]]
+name = "wasmedge-macro"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3df9b9549a9f80524d791f6cb5cbd64a0929039a61b11dfd772a603619d6649"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "wasmedge-sdk"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04b8bc771d94be284d3525a0987c9d37ce886bd276eab7bb1d52b485ecfbcce4"
+dependencies = [
+ "anyhow",
+ "thiserror",
+ "wasmedge-macro",
+ "wasmedge-sys",
+ "wasmedge-types",
+ "wat",
+]
+
+[[package]]
+name = "wasmedge-sys"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94cd867ae9d1674c82cce7f63518ef98dd254d6564471aab81540dced9ecccfd"
+dependencies = [
+ "bindgen",
+ "cmake",
+ "lazy_static",
+ "libc",
+ "parking_lot",
+ "paste",
+ "rand",
+ "thiserror",
+ "wasmedge-macro",
+ "wasmedge-types",
+]
+
+[[package]]
+name = "wasmedge-types"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44ba0c8ede5aefcd271d59c8eb5ccb73d5762bc2973876763c927c4bc22e82db"
+dependencies = [
+ "thiserror",
+ "wat",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2696,8 +2696,6 @@ dependencies = [
 [[package]]
 name = "wasmedge-macro"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3df9b9549a9f80524d791f6cb5cbd64a0929039a61b11dfd772a603619d6649"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2707,8 +2705,6 @@ dependencies = [
 [[package]]
 name = "wasmedge-sdk"
 version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04b8bc771d94be284d3525a0987c9d37ce886bd276eab7bb1d52b485ecfbcce4"
 dependencies = [
  "anyhow",
  "thiserror",
@@ -2721,8 +2717,6 @@ dependencies = [
 [[package]]
 name = "wasmedge-sys"
 version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94cd867ae9d1674c82cce7f63518ef98dd254d6564471aab81540dced9ecccfd"
 dependencies = [
  "bindgen",
  "cmake",
@@ -2739,8 +2733,6 @@ dependencies = [
 [[package]]
 name = "wasmedge-types"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44ba0c8ede5aefcd271d59c8eb5ccb73d5762bc2973876763c927c4bc22e82db"
 dependencies = [
  "thiserror",
  "wat",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1226,8 +1226,6 @@ dependencies = [
  "serial_test",
  "syscalls",
  "wasmedge-sdk",
- "wasmedge-sys",
- "wasmedge-types",
  "wasmer",
  "wasmer-wasi",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1395,6 +1395,8 @@ checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
 dependencies = [
  "autocfg",
 ]
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2709,8 +2709,6 @@ dependencies = [
 [[package]]
 name = "wasmedge-macro"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f159a9a7d3d2301de2fc9cb88ad3459af9e95cbd5a0f57437efccc2b572a027"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2719,9 +2717,7 @@ dependencies = [
 
 [[package]]
 name = "wasmedge-sdk"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "771740ee0f5840d48781dea94ad602900e4cbb49ccd13674e50fdb4933321414"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "num-derive",
@@ -2735,9 +2731,7 @@ dependencies = [
 
 [[package]]
 name = "wasmedge-sys"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e63642eaa0c5e59f135474bd37afca902793b11c98ad5018ee8988ec7b1ec4b"
+version = "0.12.1"
 dependencies = [
  "bindgen",
  "cmake",
@@ -2749,15 +2743,12 @@ dependencies = [
  "thiserror",
  "wasmedge-macro",
  "wasmedge-types",
- "wasmtime-fiber",
  "wat",
 ]
 
 [[package]]
 name = "wasmedge-types"
 version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3323fe75a4e65476b33a041092aac22a1065a7ba0bfecbedc8135e8efb6c522d"
 dependencies = [
  "thiserror",
  "wat",
@@ -3042,28 +3033,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "718ed7c55c2add6548cca3ddd6383d738cd73b892df400e96b9aa876f0141d7a"
 
 [[package]]
-name = "wasmtime-asm-macros"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f17b9bf1ff3ed08f35dd3faa8fe0dc34693939252e47a3a056073d28fcd6d7"
-dependencies = [
- "cfg-if 1.0.0",
-]
-
-[[package]]
-name = "wasmtime-fiber"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "331439bc204d5395b89a018d5aa11aaeb5819c733db40fe8bd1d4ce88bf85be1"
-dependencies = [
- "cc",
- "cfg-if 1.0.0",
- "rustix",
- "wasmtime-asm-macros",
- "windows-sys 0.36.1",
-]
-
-[[package]]
 name = "wast"
 version = "50.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3141,19 +3110,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.36.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea04155a16a59f9eab786fe12a4a450e75cdb175f9e0d80da1e17db09f55b8d2"
-dependencies = [
- "windows_aarch64_msvc 0.36.1",
- "windows_i686_gnu 0.36.1",
- "windows_i686_msvc 0.36.1",
- "windows_x86_64_gnu 0.36.1",
- "windows_x86_64_msvc 0.36.1",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
@@ -3181,12 +3137,6 @@ checksum = "cd761fd3eb9ab8cc1ed81e56e567f02dd82c4c837e48ac3b2181b9ffc5060807"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.36.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd0f252f5a35cac83d6311b2e795981f5ee6e67eb1f9a7f64eb4500fbc4dcdb4"
@@ -3196,12 +3146,6 @@ name = "windows_i686_gnu"
 version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cab0cf703a96bab2dc0c02c0fa748491294bf9b7feb27e1f4f96340f208ada0e"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.36.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3217,12 +3161,6 @@ checksum = "8cfdbe89cc9ad7ce618ba34abc34bbb6c36d99e96cae2245b7943cd75ee773d0"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.36.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84c12f65daa39dd2babe6e442988fc329d6243fdce47d7d2d155b8d874862246"
@@ -3232,12 +3170,6 @@ name = "windows_x86_64_gnu"
 version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4dd9b0c0e9ece7bb22e84d70d01b71c6d6248b81a3c60d11869451b4cb24784"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.36.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -3256,12 +3188,6 @@ name = "windows_x86_64_msvc"
 version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff1e4aa646495048ec7f3ffddc411e1d829c026a2ec62b39da15c1055e406eaa"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.36.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -98,9 +98,9 @@ checksum = "4cbbc9d0964165b47557570cce6c952866c2678457aca742aafc9fb771d30270"
 
 [[package]]
 name = "bindgen"
-version = "0.60.1"
+version = "0.61.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "062dddbc1ba4aca46de6338e2bf87771414c335f7b2f2036e8f3e9befebf88e6"
+checksum = "8a022e58a142a46fea340d68012b9201c094e93ec3d033a944a24f8fd4a4f09a"
 dependencies = [
  "bitflags",
  "cexpr",
@@ -113,6 +113,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
+ "syn",
 ]
 
 [[package]]
@@ -1270,10 +1271,11 @@ dependencies = [
 
 [[package]]
 name = "libseccomp"
-version = "0.2.3"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49bda1fbf25c42ac8942ff7df1eb6172a3bc36299e84be0dba8c888a7db68c80"
+checksum = "21c57fd8981a80019807b7b68118618d29a87177c63d704fc96e6ecd003ae5b3"
 dependencies = [
+ "bitflags",
  "libc",
  "libseccomp-sys",
  "pkg-config",
@@ -1495,6 +1497,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc51db7b362b205941f71232e56c625156eb9a929f8cf74a428fd5bc094a4afc"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "num-derive"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "876a53fff98e03a936a674b29568b0e605f06b29372c2489ff4de23f1949743d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2693,7 +2706,9 @@ dependencies = [
 
 [[package]]
 name = "wasmedge-macro"
-version = "0.1.0"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f159a9a7d3d2301de2fc9cb88ad3459af9e95cbd5a0f57437efccc2b572a027"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2702,9 +2717,13 @@ dependencies = [
 
 [[package]]
 name = "wasmedge-sdk"
-version = "0.5.0"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "771740ee0f5840d48781dea94ad602900e4cbb49ccd13674e50fdb4933321414"
 dependencies = [
  "anyhow",
+ "num-derive",
+ "num-traits",
  "thiserror",
  "wasmedge-macro",
  "wasmedge-sys",
@@ -2714,7 +2733,9 @@ dependencies = [
 
 [[package]]
 name = "wasmedge-sys"
-version = "0.10.0"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e63642eaa0c5e59f135474bd37afca902793b11c98ad5018ee8988ec7b1ec4b"
 dependencies = [
  "bindgen",
  "cmake",
@@ -2726,11 +2747,15 @@ dependencies = [
  "thiserror",
  "wasmedge-macro",
  "wasmedge-types",
+ "wasmtime-fiber",
+ "wat",
 ]
 
 [[package]]
 name = "wasmedge-types"
-version = "0.3.0"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3323fe75a4e65476b33a041092aac22a1065a7ba0bfecbedc8135e8efb6c522d"
 dependencies = [
  "thiserror",
  "wat",
@@ -3015,6 +3040,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "718ed7c55c2add6548cca3ddd6383d738cd73b892df400e96b9aa876f0141d7a"
 
 [[package]]
+name = "wasmtime-asm-macros"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41f17b9bf1ff3ed08f35dd3faa8fe0dc34693939252e47a3a056073d28fcd6d7"
+dependencies = [
+ "cfg-if 1.0.0",
+]
+
+[[package]]
+name = "wasmtime-fiber"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "331439bc204d5395b89a018d5aa11aaeb5819c733db40fe8bd1d4ce88bf85be1"
+dependencies = [
+ "cc",
+ "cfg-if 1.0.0",
+ "rustix",
+ "wasmtime-asm-macros",
+ "windows-sys 0.36.1",
+]
+
+[[package]]
 name = "wast"
 version = "50.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3092,6 +3139,19 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea04155a16a59f9eab786fe12a4a450e75cdb175f9e0d80da1e17db09f55b8d2"
+dependencies = [
+ "windows_aarch64_msvc 0.36.1",
+ "windows_i686_gnu 0.36.1",
+ "windows_i686_msvc 0.36.1",
+ "windows_x86_64_gnu 0.36.1",
+ "windows_x86_64_msvc 0.36.1",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
@@ -3119,6 +3179,12 @@ checksum = "cd761fd3eb9ab8cc1ed81e56e567f02dd82c4c837e48ac3b2181b9ffc5060807"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd0f252f5a35cac83d6311b2e795981f5ee6e67eb1f9a7f64eb4500fbc4dcdb4"
@@ -3128,6 +3194,12 @@ name = "windows_i686_gnu"
 version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cab0cf703a96bab2dc0c02c0fa748491294bf9b7feb27e1f4f96340f208ada0e"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3143,6 +3215,12 @@ checksum = "8cfdbe89cc9ad7ce618ba34abc34bbb6c36d99e96cae2245b7943cd75ee773d0"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84c12f65daa39dd2babe6e442988fc329d6243fdce47d7d2d155b8d874862246"
@@ -3152,6 +3230,12 @@ name = "windows_x86_64_gnu"
 version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4dd9b0c0e9ece7bb22e84d70d01b71c6d6248b81a3c60d11869451b4cb24784"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -3170,6 +3254,12 @@ name = "windows_x86_64_msvc"
 version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff1e4aa646495048ec7f3ffddc411e1d829c026a2ec62b39da15c1055e406eaa"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/crates/libcontainer/Cargo.toml
+++ b/crates/libcontainer/Cargo.toml
@@ -43,6 +43,9 @@ syscalls = "0.6.7"
 rust-criu = "0.2.0"
 wasmer = { version = "2.2.0", optional = true }
 wasmer-wasi = { version = "2.3.0", optional = true }
+wasmedge-sys = "0.10.0"
+wasmedge-sdk = "0.5.0"
+wasmedge-types = "0.3.0"
 
 [dev-dependencies]
 oci-spec = { version = "0.5.8", features = ["proptests", "runtime"] }

--- a/crates/libcontainer/Cargo.toml
+++ b/crates/libcontainer/Cargo.toml
@@ -18,7 +18,7 @@ systemd = ["libcgroups/systemd", "v2"]
 v2 = ["libcgroups/v2"]
 v1 = ["libcgroups/v1"]
 cgroupsv2_devices = ["libcgroups/cgroupsv2_devices"]
-wasm-wasmedge = ["wasmedge-sdk"]
+wasm-wasmedge = ["wasmedge-sdk/standalone"]
 
 [dependencies]
 anyhow = "1.0"
@@ -44,7 +44,7 @@ syscalls = "0.6.7"
 rust-criu = "0.2.0"
 wasmer = { version = "2.2.0", optional = true }
 wasmer-wasi = { version = "2.3.0", optional = true }
-wasmedge-sdk = { version = "0.7.0", features = ["standalone"], optional = true }
+wasmedge-sdk = { version = "0.7.1", optional = true }
 
 [dev-dependencies]
 oci-spec = { version = "0.5.8", features = ["proptests", "runtime"] }

--- a/crates/libcontainer/Cargo.toml
+++ b/crates/libcontainer/Cargo.toml
@@ -44,7 +44,7 @@ syscalls = "0.6.7"
 rust-criu = "0.2.0"
 wasmer = { version = "2.2.0", optional = true }
 wasmer-wasi = { version = "2.3.0", optional = true }
-wasmedge-sdk = { version = "0.5.0", path = "/home/sam/workspace/WasmEdge/bindings/rust/wasmedge-sdk", optional = true }
+wasmedge-sdk = { version = "0.6.0", optional = true }
 
 [dev-dependencies]
 oci-spec = { version = "0.5.8", features = ["proptests", "runtime"] }

--- a/crates/libcontainer/Cargo.toml
+++ b/crates/libcontainer/Cargo.toml
@@ -18,7 +18,7 @@ systemd = ["libcgroups/systemd", "v2"]
 v2 = ["libcgroups/v2"]
 v1 = ["libcgroups/v1"]
 cgroupsv2_devices = ["libcgroups/cgroupsv2_devices"]
-wasm-wasmedge = ["wasmedge-sdk", "wasmedge-sys", "wasmedge-types"]
+wasm-wasmedge = ["wasmedge-sdk"]
 
 [dependencies]
 anyhow = "1.0"
@@ -44,9 +44,7 @@ syscalls = "0.6.7"
 rust-criu = "0.2.0"
 wasmer = { version = "2.2.0", optional = true }
 wasmer-wasi = { version = "2.3.0", optional = true }
-wasmedge-sys = { version = "0.10.0", path = "/home/sam/workspace/WasmEdge/bindings/rust/wasmedge-sys", optional = true }
 wasmedge-sdk = { version = "0.5.0", path = "/home/sam/workspace/WasmEdge/bindings/rust/wasmedge-sdk", optional = true }
-wasmedge-types = { version = "0.3.0", path = "/home/sam/workspace/WasmEdge/bindings/rust/wasmedge-types", optional = true }
 
 [dev-dependencies]
 oci-spec = { version = "0.5.8", features = ["proptests", "runtime"] }

--- a/crates/libcontainer/Cargo.toml
+++ b/crates/libcontainer/Cargo.toml
@@ -18,6 +18,7 @@ systemd = ["libcgroups/systemd", "v2"]
 v2 = ["libcgroups/v2"]
 v1 = ["libcgroups/v1"]
 cgroupsv2_devices = ["libcgroups/cgroupsv2_devices"]
+wasm-wasmedge = ["wasmedge-sdk", "wasmedge-sys", "wasmedge-types"]
 
 [dependencies]
 anyhow = "1.0"
@@ -43,9 +44,9 @@ syscalls = "0.6.7"
 rust-criu = "0.2.0"
 wasmer = { version = "2.2.0", optional = true }
 wasmer-wasi = { version = "2.3.0", optional = true }
-wasmedge-sys = { version = "0.10.0", path = "/home/sam/workspace/WasmEdge/bindings/rust/wasmedge-sys" }
-wasmedge-sdk = { version = "0.5.0", path = "/home/sam/workspace/WasmEdge/bindings/rust/wasmedge-sdk" }
-wasmedge-types = { version = "0.3.0", path = "/home/sam/workspace/WasmEdge/bindings/rust/wasmedge-types" }
+wasmedge-sys = { version = "0.10.0", path = "/home/sam/workspace/WasmEdge/bindings/rust/wasmedge-sys", optional = true }
+wasmedge-sdk = { version = "0.5.0", path = "/home/sam/workspace/WasmEdge/bindings/rust/wasmedge-sdk", optional = true }
+wasmedge-types = { version = "0.3.0", path = "/home/sam/workspace/WasmEdge/bindings/rust/wasmedge-types", optional = true }
 
 [dev-dependencies]
 oci-spec = { version = "0.5.8", features = ["proptests", "runtime"] }

--- a/crates/libcontainer/Cargo.toml
+++ b/crates/libcontainer/Cargo.toml
@@ -44,7 +44,7 @@ syscalls = "0.6.7"
 rust-criu = "0.2.0"
 wasmer = { version = "2.2.0", optional = true }
 wasmer-wasi = { version = "2.3.0", optional = true }
-wasmedge-sdk = { version = "0.6.0", optional = true }
+wasmedge-sdk = { version = "0.7.0", features = ["standalone"], optional = true }
 
 [dev-dependencies]
 oci-spec = { version = "0.5.8", features = ["proptests", "runtime"] }

--- a/crates/libcontainer/Cargo.toml
+++ b/crates/libcontainer/Cargo.toml
@@ -43,9 +43,9 @@ syscalls = "0.6.7"
 rust-criu = "0.2.0"
 wasmer = { version = "2.2.0", optional = true }
 wasmer-wasi = { version = "2.3.0", optional = true }
-wasmedge-sys = "0.10.0"
-wasmedge-sdk = "0.5.0"
-wasmedge-types = "0.3.0"
+wasmedge-sys = { version = "0.10.0", path = "/home/sam/workspace/WasmEdge/bindings/rust/wasmedge-sys" }
+wasmedge-sdk = { version = "0.5.0", path = "/home/sam/workspace/WasmEdge/bindings/rust/wasmedge-sdk" }
+wasmedge-types = { version = "0.3.0", path = "/home/sam/workspace/WasmEdge/bindings/rust/wasmedge-types" }
 
 [dev-dependencies]
 oci-spec = { version = "0.5.8", features = ["proptests", "runtime"] }

--- a/crates/libcontainer/src/workload/mod.rs
+++ b/crates/libcontainer/src/workload/mod.rs
@@ -1,15 +1,9 @@
 use anyhow::{Context, Result};
 use oci_spec::runtime::Spec;
 
-use self::default::DefaultExecutor;
-#[cfg(feature = "wasm-wasmer")]
-use self::wasmer::WasmerExecutor;
+use self::wasmedge::WasmEdge;
 
-pub mod default;
-#[cfg(feature = "wasm-wasmer")]
-pub mod wasmer;
-
-static EMPTY: Vec<String> = Vec::new();
+pub mod wasmedge;
 
 pub trait Executor {
     /// Executes the workload
@@ -23,11 +17,6 @@ pub struct ExecutorManager {}
 
 impl ExecutorManager {
     pub fn exec(spec: &Spec) -> Result<()> {
-        #[cfg(feature = "wasm-wasmer")]
-        if WasmerExecutor::can_handle(spec)? {
-            return WasmerExecutor::exec(spec).context("wasmer execution failed");
-        }
-
-        DefaultExecutor::exec(spec).context("default execution failed")
+        return WasmEdge::exec(spec).context("wasmedge execution failed");
     }
 }

--- a/crates/libcontainer/src/workload/mod.rs
+++ b/crates/libcontainer/src/workload/mod.rs
@@ -1,9 +1,19 @@
 use anyhow::{Context, Result};
 use oci_spec::runtime::Spec;
 
-use self::wasmedge::WasmEdge;
+use self::default::DefaultExecutor;
+#[cfg(feature = "wasm-wasmedge")]
+use self::wasmedge::WasmEdgeExecutor;
+#[cfg(feature = "wasm-wasmer")]
+use self::wasmer::WasmerExecutor;
 
+pub mod default;
+#[cfg(feature = "wasm-wasmedge")]
 pub mod wasmedge;
+#[cfg(feature = "wasm-wasmer")]
+pub mod wasmer;
+
+static EMPTY: Vec<String> = Vec::new();
 
 pub trait Executor {
     /// Executes the workload
@@ -17,6 +27,16 @@ pub struct ExecutorManager {}
 
 impl ExecutorManager {
     pub fn exec(spec: &Spec) -> Result<()> {
-        return WasmEdge::exec(spec).context("wasmedge execution failed");
+        #[cfg(feature = "wasm-wasmer")]
+        if WasmerExecutor::can_handle(spec)? {
+            return WasmerExecutor::exec(spec).context("wasmer execution failed");
+        }
+
+        #[cfg(feature = "wasm-wasmedge")]
+        if WasmEdgeExecutor::can_handle(spec)? {
+            return WasmEdgeExecutor::exec(spec).context("wasmedge execution failed");
+        }
+
+        DefaultExecutor::exec(spec).context("default execution failed")
     }
 }

--- a/crates/libcontainer/src/workload/wasmedge.rs
+++ b/crates/libcontainer/src/workload/wasmedge.rs
@@ -1,0 +1,82 @@
+use std::path::PathBuf;
+
+use anyhow::Result;
+use oci_spec::runtime::Spec;
+use wasmedge_sdk::{
+    config::{CommonConfigOptions, ConfigBuilder, HostRegistrationConfigOptions},
+    params, Vm,
+};
+
+use super::Executor;
+
+const EXECUTOR_NAME: &str = "wasmedge";
+
+pub struct WasmEdge {}
+
+fn get_root(spec: &Spec) -> &PathBuf {
+    let root = spec.root().as_ref().unwrap();
+    root.path()
+}
+
+fn get_args(spec: &Spec) -> &[String] {
+    let p = match spec.process() {
+        None => return &[],
+        Some(p) => p,
+    };
+
+    match p.args() {
+        None => &[],
+        Some(args) => args.as_slice(),
+    }
+}
+
+fn env_to_wasi(spec: &Spec) -> Vec<String> {
+    let default = vec![];
+    let env = spec
+        .process()
+        .as_ref()
+        .unwrap()
+        .env()
+        .as_ref()
+        .unwrap_or(&default);
+    env.to_vec()
+}
+
+impl Executor for WasmEdge {
+    fn exec(spec: &Spec) -> Result<()> {
+        let host_options = HostRegistrationConfigOptions::default().wasi(true);
+        let config = ConfigBuilder::new(CommonConfigOptions::default())
+            .with_host_registration_config(host_options)
+            .build()?;
+        let mut vm = Vm::new(Some(config))?;
+
+        let args = get_args(&spec);
+        let mut cmd = args[0].clone();
+        if let Some(stripped) = args[0].strip_prefix(std::path::MAIN_SEPARATOR) {
+            cmd = stripped.to_string();
+        }
+
+        let envs = env_to_wasi(&spec);
+
+        let mut wasi_instance = vm.wasi_module()?;
+        wasi_instance.initialize(
+            Some(args.iter().map(|s| s as &str).collect()),
+            Some(envs.iter().map(|s| s as &str).collect()),
+            Some(vec![&cmd]),
+        );
+
+        let vm = vm.register_module_from_file("main", &cmd)?;
+
+        vm.run_func(Some("main"), "_start", params!())?;
+
+        Ok(())
+    }
+
+    fn can_handle(_: &Spec) -> Result<bool> {
+        Ok(true)
+    }
+
+    fn name() -> &'static str {
+        EXECUTOR_NAME
+    }
+}

--- a/crates/libcontainer/src/workload/wasmedge.rs
+++ b/crates/libcontainer/src/workload/wasmedge.rs
@@ -92,10 +92,6 @@ impl Executor for WasmEdgeExecutor {
         Ok(false)
     }
 
-    // fn can_handle(_: &Spec) -> Result<bool> {
-    //     Ok(true)
-    // }
-
     fn name() -> &'static str {
         EXECUTOR_NAME
     }

--- a/crates/libcontainer/src/workload/wasmedge.rs
+++ b/crates/libcontainer/src/workload/wasmedge.rs
@@ -13,12 +13,12 @@ pub struct WasmEdgeExecutor {}
 impl Executor for WasmEdgeExecutor {
     fn exec(spec: &Spec) -> Result<()> {
         // parse wasi parameters
-        let args = get_args(&spec);
+        let args = get_args(spec);
         let mut cmd = args[0].clone();
         if let Some(stripped) = args[0].strip_prefix(std::path::MAIN_SEPARATOR) {
             cmd = stripped.to_string();
         }
-        let envs = env_to_wasi(&spec);
+        let envs = env_to_wasi(spec);
 
         // create configuration with `wasi` option enabled
         let config = ConfigBuilder::new(CommonConfigOptions::default())

--- a/docs/src/user/webassembly.md
+++ b/docs/src/user/webassembly.md
@@ -6,13 +6,19 @@ There are 3 things you need to do to run a WebAssembly module with youki.
 2. Build a container image with the WebAssembly module
 3. Run the container with youki
 
-## Build youki with wasm-wasmer feature flag enabled
+## Build youki with `wasm-wasmedge` or `wasm-wasmer` feature flag enabled
 
-Run `build.sh` with `-f wasm-wasmer` option.
+- Run `build.sh` with `-f wasm-wasmedge` option.
 
-```console
-./script/build.sh -o -r . -f wasm-wasmer
-```
+    ```console
+    ./script/build.sh -o -r . -f wasm-wasmedge
+    ```
+
+- Run `build.sh` with `-f wasm-wasmer` option.
+
+    ```console
+    ./script/build.sh -o -r . -f wasm-wasmer
+    ```
 
 ## Build a container image with the WebAssembly module
 

--- a/docs/src/user/webassembly.md
+++ b/docs/src/user/webassembly.md
@@ -13,6 +13,16 @@ There are 3 things you need to do to run a WebAssembly module with youki.
     ```console
     ./script/build.sh -o -r . -f wasm-wasmedge
     ```
+    > The `wasm-wasmedge` feature will install WasmEdge Runtime library in the `$HOME/.wasmedge` directory. 
+    > To make the library avaible in your system, run the following command:
+    > ```bash
+    > export LD_LIBRARY_PATH=$HOME/.wasmedge/lib
+    > ```
+    > or
+    > ```bash
+    > source $HOME/.wasmedge/env
+    > ```
+    >
 
 - Run `build.sh` with `-f wasm-wasmer` option.
 


### PR DESCRIPTION
In this PR, `WasmEdgeExecutor` is  introduced into `libcontainer` for integrating `WasmEdge Runtime`. 

<a href="https://gitpod.io/#https://github.com/containers/youki/pull/1320"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

