### PR TITLE
Upgrade to 1.65 and fix lint errors

### DIFF
--- a/.github/workflows/integration_tests_validation.yaml
+++ b/.github/workflows/integration_tests_validation.yaml
@@ -26,7 +26,7 @@ jobs:
     timeout-minutes: 15
     strategy:
       matrix:
-        rust: [1.63.0, 1.64.0]
+        rust: [1.64.0, 1.65.0]
     steps:
       - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,7 +31,7 @@ jobs:
     timeout-minutes: 15
     strategy:
       matrix:
-        rust: [1.63.0, 1.64.0]
+        rust: [1.64.0, 1.65.0]
         dirs: ${{ fromJSON(needs.changes.outputs.dirs) }}
     steps:
       - uses: actions/checkout@v3
@@ -55,7 +55,7 @@ jobs:
     timeout-minutes: 15
     strategy:
       matrix:
-        rust: [1.63.0, 1.64.0]
+        rust: [1.64.0, 1.65.0]
     steps:
       - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
@@ -77,7 +77,7 @@ jobs:
       - name: Toolchain setup
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.62.1
+          toolchain: 1.65.0
           override: true
           profile: minimal
           components: llvm-tools-preview
@@ -105,7 +105,7 @@ jobs:
     timeout-minutes: 15
     strategy:
       matrix:
-        rust: [1.63.0, 1.64.0]
+        rust: [1.64.0, 1.65.0]
     steps:
       - uses: actions/checkout@v3
         with:

--- a/crates/libcgroups/src/v1/freezer.rs
+++ b/crates/libcgroups/src/v1/freezer.rs
@@ -23,7 +23,7 @@ impl Controller for Freezer {
 
     fn apply(controller_opt: &ControllerOpt, cgroup_root: &Path) -> Result<()> {
         log::debug!("Apply Freezer cgroup config");
-        create_dir_all(&cgroup_root)?;
+        create_dir_all(cgroup_root)?;
 
         if let Some(freezer_state) = Self::needs_to_handle(controller_opt) {
             Self::apply(freezer_state, cgroup_root).context("failed to appyl freezer")?;

--- a/crates/libcontainer/src/container/builder_impl.rs
+++ b/crates/libcontainer/src/container/builder_impl.rs
@@ -133,7 +133,7 @@ impl<'a> ContainerBuilderImpl<'a> {
 
         // if file to write the pid to is specified, write pid of the child
         if let Some(pid_file) = &self.pid_file {
-            fs::write(&pid_file, format!("{}", init_pid)).context("failed to write pid file")?;
+            fs::write(pid_file, format!("{}", init_pid)).context("failed to write pid file")?;
         }
 
         if let Some(container) = &mut self.container {

--- a/crates/libcontainer/src/container/init_builder.rs
+++ b/crates/libcontainer/src/container/init_builder.rs
@@ -57,7 +57,7 @@ impl<'a> InitContainerBuilder<'a> {
         unistd::chdir(&container_dir)?;
         let notify_path = container_dir.join(NOTIFY_FILE);
         // convert path of root file system of the container to absolute path
-        let rootfs = fs::canonicalize(&spec.root().as_ref().context("no root in spec")?.path())?;
+        let rootfs = fs::canonicalize(spec.root().as_ref().context("no root in spec")?.path())?;
 
         // if socket file path is given in commandline options,
         // get file descriptors of console socket

--- a/crates/libcontainer/src/container/tenant_builder.rs
+++ b/crates/libcontainer/src/container/tenant_builder.rs
@@ -116,7 +116,7 @@ impl<'a> TenantContainerBuilder<'a> {
         unistd::chdir(&container_dir)?;
         let notify_path = Self::setup_notify_listener(&container_dir)?;
         // convert path of root file system of the container to absolute path
-        let rootfs = fs::canonicalize(&spec.root().as_ref().context("no root in spec")?.path())?;
+        let rootfs = fs::canonicalize(spec.root().as_ref().context("no root in spec")?.path())?;
 
         // if socket file path is given in commandline options,
         // get file descriptors of console socket

--- a/crates/libcontainer/src/hooks.rs
+++ b/crates/libcontainer/src/hooks.rs
@@ -27,7 +27,7 @@ pub fn run_hooks(hooks: Option<&Vec<Hook>>, container: Option<&Container>) -> Re
 
     if let Some(hooks) = hooks {
         for hook in hooks {
-            let mut hook_command = process::Command::new(&hook.path());
+            let mut hook_command = process::Command::new(hook.path());
             // Based on OCI spec, the first argument of the args vector is the
             // arg0, which can be different from the path.  For example, path
             // may be "/usr/bin/true" and arg0 is set to "true". However, rust

--- a/crates/libcontainer/src/notify_socket.rs
+++ b/crates/libcontainer/src/notify_socket.rs
@@ -69,7 +69,7 @@ impl NotifySocket {
         log::debug!("notify container start");
         let cwd = env::current_dir()?;
         unistd::chdir(self.path.parent().unwrap())?;
-        let mut stream = UnixStream::connect(&self.path.file_name().unwrap())?;
+        let mut stream = UnixStream::connect(self.path.file_name().unwrap())?;
         stream.write_all(b"start container")?;
         log::debug!("notify finished");
         unistd::chdir(&cwd)?;

--- a/crates/libcontainer/src/rootfs/device.rs
+++ b/crates/libcontainer/src/rootfs/device.rs
@@ -109,7 +109,7 @@ fn create_container_dev_path(rootfs: &Path, dev: &LinuxDevice) -> Result<PathBuf
         .with_context(|| format!("could not join {:?} with {:?}", rootfs, dev.path()))?;
 
     crate::utils::create_dir_all(
-        &full_container_path
+        full_container_path
             .parent()
             .unwrap_or_else(|| Path::new("")),
     )?;

--- a/crates/libcontainer/src/rootfs/mount.rs
+++ b/crates/libcontainer/src/rootfs/mount.rs
@@ -373,21 +373,20 @@ impl Mount {
                 Path::new(&dest)
             };
 
-            create_dir_all(&dir)
+            create_dir_all(dir)
                 .with_context(|| format!("failed to create dir for bind mount: {:?}", dir))?;
 
             if src.is_file() {
                 OpenOptions::new()
                     .create(true)
                     .write(true)
-                    .open(&dest)
+                    .open(dest)
                     .with_context(|| format!("failed to create file for bind mount: {:?}", src))?;
             }
 
             src
         } else {
-            create_dir_all(&dest)
-                .with_context(|| format!("Failed to create device: {:?}", dest))?;
+            create_dir_all(dest).with_context(|| format!("Failed to create device: {:?}", dest))?;
 
             PathBuf::from(source)
         };
@@ -560,7 +559,7 @@ mod tests {
         let mounter = Mount::new();
 
         let spec_cgroup_mount = SpecMountBuilder::default()
-            .destination(&container_cgroup)
+            .destination(container_cgroup)
             .source("cgroup")
             .typ("cgroup")
             .build()
@@ -611,7 +610,7 @@ mod tests {
         let mounter = Mount::new();
 
         let spec_cgroup_mount = SpecMountBuilder::default()
-            .destination(&container_cgroup)
+            .destination(container_cgroup)
             .source("cgroup")
             .typ("cgroup")
             .build()

--- a/tests/rust-integration-tests/integration_test/src/tests/cgroups/mod.rs
+++ b/tests/rust-integration-tests/integration_test/src/tests/cgroups/mod.rs
@@ -32,7 +32,7 @@ pub fn cleanup_v2() -> Result<()> {
             .map(fs::remove_dir)
             .collect();
 
-        fs::remove_dir(&runtime_test)
+        fs::remove_dir(runtime_test)
             .with_context(|| format!("failed to delete {:?}", runtime_test))?;
     }
 

--- a/tests/rust-integration-tests/integration_test/src/tests/readonly_paths/readonly_paths_tests.rs
+++ b/tests/rust-integration-tests/integration_test/src/tests/readonly_paths/readonly_paths_tests.rs
@@ -90,7 +90,7 @@ fn check_readonly_paths() -> TestResult {
             }
         }
 
-        let test_file = bundle_path.join(&ro_file);
+        let test_file = bundle_path.join(ro_file);
         match fs::File::create(&test_file) {
             io::Result::Ok(_) => { /*This is expected*/ }
             io::Result::Err(e) => {
@@ -134,7 +134,7 @@ fn check_readonly_rel_path() -> TestResult {
 fn check_readonly_symlinks() -> TestResult {
     let root = PathBuf::from("/");
     let ro_symlink = "readonly_symlink";
-    let ro_paths = vec![root.join(&ro_symlink).to_string_lossy().to_string()];
+    let ro_paths = vec![root.join(ro_symlink).to_string_lossy().to_string()];
 
     let spec = get_spec(ro_paths);
 
@@ -185,14 +185,14 @@ fn check_readonly_symlinks() -> TestResult {
 fn test_node(mode: u32) -> TestResult {
     let root = PathBuf::from("/");
     let ro_device = "readonly_device";
-    let ro_paths = vec![root.join(&ro_device).to_string_lossy().to_string()];
+    let ro_paths = vec![root.join(ro_device).to_string_lossy().to_string()];
 
     let spec = get_spec(ro_paths);
 
     test_inside_container(spec, &|bundle_path| {
         use std::os::unix::fs::OpenOptionsExt;
         use std::{fs, io};
-        let test_file = bundle_path.join(&ro_device);
+        let test_file = bundle_path.join(ro_device);
 
         let mut opts = fs::OpenOptions::new();
         opts.mode(mode);


### PR DESCRIPTION
Upgrades CI rust version to latest stable, 1.65.0 . Now the checked are done across 1.64.0 and 1.65.0
Also fixes clippy lints generated because of the version changes

<a href="https://gitpod.io/#https://github.com/containers/youki/pull/1321"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

