### PR TITLE
Pass features across crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1146,7 +1146,6 @@ dependencies = [
  "caps",
  "chrono",
  "crossbeam-channel",
- "dbus",
  "fastrand",
  "futures",
  "libc",

--- a/Makefile
+++ b/Makefile
@@ -6,10 +6,13 @@ build:
 release-build:
 	./scripts/build.sh -o $(ROOT) -r
 
-test-all: test oci-integration-test integration-test
+test-all: test oci-integration-test integration-test features-test
 
 test: build
 	cd crates && cargo test
+
+features-test: build
+	./scripts/features_test.sh
 
 oci-integration-test:
 	./scripts/oci_integration_tests.sh $(ROOT)

--- a/crates/libcgroups/Cargo.toml
+++ b/crates/libcgroups/Cargo.toml
@@ -16,7 +16,7 @@ keywords = ["youki", "container", "cgroups"]
 default = ["v1", "v2", "systemd"]
 v1 = []
 v2 = []
-systemd = ["v2", "dbus"]
+systemd = ["v2", "dep:dbus"]
 cgroupsv2_devices = ["rbpf", "libbpf-sys", "errno", "libc"]
 
 [dependencies]

--- a/crates/libcgroups/src/common.rs
+++ b/crates/libcgroups/src/common.rs
@@ -11,9 +11,10 @@ use nix::{
     sys::statfs::{statfs, CGROUP2_SUPER_MAGIC, TMPFS_MAGIC},
     unistd::Pid,
 };
+use oci_spec::runtime::LinuxResources;
+#[cfg(any(feature = "cgroupsv2_devices", feature = "v1"))]
 use oci_spec::runtime::{
     LinuxDevice, LinuxDeviceBuilder, LinuxDeviceCgroup, LinuxDeviceCgroupBuilder, LinuxDeviceType,
-    LinuxResources,
 };
 
 #[cfg(feature = "systemd")]
@@ -299,6 +300,7 @@ impl PathBufExt for PathBuf {
     }
 }
 
+#[cfg(any(feature = "cgroupsv2_devices", feature = "v1"))]
 pub(crate) fn default_allow_devices() -> Vec<LinuxDeviceCgroup> {
     vec![
         LinuxDeviceCgroupBuilder::default()
@@ -350,6 +352,7 @@ pub(crate) fn default_allow_devices() -> Vec<LinuxDeviceCgroup> {
     ]
 }
 
+#[cfg(any(feature = "cgroupsv2_devices", feature = "v1"))]
 pub(crate) fn default_devices() -> Vec<LinuxDevice> {
     vec![
         LinuxDeviceBuilder::default()

--- a/crates/libcontainer/Cargo.toml
+++ b/crates/libcontainer/Cargo.toml
@@ -12,16 +12,18 @@ rust-version = "1.58.1"
 keywords = ["youki", "container", "cgroups"]
 
 [features]
-default = []
+default = ["systemd", "v2", "v1"]
 wasm-wasmer = ["wasmer", "wasmer-wasi"]
+systemd = ["libcgroups/systemd"]
+v2 = ["libcgroups/v2"]
+v1 = ["libcgroups/v1"]
 
 [dependencies]
 anyhow = "1.0"
 bitflags = "1.3.2"
 caps = "0.5.5"
-chrono = { version="0.4", features = ["serde"] }
+chrono = { version = "0.4", features = ["serde"] }
 crossbeam-channel = "0.5"
-dbus = "0.9.6"
 fastrand = "1.8.0"
 futures = { version = "0.3", features = ["thread-pool"] }
 libc = "0.2.127"
@@ -32,7 +34,7 @@ oci-spec = { version = "0.5.8", features = ["runtime"] }
 path-clean = "0.1.0"
 procfs = "0.14.1"
 prctl = "1.0.0"
-libcgroups = { version = "0.0.3", path = "../libcgroups" }
+libcgroups = { version = "0.0.3", path = "../libcgroups", default-features = false }
 libseccomp = { version = "0.3.0" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/crates/libcontainer/Cargo.toml
+++ b/crates/libcontainer/Cargo.toml
@@ -14,9 +14,10 @@ keywords = ["youki", "container", "cgroups"]
 [features]
 default = ["systemd", "v2", "v1"]
 wasm-wasmer = ["wasmer", "wasmer-wasi"]
-systemd = ["libcgroups/systemd"]
+systemd = ["libcgroups/systemd", "v2"]
 v2 = ["libcgroups/v2"]
 v1 = ["libcgroups/v1"]
+cgroupsv2_devices = ["libcgroups/cgroupsv2_devices"]
 
 [dependencies]
 anyhow = "1.0"

--- a/crates/libcontainer/src/container/container_checkpoint.rs
+++ b/crates/libcontainer/src/container/container_checkpoint.rs
@@ -2,10 +2,9 @@ use super::{Container, ContainerStatus};
 use crate::container::container::CheckpointOptions;
 use anyhow::{bail, Context, Result};
 
-use libcgroups::common::{
-    CgroupSetup::{Hybrid, Legacy},
-    DEFAULT_CGROUP_ROOT,
-};
+use libcgroups::common::CgroupSetup::{Hybrid, Legacy};
+#[cfg(feature = "v1")]
+use libcgroups::common::DEFAULT_CGROUP_ROOT;
 use oci_spec::runtime::Spec;
 use std::os::unix::io::AsRawFd;
 
@@ -54,6 +53,9 @@ impl Container {
                     {
                         // For v1 it is necessary to list all cgroup mounts as external mounts
                         Legacy | Hybrid => {
+                            #[cfg(not(feature = "v1"))]
+                            panic!("libcontainer can't run in a Legacy or Hybrid cgroup setup without the v1 feature");
+                            #[cfg(feature = "v1")]
                             for mp in libcgroups::v1::util::list_subsystem_mount_points()
                                 .context("failed to get subsystem mount points")?
                             {

--- a/crates/libcontainer/src/rootfs/symlink.rs
+++ b/crates/libcontainer/src/rootfs/symlink.rs
@@ -23,6 +23,7 @@ impl Symlink {
     }
 
     // Create symlinks for subsystems that have been comounted e.g. cpu -> cpu,cpuacct, cpuacct -> cpu,cpuacct
+    #[cfg(feature = "v1")]
     pub fn setup_comount_symlinks(&self, cgroup_root: &Path, subsystem_name: &str) -> Result<()> {
         if !subsystem_name.contains(',') {
             return Ok(());
@@ -83,13 +84,17 @@ impl Symlink {
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[cfg(feature = "v1")]
     use crate::syscall::linux::LinuxSyscall;
+    use crate::syscall::test::TestHelperSyscall;
+    #[cfg(feature = "v1")]
+    use crate::utils::create_temp_dir;
     use crate::utils::TempDir;
-    use crate::{syscall::test::TestHelperSyscall, utils::create_temp_dir};
     use nix::{
         fcntl::{open, OFlag},
         sys::stat::Mode,
     };
+    #[cfg(feature = "v1")]
     use std::fs;
     use std::path::PathBuf;
 
@@ -166,6 +171,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "v1")]
     fn setup_comounted_symlinks_success() -> Result<()> {
         // arrange
         let tmp = create_temp_dir("setup_comounted_symlinks_success")?;
@@ -208,6 +214,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "v1")]
     fn setup_comounted_symlinks_no_comounts() -> Result<()> {
         // arrange
         let tmp = create_temp_dir("setup_comounted_symlinks_no_comounts")?;

--- a/crates/youki/Cargo.toml
+++ b/crates/youki/Cargo.toml
@@ -11,6 +11,11 @@ edition = "2021"
 build = "build.rs"
 keywords = ["youki", "container"]
 
+[features]
+systemd = ["libcgroups/systemd", "libcontainer/systemd"]
+v2 = ["libcgroups/v2", "libcontainer/v2"]
+v1 = ["libcgroups/v1", "libcontainer/v1"]
+
 [dependencies.clap]
 version = "3.2.23"
 default-features = false
@@ -18,11 +23,11 @@ features = ["std", "suggestions", "derive", "cargo"]
 
 [dependencies]
 anyhow = "1.0.65"
-chrono = { version="0.4", features = ["serde"] }
-libcgroups = { version = "0.0.3", path = "../libcgroups" }
-libcontainer = { version = "0.0.3", path = "../libcontainer" }
+chrono = { version = "0.4", features = ["serde"] }
+libcgroups = { version = "0.0.3", path = "../libcgroups", default-features = false }
+libcontainer = { version = "0.0.3", path = "../libcontainer", default-features = false }
 liboci-cli = { version = "0.0.3", path = "../liboci-cli" }
-log = { version = "0.4", features = ["std"]}
+log = { version = "0.4", features = ["std"] }
 nix = "0.25.0"
 oci-spec = { version = "0.5.8", features = ["runtime"] }
 once_cell = "1.16.0"

--- a/crates/youki/Cargo.toml
+++ b/crates/youki/Cargo.toml
@@ -12,9 +12,10 @@ build = "build.rs"
 keywords = ["youki", "container"]
 
 [features]
-systemd = ["libcgroups/systemd", "libcontainer/systemd"]
+systemd = ["libcgroups/systemd", "libcontainer/systemd", "v2"]
 v2 = ["libcgroups/v2", "libcontainer/v2"]
 v1 = ["libcgroups/v1", "libcontainer/v1"]
+cgroupsv2_devices = ["libcgroups/cgroupsv2_devices", "libcontainer/cgroupsv2_devices"]
 
 [dependencies.clap]
 version = "3.2.23"

--- a/crates/youki/src/commands/info.rs
+++ b/crates/youki/src/commands/info.rs
@@ -1,11 +1,14 @@
 //! Contains functions related to printing information about system running Youki
-use std::{collections::HashSet, fs, path::Path};
+#[cfg(feature = "v2")]
+use std::collections::HashSet;
+use std::{fs, path::Path};
 
 use anyhow::Result;
 use clap::Parser;
 use libcontainer::rootless;
 use procfs::{CpuInfo, Meminfo};
 
+#[cfg(feature = "v2")]
 use libcgroups::{common::CgroupSetup, v2::controller_type::ControllerType};
 /// Show information about the system
 #[derive(Parser, Debug)]
@@ -114,6 +117,7 @@ pub fn print_hardware() {
 pub fn print_cgroups() {
     print_cgroups_setup();
     print_cgroup_mounts();
+    #[cfg(feature = "v2")]
     print_cgroup_v2_controllers();
 }
 
@@ -126,6 +130,7 @@ pub fn print_cgroups_setup() {
 
 pub fn print_cgroup_mounts() {
     println!("Cgroup mounts");
+    #[cfg(feature = "v1")]
     if let Ok(v1_mounts) = libcgroups::v1::util::list_supported_mount_points() {
         let mut v1_mounts: Vec<String> = v1_mounts
             .iter()
@@ -138,12 +143,13 @@ pub fn print_cgroup_mounts() {
         }
     }
 
-    let unified = libcgroups::v2::util::get_unified_mount_point();
-    if let Ok(mount_point) = &unified {
+    #[cfg(feature = "v2")]
+    if let Ok(mount_point) = libcgroups::v2::util::get_unified_mount_point() {
         println!("  {:<16}{}", "unified", mount_point.display());
     }
 }
 
+#[cfg(feature = "v2")]
 pub fn print_cgroup_v2_controllers() {
     let cgroup_setup = libcgroups::common::get_cgroup_setup();
     let unified = libcgroups::v2::util::get_unified_mount_point();

--- a/scripts/features_test.sh
+++ b/scripts/features_test.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -eu
+
+# Build the different features individually
+cargo build --no-default-features -F v1
+cargo build --no-default-features -F v2
+cargo build --no-default-features -F systemd
+cargo build --no-default-features -F v2 -F cgroupsv2_devices
+cargo build --no-default-features -F systemd -F cgroupsv2_devices
+
+# Test the different features individually
+cargo test --no-default-features -F v1
+cargo test --no-default-features -F v2
+cargo test --no-default-features -F systemd
+cargo test --no-default-features -F v2 -F cgroupsv2_devices
+cargo test --no-default-features -F systemd -F cgroupsv2_devices
+
+exit 0


### PR DESCRIPTION
The crate libcgroups depends on dbus and libelf for some specific features only, namely systemd cgroups and cgroups v2 devices. If a target host doesn't require any of those features it is not possible to build the youki or libcontainer crates because these two are not mapping their features to the features of libcgroups.

In this pull request the features have been mapped all the way to the youki crate and a specific test has been created to ensure that the different combinations of features can still build and also that they all pass the tests individually.

<a href="https://gitpod.io/#https://github.com/containers/youki/pull/1330"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

