### PR TITLE
Add hostname test

### DIFF
--- a/tests/rust-integration-tests/integration_test/src/main.rs
+++ b/tests/rust-integration-tests/integration_test/src/main.rs
@@ -8,6 +8,7 @@ use crate::tests::pidfile::get_pidfile_test;
 use crate::tests::readonly_paths::get_ro_paths_test;
 use crate::tests::seccomp_notify::get_seccomp_notify_test;
 use crate::tests::tlb::get_tlb_test;
+use crate::tests::hostname::get_hostname_test;
 use crate::utils::support::{set_runtime_path, set_runtimetest_path};
 use anyhow::{Context, Result};
 use clap::Parser;
@@ -88,6 +89,7 @@ fn main() -> Result<()> {
     let cgroup_v1_blkio = cgroups::blkio::get_test_group();
     let seccomp_notify = get_seccomp_notify_test();
     let ro_paths = get_ro_paths_test();
+    let hostname = get_hostname_test();
 
     tm.add_test_group(Box::new(cl));
     tm.add_test_group(Box::new(cc));
@@ -103,6 +105,7 @@ fn main() -> Result<()> {
     tm.add_test_group(Box::new(cgroup_v1_blkio));
     tm.add_test_group(Box::new(seccomp_notify));
     tm.add_test_group(Box::new(ro_paths));
+    tm.add_test_group(Box::new(hostname));
 
     tm.add_cleanup(Box::new(cgroups::cleanup_v1));
     tm.add_cleanup(Box::new(cgroups::cleanup_v2));

--- a/tests/rust-integration-tests/integration_test/src/tests/hostname/mod.rs
+++ b/tests/rust-integration-tests/integration_test/src/tests/hostname/mod.rs
@@ -7,12 +7,9 @@ fn create_spec(hostname: &str) -> Spec {
     SpecBuilder::default()
         .hostname(hostname)
         .linux(
+            // Need to reset the read-only paths
             LinuxBuilder::default()
-                .readonly_paths(vec![
-                    "/proc/bus".to_string(),
-                    "/proc/fs".to_string(),
-                    "/proc/sys".to_string(),
-                ])
+                .readonly_paths(vec![])
                 .build()
                 .expect("error in building linux config"),
         )

--- a/tests/rust-integration-tests/integration_test/src/tests/hostname/mod.rs
+++ b/tests/rust-integration-tests/integration_test/src/tests/hostname/mod.rs
@@ -1,0 +1,53 @@
+use anyhow::{Context, Result};
+use oci_spec::runtime::{LinuxBuilder, ProcessBuilder, Spec, SpecBuilder};
+use test_framework::{Test, TestGroup, TestResult};
+
+use crate::utils::test_inside_container;
+
+fn create_spec(hostname: &str) -> Result<Spec> {
+    Ok(SpecBuilder::default()
+        .hostname(hostname)
+        .linux(
+            LinuxBuilder::default()
+                .readonly_paths(vec![
+                    "/proc/bus".to_string(),
+                    "/proc/fs".to_string(),
+                    "/proc/sys".to_string(),
+                ])
+                .build()
+                .expect("should build linux config"),
+        )
+        .process(
+            ProcessBuilder::default()
+                .args(vec!["runtimetest".to_string()])
+                .build()
+                .expect("can create process"),
+        )
+        .build()
+        .context("Failed to build hostname spec")?)
+}
+
+fn hostname_test() -> TestResult {
+    let cases = vec!["hostname-specific", ""];
+    for case in cases {
+        let spec = create_spec(case).expect("should create spec");
+        let test_result = test_inside_container(spec, &|_| {
+            // As long as the container is created, we expect the hostname to be determined
+            // by the spec, so nothing to prepare prior.
+            Ok(())
+        });
+        // fail fast
+        if let TestResult::Failed(e) = test_result {
+            return TestResult::Failed(e);
+        }
+    }
+    TestResult::Passed
+}
+
+pub fn get_hostname_test() -> TestGroup {
+    let mut test_group = TestGroup::new("set_host_name");
+    let hostname_test = Test::new("set_host_name_test", Box::new(hostname_test));
+    test_group.add(vec![Box::new(hostname_test)]);
+
+    test_group
+}

--- a/tests/rust-integration-tests/integration_test/src/tests/hostname/mod.rs
+++ b/tests/rust-integration-tests/integration_test/src/tests/hostname/mod.rs
@@ -1,11 +1,10 @@
-use anyhow::{Context, Result};
 use oci_spec::runtime::{LinuxBuilder, ProcessBuilder, Spec, SpecBuilder};
 use test_framework::{Test, TestGroup, TestResult};
 
 use crate::utils::test_inside_container;
 
-fn create_spec(hostname: &str) -> Result<Spec> {
-    Ok(SpecBuilder::default()
+fn create_spec(hostname: &str) -> Spec {
+    SpecBuilder::default()
         .hostname(hostname)
         .linux(
             LinuxBuilder::default()
@@ -15,39 +14,41 @@ fn create_spec(hostname: &str) -> Result<Spec> {
                     "/proc/sys".to_string(),
                 ])
                 .build()
-                .expect("should build linux config"),
+                .expect("error in building linux config"),
         )
         .process(
             ProcessBuilder::default()
                 .args(vec!["runtimetest".to_string()])
                 .build()
-                .expect("can create process"),
+                .expect("error in creating process config"),
         )
         .build()
-        .context("Failed to build hostname spec")?)
+        .unwrap()
 }
 
 fn hostname_test() -> TestResult {
-    let cases = vec!["hostname-specific", ""];
-    for case in cases {
-        let spec = create_spec(case).expect("should create spec");
-        let test_result = test_inside_container(spec, &|_| {
-            // As long as the container is created, we expect the hostname to be determined
-            // by the spec, so nothing to prepare prior.
-            Ok(())
-        });
-        // fail fast
-        if let TestResult::Failed(e) = test_result {
-            return TestResult::Failed(e);
-        }
-    }
-    TestResult::Passed
+    let spec = create_spec("hostname-specific");
+    test_inside_container(spec, &|_| {
+        // As long as the container is created, we expect the hostname to be determined
+        // by the spec, so nothing to prepare prior.
+        Ok(())
+    })
+}
+
+fn empty_hostname() -> TestResult {
+    let spec = create_spec("");
+    test_inside_container(spec, &|_| {
+        // As long as the container is created, we expect the hostname to be determined
+        // by the spec, so nothing to prepare prior.
+        Ok(())
+    })
 }
 
 pub fn get_hostname_test() -> TestGroup {
     let mut test_group = TestGroup::new("set_host_name");
     let hostname_test = Test::new("set_host_name_test", Box::new(hostname_test));
-    test_group.add(vec![Box::new(hostname_test)]);
+    let empty_hostname_test = Test::new("set_empty_host_name_test", Box::new(empty_hostname));
+    test_group.add(vec![Box::new(hostname_test), Box::new(empty_hostname_test)]);
 
     test_group
 }

--- a/tests/rust-integration-tests/integration_test/src/tests/mod.rs
+++ b/tests/rust-integration-tests/integration_test/src/tests/mod.rs
@@ -6,3 +6,4 @@ pub mod pidfile;
 pub mod readonly_paths;
 pub mod seccomp_notify;
 pub mod tlb;
+pub mod hostname;

--- a/tests/rust-integration-tests/runtimetest/src/main.rs
+++ b/tests/rust-integration-tests/runtimetest/src/main.rs
@@ -20,4 +20,5 @@ fn get_spec() -> Spec {
 fn main() {
     let spec = get_spec();
     tests::validate_readonly_paths(&spec);
+    tests::validate_hostname(&spec);
 }

--- a/tests/rust-integration-tests/runtimetest/src/tests.rs
+++ b/tests/rust-integration-tests/runtimetest/src/tests.rs
@@ -59,3 +59,20 @@ pub fn validate_readonly_paths(spec: &Spec) {
         }
     }
 }
+
+pub fn validate_hostname(spec: &Spec) {
+    if let Some(expected_hostname) = spec.hostname() {
+        if expected_hostname.is_empty() {
+            // Skipping empty hostname
+            return;
+        }
+        let actual_hostname = nix::unistd::gethostname().expect("failed to get current hostname");
+        let actual_hostname = actual_hostname.to_str().unwrap();
+        if &actual_hostname != expected_hostname {
+            eprintln!(
+                "Unexpected hostname, expected: {:?} found: {:?}",
+                expected_hostname, actual_hostname
+            );
+        }
+    }
+}

--- a/tests/rust-integration-tests/runtimetest/src/tests.rs
+++ b/tests/rust-integration-tests/runtimetest/src/tests.rs
@@ -12,9 +12,12 @@ pub fn validate_readonly_paths(spec: &Spec) {
         }
     };
 
+    if ro_paths.is_empty() {
+        return;
+    }
+
     // TODO when https://github.com/rust-lang/rust/issues/86442 stabilizes,
     // change manual matching of i32 to e.kind() and match statement
-
     for path in ro_paths {
         if let std::io::Result::Err(e) = test_read_access(path) {
             let errno = Errno::from_i32(e.raw_os_error().unwrap());

--- a/tests/rust-integration-tests/runtimetest/src/tests.rs
+++ b/tests/rust-integration-tests/runtimetest/src/tests.rs
@@ -11,10 +11,7 @@ pub fn validate_readonly_paths(spec: &Spec) {
             return;
         }
     };
-    if ro_paths.is_empty() {
-        eprintln!("in readonly paths, expected some readonly paths to be set, found none");
-        return;
-    }
+
     // TODO when https://github.com/rust-lang/rust/issues/86442 stabilizes,
     // change manual matching of i32 to e.kind() and match statement
 


### PR DESCRIPTION
The test is ported from https://github.com/opencontainers/runtime-tools/blob/2802ff9ff5/validation/hostname/hostname.go

The intent is to make sure that the hostname set in the spec is actually set within the container.

Signed-off-by: chermehdi <mehdi.cheracher@gmail.com>

<a href="https://gitpod.io/#https://github.com/containers/youki/pull/1376"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

