### PR TITLE
Update makefile changes in containerd ci

### DIFF
--- a/.github/workflows/containerd_integration_tests.yaml
+++ b/.github/workflows/containerd_integration_tests.yaml
@@ -14,14 +14,14 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: '1.64.0'
+          toolchain: '1.65.0'
           override: true
       - name: Cache youki
         uses: Swatinem/rust-cache@v1
       - run: sudo apt-get -y update
       - run: sudo apt-get install -y pkg-config libsystemd-dev libdbus-glib-1-dev libelf-dev libseccomp-dev
       - name: Build youki
-        run: make release-build
+        run: make youki-release
       - name: Upload youki binary
         uses: actions/upload-artifact@v3
         with:


### PR DESCRIPTION
When #968 was merged, it  wasn't rebased from #1383 or vice-versa resulting in breaking the CI on main

<a href="https://gitpod.io/#https://github.com/containers/youki/pull/1386"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

