### PR TITLE
Check capabilities in youki info subcommand

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3277,6 +3277,7 @@ name = "youki"
 version = "0.0.3"
 dependencies = [
  "anyhow",
+ "caps",
  "chrono",
  "clap",
  "clap_complete",

--- a/crates/youki/Cargo.toml
+++ b/crates/youki/Cargo.toml
@@ -38,6 +38,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tabwriter = "1"
 clap_complete = "3.2.5"
+caps = "0.5.5"
 
 [dev-dependencies]
 serial_test = "0.9.0"

--- a/crates/youki/src/commands/info.rs
+++ b/crates/youki/src/commands/info.rs
@@ -4,7 +4,6 @@ use std::collections::HashSet;
 use std::{fs, path::Path};
 
 use anyhow::Result;
-use caps::Capability;
 use clap::Parser;
 use libcontainer::rootless;
 use procfs::{CpuInfo, Meminfo};

--- a/crates/youki/src/commands/info.rs
+++ b/crates/youki/src/commands/info.rs
@@ -224,17 +224,18 @@ pub fn print_namespaces() {
     }
 }
 
+#[inline]
+fn get_cap_supported(caps: &caps::CapsHashSet, cap: caps::Capability) -> &'static str {
+    if caps.contains(&cap) {
+        "available"
+    } else {
+        "unsupported"
+    }
+}
+
 pub fn print_capabilities() {
     println!("Capabilities");
     if let Ok(current) = caps::read(None, caps::CapSet::Bounding) {
-        fn get_cap_supported(caps: &caps::CapsHashSet, cap: caps::Capability) -> &'static str {
-            if caps.contains(&cap) {
-                "available"
-            } else {
-                "unsupported"
-            }
-        }
-
         println!(
             "{:<17} {}",
             "CAP_BPF",

--- a/crates/youki/src/commands/info.rs
+++ b/crates/youki/src/commands/info.rs
@@ -225,11 +225,11 @@ pub fn print_namespaces() {
 }
 
 #[inline]
-fn get_cap_supported(caps: &caps::CapsHashSet, cap: caps::Capability) -> &'static str {
+fn is_cap_available(caps: &caps::CapsHashSet, cap: caps::Capability) -> &'static str {
     if caps.contains(&cap) {
         "available"
     } else {
-        "unsupported"
+        "unavailable"
     }
 }
 
@@ -239,17 +239,17 @@ pub fn print_capabilities() {
         println!(
             "{:<17} {}",
             "CAP_BPF",
-            get_cap_supported(&current, caps::Capability::CAP_BPF)
+            is_cap_available(&current, caps::Capability::CAP_BPF)
         );
         println!(
             "{:<17} {}",
             "CAP_PERFMON",
-            get_cap_supported(&current, caps::Capability::CAP_PERFMON)
+            is_cap_available(&current, caps::Capability::CAP_PERFMON)
         );
         println!(
             "{:<17} {}",
             "CAP_CHECKPOINT_RESTORE",
-            get_cap_supported(&current, caps::Capability::CAP_CHECKPOINT_RESTORE)
+            is_cap_available(&current, caps::Capability::CAP_CHECKPOINT_RESTORE)
         );
     } else {
         println!("<cannot find cap info>");

--- a/crates/youki/src/commands/info.rs
+++ b/crates/youki/src/commands/info.rs
@@ -4,6 +4,7 @@ use std::collections::HashSet;
 use std::{fs, path::Path};
 
 use anyhow::Result;
+use caps::Capability;
 use clap::Parser;
 use libcontainer::rootless;
 use procfs::{CpuInfo, Meminfo};
@@ -21,6 +22,7 @@ pub fn info(_: Info) -> Result<()> {
     print_hardware();
     print_cgroups();
     print_namespaces();
+    print_capabilities();
 
     Ok(())
 }
@@ -220,6 +222,37 @@ pub fn print_namespaces() {
         // While the CONFIG_CGROUP_NS kernel feature exists, it is obsolete and should not be used. CGroup namespaces
         // are instead enabled with CONFIG_CGROUPS.
         print_feature_status(&content, "CONFIG_CGROUPS", FeatureDisplay::new("cgroup"))
+    }
+}
+
+pub fn print_capabilities() {
+    println!("Capabilities");
+    if let Ok(current) = caps::read(None, caps::CapSet::Bounding) {
+        fn get_cap_supported(caps: &caps::CapsHashSet, cap: caps::Capability) -> &'static str {
+            if caps.contains(&cap) {
+                "available"
+            } else {
+                "unsupported"
+            }
+        }
+
+        println!(
+            "{:<17} {}",
+            "CAP_BPF",
+            get_cap_supported(&current, caps::Capability::CAP_BPF)
+        );
+        println!(
+            "{:<17} {}",
+            "CAP_PERFMON",
+            get_cap_supported(&current, caps::Capability::CAP_PERFMON)
+        );
+        println!(
+            "{:<17} {}",
+            "CAP_CHECKPOINT_RESTORE",
+            get_cap_supported(&current, caps::Capability::CAP_CHECKPOINT_RESTORE)
+        );
+    } else {
+        println!("<cannot find cap info>");
     }
 }
 

--- a/tests/rust-integration-tests/integration_test/src/main.rs
+++ b/tests/rust-integration-tests/integration_test/src/main.rs
@@ -2,13 +2,13 @@ mod tests;
 mod utils;
 
 use crate::tests::hooks::get_hooks_tests;
+use crate::tests::hostname::get_hostname_test;
 use crate::tests::lifecycle::{ContainerCreate, ContainerLifecycle};
 use crate::tests::linux_ns_itype::get_ns_itype_tests;
 use crate::tests::pidfile::get_pidfile_test;
 use crate::tests::readonly_paths::get_ro_paths_test;
 use crate::tests::seccomp_notify::get_seccomp_notify_test;
 use crate::tests::tlb::get_tlb_test;
-use crate::tests::hostname::get_hostname_test;
 use crate::utils::support::{set_runtime_path, set_runtimetest_path};
 use anyhow::{Context, Result};
 use clap::Parser;

--- a/tests/rust-integration-tests/integration_test/src/tests/mod.rs
+++ b/tests/rust-integration-tests/integration_test/src/tests/mod.rs
@@ -1,9 +1,9 @@
 pub mod cgroups;
 pub mod hooks;
+pub mod hostname;
 pub mod lifecycle;
 pub mod linux_ns_itype;
 pub mod pidfile;
 pub mod readonly_paths;
 pub mod seccomp_notify;
 pub mod tlb;
-pub mod hostname;


### PR DESCRIPTION
Shows supported capabilities that started to be supported in recent kernel release.

At first I tried to call `caps::drop()` actually for each newly added caps, but it required privilege. So I just check these caps from default `CapSet::Bounding`.