### PR TITLE
Pin github action image

### DIFF
--- a/.github/workflows/benchmark_execution_time.yml
+++ b/.github/workflows/benchmark_execution_time.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   building-pr-branch:
     if: (github.event.issue.pull_request != null) && github.event.comment.body == '!github easy-benchmark'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     timeout-minutes: 15
 
     steps:
@@ -37,7 +37,7 @@ jobs:
 
   building-main-branch:
     if: (github.event.issue.pull_request != null) && github.event.comment.body == '!github easy-benchmark'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     timeout-minutes: 15
 
     steps:
@@ -72,7 +72,7 @@ jobs:
     needs:
       - building-pr-branch
       - building-main-branch
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     timeout-minutes: 15
 
     steps:

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   changes:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     timeout-minutes: 15
     outputs:
       dirs: ${{ steps.filter.outputs.changes }}
@@ -19,7 +19,7 @@ jobs:
   deploy:
     needs: [changes]
     if: ${{ !contains(needs.changes.outputs.dirs, '[]') }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     timeout-minutes: 15
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/integration_tests_validation.yaml
+++ b/.github/workflows/integration_tests_validation.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   changes:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     timeout-minutes: 15
     outputs:
       dirs: ${{ steps.filter.outputs.changes }}
@@ -22,7 +22,7 @@ jobs:
   validate:
     needs: [changes]
     if: ${{ !contains(needs.changes.outputs.dirs, '[]') }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     timeout-minutes: 15
     strategy:
       matrix:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   changes:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     timeout-minutes: 15
     outputs:
       dirs: ${{ steps.filter.outputs.changes }}
@@ -27,7 +27,7 @@ jobs:
   check:
     needs: [changes]
     if: ${{ !contains(needs.changes.outputs.dirs, '[]') }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     timeout-minutes: 15
     strategy:
       matrix:
@@ -51,7 +51,7 @@ jobs:
         working-directory: ${{matrix.dirs}}
         run: cargo clippy --all-targets --all-features -- -D warnings
   tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     timeout-minutes: 15
     strategy:
       matrix:
@@ -71,7 +71,7 @@ jobs:
           export LD_LIBRARY_PATH=$HOME/.wasmedge/lib
           cd ./crates && cargo test --all --all-features --no-fail-fast
   coverage:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     timeout-minutes: 15
     name: Run test coverage
     steps:
@@ -103,7 +103,7 @@ jobs:
         with:
           file: ./coverage.lcov
   integration_tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     timeout-minutes: 15
     strategy:
       matrix:

--- a/.github/workflows/podman_tests.yaml
+++ b/.github/workflows/podman_tests.yaml
@@ -4,7 +4,7 @@ on:
 
 jobs:
   podman-tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
       - run: sudo apt-get -y update

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   check:
     name: Check
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
         with:
@@ -27,7 +27,7 @@ jobs:
   upload:
     name: Upload
     needs: check
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
       - run: sudo apt-get -y update
@@ -54,7 +54,7 @@ jobs:
 
   release:
     name: Publish Release
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs:
       - upload
     outputs:
@@ -113,7 +113,7 @@ jobs:
   publish:
     name: Publish Packages
     needs: check
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     env:
       CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
     steps:


### PR DESCRIPTION
Github is rolling out Ubuntu 22.04 which is breaking our integration tests because 22.04 is using cgroup v2. Lets pin the version for now until we decide on how to handle this.