### PR TITLE
Added recursive mount attr test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2061,8 +2061,6 @@ name = "runtimetest"
 version = "0.0.1"
 dependencies = [
  "anyhow",
- "clap",
- "clap_derive 4.0.21",
  "nix",
  "oci-spec",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2060,6 +2060,9 @@ dependencies = [
 name = "runtimetest"
 version = "0.0.1"
 dependencies = [
+ "anyhow",
+ "clap",
+ "clap_derive 4.0.21",
  "nix",
  "oci-spec",
 ]

--- a/tests/rust-integration-tests/integration_test/src/main.rs
+++ b/tests/rust-integration-tests/integration_test/src/main.rs
@@ -5,6 +5,7 @@ use crate::tests::hooks::get_hooks_tests;
 use crate::tests::hostname::get_hostname_test;
 use crate::tests::lifecycle::{ContainerCreate, ContainerLifecycle};
 use crate::tests::linux_ns_itype::get_ns_itype_tests;
+use crate::tests::mounts_recursive::get_mounts_recursive_test;
 use crate::tests::pidfile::get_pidfile_test;
 use crate::tests::readonly_paths::get_ro_paths_test;
 use crate::tests::seccomp_notify::get_seccomp_notify_test;
@@ -90,6 +91,7 @@ fn main() -> Result<()> {
     let seccomp_notify = get_seccomp_notify_test();
     let ro_paths = get_ro_paths_test();
     let hostname = get_hostname_test();
+    let mounts_recursive = get_mounts_recursive_test();
 
     tm.add_test_group(Box::new(cl));
     tm.add_test_group(Box::new(cc));
@@ -106,6 +108,7 @@ fn main() -> Result<()> {
     tm.add_test_group(Box::new(seccomp_notify));
     tm.add_test_group(Box::new(ro_paths));
     tm.add_test_group(Box::new(hostname));
+    tm.add_test_group(Box::new(mounts_recursive));
 
     tm.add_cleanup(Box::new(cgroups::cleanup_v1));
     tm.add_cleanup(Box::new(cgroups::cleanup_v2));

--- a/tests/rust-integration-tests/integration_test/src/tests/hostname/mod.rs
+++ b/tests/rust-integration-tests/integration_test/src/tests/hostname/mod.rs
@@ -15,7 +15,7 @@ fn create_spec(hostname: &str) -> Spec {
         )
         .process(
             ProcessBuilder::default()
-                .args(vec!["runtimetest".to_string()])
+                .args(vec!["runtimetest".to_string(), "set_host_name".to_string()])
                 .build()
                 .expect("error in creating process config"),
         )

--- a/tests/rust-integration-tests/integration_test/src/tests/mod.rs
+++ b/tests/rust-integration-tests/integration_test/src/tests/mod.rs
@@ -3,6 +3,7 @@ pub mod hooks;
 pub mod hostname;
 pub mod lifecycle;
 pub mod linux_ns_itype;
+pub mod mounts_recursive;
 pub mod pidfile;
 pub mod readonly_paths;
 pub mod seccomp_notify;

--- a/tests/rust-integration-tests/integration_test/src/tests/mounts_recursive/mod.rs
+++ b/tests/rust-integration-tests/integration_test/src/tests/mounts_recursive/mod.rs
@@ -1,0 +1,74 @@
+use crate::utils::test_inside_container;
+use nix::mount::{mount, umount, MsFlags};
+use oci_spec::runtime::{get_default_mounts, Mount, ProcessBuilder, Spec, SpecBuilder};
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::str::FromStr;
+use test_framework::{Test, TestGroup, TestResult};
+
+fn get_spec(added_mounts: Vec<Mount>) -> Spec {
+    let mut mounts = get_default_mounts();
+    for mount in added_mounts {
+        mounts.push(mount);
+    }
+
+    SpecBuilder::default()
+        .mounts(mounts)
+        .process(
+            ProcessBuilder::default()
+                .args(vec![
+                    "runtimetest".to_string(),
+                    "mounts_recursive".to_string(),
+                ])
+                .build()
+                .unwrap(),
+        )
+        .build()
+        .unwrap()
+}
+
+fn setup_mount(mount_dir: &Path, sub_mount_dir: &Path) {
+    fs::create_dir(mount_dir).unwrap();
+    mount::<Path, Path, str, str>(None, mount_dir, Some("tmpfs"), MsFlags::empty(), None).unwrap();
+    fs::create_dir(sub_mount_dir).unwrap();
+    mount::<Path, Path, str, str>(None, sub_mount_dir, Some("tmpfs"), MsFlags::empty(), None)
+        .unwrap();
+}
+
+fn clean_mount(mount_dir: &Path, sub_mount_dir: &Path) {
+    umount(sub_mount_dir).unwrap();
+    umount(mount_dir).unwrap();
+    fs::remove_dir_all(mount_dir).unwrap();
+}
+
+fn check_recursive_readonly() -> TestResult {
+    let rro_test_base_dir = PathBuf::from_str("/tmp").unwrap();
+    let rro_dir_path = rro_test_base_dir.join("rro_dir");
+    let rro_subdir_path = rro_dir_path.join("rro_subdir");
+    let mount_dest_path = PathBuf::from_str("/mnt").unwrap();
+
+    let mount_options = vec!["rbind".to_string(), "rro".to_string()];
+    let mut mount_spec = Mount::default();
+    mount_spec
+        .set_destination(mount_dest_path.clone())
+        .set_typ(None)
+        .set_source(Some(rro_dir_path.clone()))
+        .set_options(Some(mount_options.clone()));
+    let spec = get_spec(vec![mount_spec]);
+
+    let result = test_inside_container(spec, &|_| {
+        setup_mount(&rro_dir_path, &rro_subdir_path);
+        Ok(())
+    });
+
+    clean_mount(&rro_dir_path, &rro_subdir_path);
+
+    result
+}
+
+pub fn get_mounts_recursive_test() -> TestGroup {
+    let rro_test = Test::new("rro_test", Box::new(check_recursive_readonly));
+    let mut tg = TestGroup::new("mounts_recursive");
+    tg.add(vec![Box::new(rro_test)]);
+    tg
+}

--- a/tests/rust-integration-tests/integration_test/src/tests/mounts_recursive/mod.rs
+++ b/tests/rust-integration-tests/integration_test/src/tests/mounts_recursive/mod.rs
@@ -1,7 +1,10 @@
 use crate::utils::test_inside_container;
 use nix::mount::{mount, umount, MsFlags};
-use oci_spec::runtime::{get_default_mounts, Mount, ProcessBuilder, Spec, SpecBuilder};
+use oci_spec::runtime::{
+    get_default_mounts, LinuxBuilder, Mount, ProcessBuilder, Spec, SpecBuilder,
+};
 use std::fs;
+use std::os::unix::prelude::PermissionsExt;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use test_framework::{Test, TestGroup, TestResult};
@@ -14,6 +17,13 @@ fn get_spec(added_mounts: Vec<Mount>) -> Spec {
 
     SpecBuilder::default()
         .mounts(mounts)
+        .linux(
+            // Need to reset the read-only paths
+            LinuxBuilder::default()
+                .readonly_paths(vec![])
+                .build()
+                .expect("error in building linux config"),
+        )
         .process(
             ProcessBuilder::default()
                 .args(vec![
@@ -66,9 +76,67 @@ fn check_recursive_readonly() -> TestResult {
     result
 }
 
+fn check_recursive_nosuid() -> TestResult {
+    let rnosuid_test_base_dir = PathBuf::from_str("/tmp").unwrap();
+    let rnosuid_dir_path = rnosuid_test_base_dir.join("rnosuid_dir");
+    let rnosuid_subdir_path = rnosuid_dir_path.join("rnosuid_subdir");
+    let mount_dest_path = PathBuf::from_str("/mnt").unwrap();
+
+    let mount_options = vec!["rbind".to_string(), "rnosuid".to_string()];
+    let mut mount_spec = Mount::default();
+    mount_spec
+        .set_destination(mount_dest_path.clone())
+        .set_typ(None)
+        .set_source(Some(rnosuid_dir_path.clone()))
+        .set_options(Some(mount_options.clone()));
+    let spec = get_spec(vec![mount_spec]);
+
+    let result = test_inside_container(spec, &|bundle_path| {
+        setup_mount(&rnosuid_dir_path, &rnosuid_subdir_path);
+
+        let executable_file_path = bundle_path.join("bin/yes");
+        let in_container_executable_file_path = rnosuid_dir_path.join("executable_file");
+        let in_container_executable_subdir_file_path = rnosuid_subdir_path.join("executable_file");
+
+        fs::copy(&executable_file_path, &in_container_executable_file_path)?;
+        fs::copy(
+            &executable_file_path,
+            &in_container_executable_subdir_file_path,
+        )?;
+
+        let in_container_executable_file = fs::File::open(&in_container_executable_file_path)?;
+        let in_container_executable_subdir_file =
+            fs::File::open(&in_container_executable_subdir_file_path)?;
+
+        let mut in_container_executable_file_perm =
+            in_container_executable_file.metadata()?.permissions();
+        let mut in_container_executable_subdir_file_perm = in_container_executable_subdir_file
+            .metadata()?
+            .permissions();
+
+        in_container_executable_file_perm
+            .set_mode(in_container_executable_file_perm.mode() + 0o4000);
+        in_container_executable_subdir_file_perm
+            .set_mode(in_container_executable_subdir_file_perm.mode() + 0o4000);
+
+        in_container_executable_file.set_permissions(in_container_executable_file_perm.clone())?;
+        in_container_executable_subdir_file
+            .set_permissions(in_container_executable_subdir_file_perm.clone())?;
+
+        Ok(())
+    });
+
+    clean_mount(&rnosuid_dir_path, &rnosuid_subdir_path);
+
+    result
+}
+
 pub fn get_mounts_recursive_test() -> TestGroup {
     let rro_test = Test::new("rro_test", Box::new(check_recursive_readonly));
+    let rnosuid_test = Test::new("rnosuid_test", Box::new(check_recursive_nosuid));
+
     let mut tg = TestGroup::new("mounts_recursive");
-    tg.add(vec![Box::new(rro_test)]);
+    tg.add(vec![Box::new(rro_test), Box::new(rnosuid_test)]);
+
     tg
 }

--- a/tests/rust-integration-tests/integration_test/src/tests/mounts_recursive/mod.rs
+++ b/tests/rust-integration-tests/integration_test/src/tests/mounts_recursive/mod.rs
@@ -1,18 +1,48 @@
 use crate::utils::test_inside_container;
 use nix::mount::{mount, umount, MsFlags};
+use nix::sys::stat::Mode;
+use nix::unistd::{chown, Uid};
 use oci_spec::runtime::{
-    get_default_mounts, LinuxBuilder, Mount, ProcessBuilder, Spec, SpecBuilder,
+    get_default_mounts, Capability, LinuxBuilder, LinuxCapabilitiesBuilder, Mount, ProcessBuilder,
+    Spec, SpecBuilder,
 };
+use std::collections::hash_set::HashSet;
 use std::fs;
 use std::os::unix::prelude::PermissionsExt;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use test_framework::{Test, TestGroup, TestResult};
 
-fn get_spec(added_mounts: Vec<Mount>) -> Spec {
+fn get_spec(added_mounts: Vec<Mount>, process_args: Vec<String>) -> Spec {
     let mut mounts = get_default_mounts();
     for mount in added_mounts {
         mounts.push(mount);
+    }
+
+    let caps = vec![
+        Capability::Chown,
+        Capability::DacOverride,
+        Capability::Fsetid,
+        Capability::Fowner,
+        Capability::Mknod,
+        Capability::NetRaw,
+        Capability::Setgid,
+        Capability::Setuid,
+        Capability::Setfcap,
+        Capability::Setpcap,
+        Capability::NetBindService,
+        Capability::SysChroot,
+        Capability::Kill,
+        Capability::AuditWrite,
+    ];
+    let mut cap_bounding = HashSet::new();
+    let mut cap_effective = HashSet::new();
+    let mut cap_permitted = HashSet::new();
+
+    for cap in caps {
+        cap_bounding.insert(cap);
+        cap_effective.insert(cap);
+        cap_permitted.insert(cap);
     }
 
     SpecBuilder::default()
@@ -26,10 +56,17 @@ fn get_spec(added_mounts: Vec<Mount>) -> Spec {
         )
         .process(
             ProcessBuilder::default()
-                .args(vec![
-                    "runtimetest".to_string(),
-                    "mounts_recursive".to_string(),
-                ])
+                .args(process_args)
+                .capabilities(
+                    LinuxCapabilitiesBuilder::default()
+                        .bounding(cap_bounding)
+                        .effective(cap_effective)
+                        .permitted(cap_permitted)
+                        .build()
+                        .unwrap(),
+                )
+                .rlimits(vec![])
+                .no_new_privileges(false)
                 .build()
                 .unwrap(),
         )
@@ -64,7 +101,10 @@ fn check_recursive_readonly() -> TestResult {
         .set_typ(None)
         .set_source(Some(rro_dir_path.clone()))
         .set_options(Some(mount_options.clone()));
-    let spec = get_spec(vec![mount_spec]);
+    let spec = get_spec(
+        vec![mount_spec],
+        vec!["runtimetest".to_string(), "mounts_recursive".to_string()],
+    );
 
     let result = test_inside_container(spec, &|_| {
         setup_mount(&rro_dir_path, &rro_subdir_path);
@@ -81,6 +121,7 @@ fn check_recursive_nosuid() -> TestResult {
     let rnosuid_dir_path = rnosuid_test_base_dir.join("rnosuid_dir");
     let rnosuid_subdir_path = rnosuid_dir_path.join("rnosuid_subdir");
     let mount_dest_path = PathBuf::from_str("/mnt").unwrap();
+    let executable_file_name = "whoami";
 
     let mount_options = vec!["rbind".to_string(), "rnosuid".to_string()];
     let mut mount_spec = Mount::default();
@@ -89,14 +130,29 @@ fn check_recursive_nosuid() -> TestResult {
         .set_typ(None)
         .set_source(Some(rnosuid_dir_path.clone()))
         .set_options(Some(mount_options.clone()));
-    let spec = get_spec(vec![mount_spec]);
+    let spec = get_spec(
+        vec![mount_spec],
+        vec![
+            "sh".to_string(),
+            "-c".to_string(),
+            format!(
+                "{}; {}",
+                mount_dest_path.join(executable_file_name).to_str().unwrap(),
+                mount_dest_path
+                    .join("rnosuid_subdir/whoami")
+                    .to_str()
+                    .unwrap()
+            ),
+        ],
+    );
 
     let result = test_inside_container(spec, &|bundle_path| {
         setup_mount(&rnosuid_dir_path, &rnosuid_subdir_path);
 
-        let executable_file_path = bundle_path.join("bin/yes");
-        let in_container_executable_file_path = rnosuid_dir_path.join("executable_file");
-        let in_container_executable_subdir_file_path = rnosuid_subdir_path.join("executable_file");
+        let executable_file_path = bundle_path.join("bin").join(executable_file_name);
+        let in_container_executable_file_path = rnosuid_dir_path.join(executable_file_name);
+        let in_container_executable_subdir_file_path =
+            rnosuid_subdir_path.join(executable_file_name);
 
         fs::copy(&executable_file_path, &in_container_executable_file_path)?;
         fs::copy(
@@ -114,10 +170,25 @@ fn check_recursive_nosuid() -> TestResult {
             .metadata()?
             .permissions();
 
+        // Change file user to nonexistent uid and set suid.
+        // if rnosuid is applied, whoami command is executed as root.
+        // but if not adapted, whoami command is executed as uid 1200 and make an error.
+        chown(
+            &in_container_executable_file_path,
+            Some(Uid::from_raw(1200)),
+            None,
+        )
+        .unwrap();
+        chown(
+            &in_container_executable_subdir_file_path,
+            Some(Uid::from_raw(1200)),
+            None,
+        )
+        .unwrap();
         in_container_executable_file_perm
-            .set_mode(in_container_executable_file_perm.mode() + 0o4000);
+            .set_mode(in_container_executable_file_perm.mode() | Mode::S_ISUID.bits());
         in_container_executable_subdir_file_perm
-            .set_mode(in_container_executable_subdir_file_perm.mode() + 0o4000);
+            .set_mode(in_container_executable_subdir_file_perm.mode() | Mode::S_ISUID.bits());
 
         in_container_executable_file.set_permissions(in_container_executable_file_perm.clone())?;
         in_container_executable_subdir_file

--- a/tests/rust-integration-tests/integration_test/src/tests/readonly_paths/readonly_paths_tests.rs
+++ b/tests/rust-integration-tests/integration_test/src/tests/readonly_paths/readonly_paths_tests.rs
@@ -16,7 +16,10 @@ fn get_spec(readonly_paths: Vec<String>) -> Spec {
         )
         .process(
             ProcessBuilder::default()
-                .args(vec!["runtimetest".to_string()])
+                .args(vec![
+                    "runtimetest".to_string(),
+                    "readonly_paths".to_string(),
+                ])
                 .build()
                 .unwrap(),
         )

--- a/tests/rust-integration-tests/runtimetest/Cargo.toml
+++ b/tests/rust-integration-tests/runtimetest/Cargo.toml
@@ -8,11 +8,3 @@ oci-spec = { version = "0.5.8", features = ["runtime"] }
 nix = "0.25.0"
 anyhow = "1.0"
 
-[dependencies.clap]
-version = "3.2.23"
-default-features = false
-features = ["std", "suggestions", "derive", "cargo"]
-
-[dependencies.clap_derive]
-version = "4.0.21"
-default-features = true

--- a/tests/rust-integration-tests/runtimetest/Cargo.toml
+++ b/tests/rust-integration-tests/runtimetest/Cargo.toml
@@ -6,3 +6,13 @@ edition = "2021"
 [dependencies]
 oci-spec = { version = "0.5.8", features = ["runtime"] }
 nix = "0.25.0"
+anyhow = "1.0"
+
+[dependencies.clap]
+version = "3.2.23"
+default-features = false
+features = ["std", "suggestions", "derive", "cargo"]
+
+[dependencies.clap_derive]
+version = "4.0.21"
+default-features = true

--- a/tests/rust-integration-tests/runtimetest/src/main.rs
+++ b/tests/rust-integration-tests/runtimetest/src/main.rs
@@ -1,28 +1,9 @@
 mod tests;
 mod utils;
 
-use clap::Parser;
 use oci_spec::runtime::Spec;
 use std::path::PathBuf;
-
-#[derive(Parser, Debug)]
-#[clap(version = "0.0.1", author = "youki team")]
-struct Opts {
-    #[clap(subcommand)]
-    command: SubCommand,
-}
-
-#[derive(Parser, Debug)]
-enum SubCommand {
-    #[clap(name = "readonly_paths")]
-    ReadonlyPaths,
-
-    #[clap(name = "set_host_name")]
-    SetHostName,
-
-    #[clap(name = "mounts_recursive")]
-    MountsRecursive,
-}
+use std::env;
 
 const SPEC_PATH: &str = "/config.json";
 
@@ -38,12 +19,17 @@ fn get_spec() -> Spec {
 }
 
 fn main() {
-    let opts: Opts = Opts::parse();
     let spec = get_spec();
-
-    match opts.command {
-        SubCommand::ReadonlyPaths => tests::validate_readonly_paths(&spec),
-        SubCommand::SetHostName => tests::validate_hostname(&spec),
-        SubCommand::MountsRecursive => tests::validate_mounts_recursive(&spec),
+    let args: Vec<String> = env::args().collect();
+    let execute_test = match args.get(1) {
+        Some(execute_test) => execute_test.to_string(),
+        None => return eprintln!("error due to execute test flag not found"),
     };
+    
+    match &*execute_test {
+        "readonly_paths" => tests::validate_readonly_paths(&spec),
+        "set_host_name" => tests::validate_hostname(&spec),
+        "mounts_recursive" => tests::validate_mounts_recursive(&spec),
+        _ => eprintln!("error due to unexpected execute test flag: {}", execute_test),
+    }
 }

--- a/tests/rust-integration-tests/runtimetest/src/main.rs
+++ b/tests/rust-integration-tests/runtimetest/src/main.rs
@@ -23,13 +23,13 @@ fn main() {
     let args: Vec<String> = env::args().collect();
     let execute_test = match args.get(1) {
         Some(execute_test) => execute_test.to_string(),
-        None => return eprintln!("error due to execute test flag not found"),
+        None => return eprintln!("error due to execute test name not found"),
     };
     
     match &*execute_test {
         "readonly_paths" => tests::validate_readonly_paths(&spec),
         "set_host_name" => tests::validate_hostname(&spec),
         "mounts_recursive" => tests::validate_mounts_recursive(&spec),
-        _ => eprintln!("error due to unexpected execute test flag: {}", execute_test),
+        _ => eprintln!("error due to unexpected execute test name: {}", execute_test),
     }
 }

--- a/tests/rust-integration-tests/runtimetest/src/main.rs
+++ b/tests/rust-integration-tests/runtimetest/src/main.rs
@@ -1,8 +1,28 @@
 mod tests;
 mod utils;
 
+use clap::Parser;
 use oci_spec::runtime::Spec;
 use std::path::PathBuf;
+
+#[derive(Parser, Debug)]
+#[clap(version = "0.0.1", author = "youki team")]
+struct Opts {
+    #[clap(subcommand)]
+    command: SubCommand,
+}
+
+#[derive(Parser, Debug)]
+enum SubCommand {
+    #[clap(name = "readonly_paths")]
+    ReadonlyPaths,
+
+    #[clap(name = "set_host_name")]
+    SetHostName,
+
+    #[clap(name = "mounts_recursive")]
+    MountsRecursive,
+}
 
 const SPEC_PATH: &str = "/config.json";
 
@@ -18,7 +38,12 @@ fn get_spec() -> Spec {
 }
 
 fn main() {
+    let opts: Opts = Opts::parse();
     let spec = get_spec();
-    tests::validate_readonly_paths(&spec);
-    tests::validate_hostname(&spec);
+
+    match opts.command {
+        SubCommand::ReadonlyPaths => tests::validate_readonly_paths(&spec),
+        SubCommand::SetHostName => tests::validate_hostname(&spec),
+        SubCommand::MountsRecursive => tests::validate_mounts_recursive(&spec),
+    };
 }

--- a/tests/rust-integration-tests/runtimetest/src/tests.rs
+++ b/tests/rust-integration-tests/runtimetest/src/tests.rs
@@ -122,7 +122,21 @@ pub fn validate_mounts_recursive(spec: &Spec) {
                                 eprintln!("error in testing rro recursive mounting : {}", e);
                             }
                         }
-                        "rrw" => { /*TODO..*/ }
+                        "rnoexec" => {
+                            if let Err(e) = do_test_mounts_recursive(
+                                mount.destination(),
+                                &|test_file_path| {
+                                    if utils::test_file_executable(test_file_path.to_str().unwrap())
+                                        .is_ok()
+                                    {
+                                        bail!("path {:?} expected to be not executable, found executable", test_file_path);
+                                    }
+                                    Ok(())
+                                },
+                            ) {
+                                eprintln!("error in testing rnoexec recursive mounting: {}", e);
+                            }
+                        }
                         _ => {}
                     }
                 }

--- a/tests/rust-integration-tests/runtimetest/src/tests.rs
+++ b/tests/rust-integration-tests/runtimetest/src/tests.rs
@@ -122,23 +122,7 @@ pub fn validate_mounts_recursive(spec: &Spec) {
                                 eprintln!("error in testing rro recursive mounting : {}", e);
                             }
                         }
-                        "rnosuid" => {
-                            if let Err(e) =
-                                do_test_mounts_recursive(mount.destination(), &|test_file_path| {
-                                    if utils::test_file_suid(test_file_path.to_str().unwrap())
-                                        .unwrap()
-                                    {
-                                        bail!(
-                                            "path {:?} expected to be nosuid, found suid",
-                                            test_file_path
-                                        );
-                                    }
-                                    Ok(())
-                                })
-                            {
-                                eprintln!("error in testing rnosuid recursive mounting : {}", e);
-                            }
-                        }
+                        "rrw" => { /*TODO..*/ }
                         _ => {}
                     }
                 }

--- a/tests/rust-integration-tests/runtimetest/src/utils.rs
+++ b/tests/rust-integration-tests/runtimetest/src/utils.rs
@@ -1,9 +1,7 @@
-use std::fs;
-use std::os::unix::prelude::PermissionsExt;
 use std::path::PathBuf;
+use std::process::Command;
 
 use nix::sys::stat::stat;
-use nix::sys::stat::Mode;
 use nix::sys::stat::SFlag;
 
 fn test_file_read_access(path: &str) -> Result<(), std::io::Error> {
@@ -78,5 +76,18 @@ pub fn test_write_access(path: &str) -> Result<(), std::io::Error> {
             "cannot test write access for {:?}, has mode {:x}",
             path, mode
         ),
+    ))
+}
+
+pub fn test_file_executable(path: &str) -> Result<(), std::io::Error> {
+    let fstat = stat(path)?;
+    let mode = fstat.st_mode;
+    if is_file_like(mode) {
+        Command::new(path).output()?;
+    }
+
+    Err(std::io::Error::new(
+        std::io::ErrorKind::Other,
+        format!("{:?} is directory, so cannot execute", path),
     ))
 }

--- a/tests/rust-integration-tests/runtimetest/src/utils.rs
+++ b/tests/rust-integration-tests/runtimetest/src/utils.rs
@@ -1,6 +1,9 @@
+use std::fs;
+use std::os::unix::prelude::PermissionsExt;
 use std::path::PathBuf;
 
 use nix::sys::stat::stat;
+use nix::sys::stat::Mode;
 use nix::sys::stat::SFlag;
 
 fn test_file_read_access(path: &str) -> Result<(), std::io::Error> {
@@ -76,4 +79,12 @@ pub fn test_write_access(path: &str) -> Result<(), std::io::Error> {
             path, mode
         ),
     ))
+}
+
+pub fn test_file_suid(path: &str) -> Result<bool, std::io::Error> {
+    let file = fs::File::open(path)?;
+    if (file.metadata()?.permissions().mode() & Mode::S_ISUID.bits()) == Mode::S_ISUID.bits() {
+        return Ok(true);
+    }
+    Ok(false)
 }

--- a/tests/rust-integration-tests/runtimetest/src/utils.rs
+++ b/tests/rust-integration-tests/runtimetest/src/utils.rs
@@ -80,11 +80,3 @@ pub fn test_write_access(path: &str) -> Result<(), std::io::Error> {
         ),
     ))
 }
-
-pub fn test_file_suid(path: &str) -> Result<bool, std::io::Error> {
-    let file = fs::File::open(path)?;
-    if (file.metadata()?.permissions().mode() & Mode::S_ISUID.bits()) == Mode::S_ISUID.bits() {
-        return Ok(true);
-    }
-    Ok(false)
-}


### PR DESCRIPTION
Added test of rro mount option that implemented in #1398.
`/tmp/` is used as the bind mount path used for testing.

Now, this PR implement rro option test only.
And if this test is correct, add other option test(rrw, rnosuid...).

- [x] rro
- [ ] rrw
- [x] rnosuid
- [ ] rsuid
- [ ] rnodev
- [ ] rdev
- [x] rnoexec
- [ ] rexec
- [ ] rnodiratime
- [ ] rdiratime
- [ ] rrelatime
- [ ] rnorelatime
- [ ] rnoatime
- [ ] ratime
- [ ] rstrictatime
- [ ] rnostrictatime
- [ ] rnosymfollow
- [ ] rsymfollow

Signed-off-by: higuruchi <fumiya2324@gmail.com>