### PR TITLE
Upgrade clap to v4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -345,41 +345,26 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.2.23"
+version = "4.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71655c45cb9845d3270c9d6df84ebe72b4dad3c2ba3f7023ad47c144e4e473a5"
+checksum = "a7db700bc935f9e43e88d00b0850dae18a63773cfbec6d8e070fccf7fef89a39"
 dependencies = [
- "atty",
  "bitflags",
- "clap_derive 3.2.18",
+ "clap_derive",
  "clap_lex",
- "indexmap",
+ "is-terminal",
  "once_cell",
  "strsim",
  "termcolor",
- "textwrap",
 ]
 
 [[package]]
 name = "clap_complete"
-version = "3.2.5"
+version = "4.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f7a2e0a962c45ce25afce14220bc24f9dade0a1787f185cecf96bfba7847cd8"
+checksum = "10861370d2ba66b0f5989f83ebf35db6421713fd92351790e7fdd6c36774c56b"
 dependencies = [
  "clap",
-]
-
-[[package]]
-name = "clap_derive"
-version = "3.2.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea0c8bce528c4be4da13ea6fead8965e95b6073585a2f05204bd8f4119f82a65"
-dependencies = [
- "heck",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -397,9 +382,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.2.4"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+checksum = "0d4198f73e42b4936b35b5bb248d81d2b595ecb170da0bac7655c54eedfa8da8"
 dependencies = [
  "os_str_bytes",
 ]
@@ -1358,15 +1343,6 @@ checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "hermit-abi"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
@@ -1453,7 +1429,7 @@ dependencies = [
  "anyhow",
  "chrono",
  "clap",
- "clap_derive 4.0.21",
+ "clap_derive",
  "flate2",
  "libcgroups",
  "libcontainer",
@@ -2015,7 +1991,7 @@ version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
 dependencies = [
- "hermit-abi 0.2.6",
+ "hermit-abi",
  "libc",
 ]
 
@@ -3000,12 +2976,6 @@ dependencies = [
  "anyhow",
  "crossbeam",
 ]
-
-[[package]]
-name = "textwrap"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
 
 [[package]]
 name = "thiserror"

--- a/crates/libcgroups/Cargo.toml
+++ b/crates/libcgroups/Cargo.toml
@@ -37,7 +37,7 @@ libc = { version = "0.2.138", optional = true }
 oci-spec = { version = "0.5.8", features = ["proptests", "runtime"] }
 quickcheck = "1"
 mockall = { version = "0.11.3", features = [] }
-clap = "3.2.23"
+clap = "4.0.32"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 env_logger = "0.10"

--- a/crates/liboci-cli/Cargo.toml
+++ b/crates/liboci-cli/Cargo.toml
@@ -11,6 +11,6 @@ edition = "2021"
 keywords = ["youki", "container", "oci"]
 
 [dependencies.clap]
-version = "3.2.23"
+version = "4.0.32"
 default-features = false
-features = ["std", "suggestions", "derive", "cargo"]
+features = ["std", "suggestions", "derive", "cargo", "help", "usage", "error-context"]

--- a/crates/liboci-cli/src/checkpoint.rs
+++ b/crates/liboci-cli/src/checkpoint.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 /// Checkpoint a running container
 #[derive(Parser, Debug)]
 pub struct Checkpoint {
-    #[clap(forbid_empty_values = true, required = true)]
+    #[clap(value_parser = clap::builder::NonEmptyStringValueParser::new(), required = true)]
     pub container_id: String,
     /// Allow external unix sockets
     #[clap(long)]

--- a/crates/liboci-cli/src/create.rs
+++ b/crates/liboci-cli/src/create.rs
@@ -19,6 +19,6 @@ pub struct Create {
     #[clap(long, default_value = "0")]
     pub preserve_fds: i32,
     /// name of the container instance to be started
-    #[clap(forbid_empty_values = true, required = true)]
+    #[clap(value_parser = clap::builder::NonEmptyStringValueParser::new(), required = true)]
     pub container_id: String,
 }

--- a/crates/liboci-cli/src/delete.rs
+++ b/crates/liboci-cli/src/delete.rs
@@ -3,7 +3,7 @@ use clap::Parser;
 /// Release any resources held by the container
 #[derive(Parser, Debug)]
 pub struct Delete {
-    #[clap(forbid_empty_values = true, required = true)]
+    #[clap(value_parser = clap::builder::NonEmptyStringValueParser::new(), required = true)]
     pub container_id: String,
     /// forces deletion of the container if it is still running (using SIGKILL)
     #[clap(short, long)]

--- a/crates/liboci-cli/src/events.rs
+++ b/crates/liboci-cli/src/events.rs
@@ -10,6 +10,6 @@ pub struct Events {
     #[clap(long)]
     pub stats: bool,
     /// Name of the container instance
-    #[clap(forbid_empty_values = true, required = true)]
+    #[clap(value_parser = clap::builder::NonEmptyStringValueParser::new(), required = true)]
     pub container_id: String,
 }

--- a/crates/liboci-cli/src/exec.rs
+++ b/crates/liboci-cli/src/exec.rs
@@ -18,7 +18,7 @@ pub struct Exec {
     /// The file to which the pid of the container process should be written to
     pub pid_file: Option<PathBuf>,
     /// Environment variables that should be set in the container
-    #[clap(short, long, parse(try_from_str = parse_key_val), number_of_values = 1)]
+    #[clap(short, long, value_parser = parse_key_val::<String, String>, number_of_values = 1)]
     pub env: Vec<(String, String)>,
     /// Prevent the process from gaining additional privileges
     #[clap(long)]
@@ -30,7 +30,7 @@ pub struct Exec {
     #[clap(short, long)]
     pub detach: bool,
     /// Identifier of the container
-    #[clap(forbid_empty_values = true, required = true)]
+    #[clap(value_parser = clap::builder::NonEmptyStringValueParser::new(), required = true)]
     pub container_id: String,
     /// Command that should be executed in the container
     #[clap(required = false)]

--- a/crates/liboci-cli/src/kill.rs
+++ b/crates/liboci-cli/src/kill.rs
@@ -3,7 +3,7 @@ use clap::Parser;
 /// Send the specified signal to the container
 #[derive(Parser, Debug)]
 pub struct Kill {
-    #[clap(forbid_empty_values = true, required = true)]
+    #[clap(value_parser = clap::builder::NonEmptyStringValueParser::new(), required = true)]
     pub container_id: String,
     pub signal: String,
     #[clap(short, long)]

--- a/crates/liboci-cli/src/pause.rs
+++ b/crates/liboci-cli/src/pause.rs
@@ -3,6 +3,6 @@ use clap::Parser;
 /// Suspend the processes within the container
 #[derive(Parser, Debug)]
 pub struct Pause {
-    #[clap(forbid_empty_values = true, required = true)]
+    #[clap(value_parser = clap::builder::NonEmptyStringValueParser::new(), required = true)]
     pub container_id: String,
 }

--- a/crates/liboci-cli/src/ps.rs
+++ b/crates/liboci-cli/src/ps.rs
@@ -6,7 +6,7 @@ pub struct Ps {
     /// format to display processes: table or json (default: "table")
     #[clap(short, long, default_value = "table")]
     pub format: String,
-    #[clap(forbid_empty_values = true, required = true)]
+    #[clap(value_parser = clap::builder::NonEmptyStringValueParser::new(), required = true)]
     pub container_id: String,
     /// options will be passed to the ps utility
     #[clap(last = true)]

--- a/crates/liboci-cli/src/resume.rs
+++ b/crates/liboci-cli/src/resume.rs
@@ -3,6 +3,6 @@ use clap::Parser;
 /// Resume the processes within the container
 #[derive(Parser, Debug)]
 pub struct Resume {
-    #[clap(forbid_empty_values = true, required = true)]
+    #[clap(value_parser = clap::builder::NonEmptyStringValueParser::new(), required = true)]
     pub container_id: String,
 }

--- a/crates/liboci-cli/src/run.rs
+++ b/crates/liboci-cli/src/run.rs
@@ -18,6 +18,6 @@ pub struct Run {
     #[clap(long, default_value = "0")]
     pub preserve_fds: i32,
     /// name of the container instance to be started
-    #[clap(forbid_empty_values = true, required = true)]
+    #[clap(value_parser = clap::builder::NonEmptyStringValueParser::new(), required = true)]
     pub container_id: String,
 }

--- a/crates/liboci-cli/src/start.rs
+++ b/crates/liboci-cli/src/start.rs
@@ -3,6 +3,6 @@ use clap::Parser;
 /// Start a previously created container
 #[derive(Parser, Debug)]
 pub struct Start {
-    #[clap(forbid_empty_values = true, required = true)]
+    #[clap(value_parser = clap::builder::NonEmptyStringValueParser::new(), required = true)]
     pub container_id: String,
 }

--- a/crates/liboci-cli/src/state.rs
+++ b/crates/liboci-cli/src/state.rs
@@ -3,6 +3,6 @@ use clap::Parser;
 /// Show the container state
 #[derive(Parser, Debug)]
 pub struct State {
-    #[clap(forbid_empty_values = true, required = true)]
+    #[clap(value_parser = clap::builder::NonEmptyStringValueParser::new(), required = true)]
     pub container_id: String,
 }

--- a/crates/liboci-cli/src/update.rs
+++ b/crates/liboci-cli/src/update.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 /// Update running container resource constraints
 #[derive(Parser, Debug)]
 pub struct Update {
-    #[clap(forbid_empty_values = true, required = true)]
+    #[clap(value_parser = clap::builder::NonEmptyStringValueParser::new(), required = true)]
     pub container_id: String,
 
     /// Read the new resource limits from the given json file. Use - to read from stdin.

--- a/crates/youki/Cargo.toml
+++ b/crates/youki/Cargo.toml
@@ -21,9 +21,9 @@ wasm-wasmedge = ["libcontainer/wasm-wasmedge"]
 wasm-wasmtime = ["libcontainer/wasm-wasmtime"]
 
 [dependencies.clap]
-version = "3.2.23"
+version = "4.0.32"
 default-features = false
-features = ["std", "suggestions", "derive", "cargo"]
+features = ["std", "suggestions", "derive", "cargo", "help", "usage", "error-context"]
 
 [dependencies]
 anyhow = "1.0.65"
@@ -40,7 +40,7 @@ procfs = "0.14.2"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tabwriter = "1"
-clap_complete = "3.2.5"
+clap_complete = "4.0.7"
 caps = "0.5.5"
 
 [dev-dependencies]

--- a/crates/youki/src/commands/completion.rs
+++ b/crates/youki/src/commands/completion.rs
@@ -7,7 +7,7 @@ use std::io;
 #[derive(Debug, Parser)]
 /// Generate scripts for shell completion
 pub struct Completion {
-    #[clap(long = "shell", short = 's', arg_enum)]
+    #[clap(long = "shell", short = 's', value_enum)]
     pub shell: Shell,
 }
 

--- a/crates/youki/src/main.rs
+++ b/crates/youki/src/main.rs
@@ -7,7 +7,7 @@ mod logger;
 use anyhow::bail;
 use anyhow::Context;
 use anyhow::Result;
-use clap::IntoApp;
+use clap::CommandFactory;
 use clap::{crate_version, Parser};
 use nix::libc;
 use std::fs;

--- a/tests/rust-integration-tests/integration_test/Cargo.toml
+++ b/tests/rust-integration-tests/integration_test/Cargo.toml
@@ -25,9 +25,9 @@ uuid = "1.2"
 which = "4.3.0"
 
 [dependencies.clap]
-version = "3.2.23"
+version = "4.0.32"
 default-features = false
-features = ["std", "suggestions", "derive", "cargo"]
+features = ["std", "suggestions", "derive", "cargo", "help", "usage", "error-context"]
 
 [dependencies.clap_derive]
 version = "4.0.21"

--- a/tests/rust-integration-tests/integration_test/src/main.rs
+++ b/tests/rust-integration-tests/integration_test/src/main.rs
@@ -47,7 +47,7 @@ struct Run {
     /// Selected tests to be run, format should be
     /// space separated groups, eg
     /// -t group1::test1,test3 group2 group3::test5
-    #[clap(short, long, multiple_values = true, value_delimiter = ' ')]
+    #[clap(short, long, num_args(1..), value_delimiter = ' ')]
     tests: Option<Vec<String>>,
 }
 


### PR DESCRIPTION
### Description

The major update of clap from v3 to v4 comes with code-breaking changes.

See #1236. 

### Proposed changes

Refactor youki's CLI _just enough_ to bring in clap v4 and allow dependabot to manage the dependency once more.
In order to upgrade clap, I had followed the migration guide:

https://github.com/clap-rs/clap/blob/master/CHANGELOG.md#400---2022-09-28

This upgrade does change the `--help` output a little bit. I assume this is the full list of changes, but I could be mistaken:

https://github.com/clap-rs/clap/issues/4132

As part of my testing, I ran `make test-all` and followed the user guide to build and run a container. Some tests are failing locally for me, but these same tests are failing for me on the main branch. I haven't yet determined if that is due to my local development environment (Fedora 36) or not.