### PR TITLE
Compile libcontainer with musl static build

### DIFF
--- a/crates/libcontainer/src/syscall/linux.rs
+++ b/crates/libcontainer/src/syscall/linux.rs
@@ -374,7 +374,7 @@ impl Syscall for LinuxSyscall {
             rlim_cur: rlimit.soft(),
             rlim_max: rlimit.hard(),
         };
-        let res = unsafe { libc::setrlimit(rlimit.typ() as u32, rlim) };
+	let res = unsafe { libc::setrlimit((rlimit.typ() as u32).try_into().unwrap(), rlim) };
         if let Err(e) = Errno::result(res).map(drop) {
             bail!("Failed to set {:?}. {:?}", rlimit.typ(), e)
         }


### PR DESCRIPTION
Hey @utam0k 🦀 😄 I love your beautiful work.

Can we please discuss #1462 and https://github.com/aurae-runtime/aurae/issues/251 in this pull request? 

This small patch will address the issue I am seeing when I compile with MUSL, however I use `.unwrap()` which is not the best practices. 

Do you have thoughts on implementation? Can I provide more detail on how to replicate this on your machine?

```bash 
git clone git@github.com:aurae-runtime/aurae.git
cd aurae
cargo install --target x86_64-unknown-linux-musl --path ./auraed
```

Arch Linux with 6.1.1 kernel on X86 architecture because I am basic.

```bash
uname -r
6.1.1-arch1-1

rustc --version
rustc 1.66.0 (69f9c33d7 2022-12-12)

cargo --version
cargo 1.66.0 (d65d197ad 2022-11-15)

musl-gcc --version
gcc (GCC) 12.2.0

musl-clang --version
clang version 14.0.6
Target: x86_64-pc-linux-gnu
```


There are other dependencies that `libcontainer` tries to depend on from the gnu collection. Primarily:

 - `libdbus`
 - `libseccomp`

Both of which prevent me from linking with musl. If possible I would like to work towards finding a way for `libcontainer` to build without gnu collection? Otherwise I might need to fork youki 😞 


Signed-off-by: Kris Nóva <kris@nivenly.com>