### PR TITLE
Introduce seccomp feature for libcontainer with musl

### DIFF
--- a/crates/libcontainer/Cargo.toml
+++ b/crates/libcontainer/Cargo.toml
@@ -14,9 +14,6 @@ keywords = ["youki", "container", "cgroups"]
 [features]
 default = ["systemd", "v2", "v1", "libseccomp"]
 libseccomp = ["dep:libseccomp"]
-wasm-wasmer = ["wasmer", "wasmer-wasi"]
-wasm-wasmedge = ["wasmedge-sdk/standalone"]
-wasm-wasmtime = ["wasmtime", "wasmtime-wasi"]
 systemd = ["libcgroups/systemd", "v2"]
 v2 = ["libcgroups/v2"]
 v1 = ["libcgroups/v1"]
@@ -45,11 +42,6 @@ serde_json = "1.0"
 syscalls = "0.6.8"
 rust-criu = "0.4.0"
 clone3 = "0.2.3"
-wasmer = { version = "2.2.0", optional = true }
-wasmer-wasi = { version = "2.3.0", optional = true }
-wasmedge-sdk = { version = "0.7.1", optional = true }
-wasmtime = {version = "4.0.0", optional = true }
-wasmtime-wasi = {version = "4.0.0", optional = true }
 
 [dev-dependencies]
 oci-spec = { version = "^0.6.0", features = ["proptests", "runtime"] }

--- a/crates/libcontainer/Cargo.toml
+++ b/crates/libcontainer/Cargo.toml
@@ -12,7 +12,11 @@ rust-version = "1.58.1"
 keywords = ["youki", "container", "cgroups"]
 
 [features]
-default = ["systemd", "v2", "v1"]
+default = ["systemd", "v2", "v1", "libseccomp"]
+libseccomp = ["dep:libseccomp"]
+wasm-wasmer = ["wasmer", "wasmer-wasi"]
+wasm-wasmedge = ["wasmedge-sdk/standalone"]
+wasm-wasmtime = ["wasmtime", "wasmtime-wasi"]
 systemd = ["libcgroups/systemd", "v2"]
 v2 = ["libcgroups/v2"]
 v1 = ["libcgroups/v1"]
@@ -35,12 +39,17 @@ oci-spec = { version = "^0.6.0", features = ["runtime"] }
 procfs = "0.15.1"
 prctl = "1.0.0"
 libcgroups = { version = "0.0.4", path = "../libcgroups", default-features = false }
-libseccomp = { version = "0.3.0" }
+libseccomp = { version = "0.3.0", optional=true }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 syscalls = "0.6.8"
 rust-criu = "0.4.0"
 clone3 = "0.2.3"
+wasmer = { version = "2.2.0", optional = true }
+wasmer-wasi = { version = "2.3.0", optional = true }
+wasmedge-sdk = { version = "0.7.1", optional = true }
+wasmtime = {version = "4.0.0", optional = true }
+wasmtime-wasi = {version = "4.0.0", optional = true }
 
 [dev-dependencies]
 oci-spec = { version = "^0.6.0", features = ["proptests", "runtime"] }

--- a/crates/libcontainer/README.md
+++ b/crates/libcontainer/README.md
@@ -1,1 +1,22 @@
 # libcontainer
+
+### Building with musl
+
+In order to build with musl you must first remove the libseccomp dependency as it will reference shared libraries (`libdbus` and `libseccomp`) which cannot be built with musl.
+
+Do this by using adding flags to Cargo. Use the `--no-default-features` flag followed by `-F` and whatever features you intend to build with such as `v2` as defined in Cargo.toml under features section.
+
+Next you will also need the `+nightly` flags when building with `rustup` and `cargo`.
+
+```bash 
+# Add rustup +nigthly musl to toolchain
+rustup +nightly target add $(uname -m)-unknown-linux-musl
+
+# Build rustup +nigthly stdlib with musl
+rustup +nightly toolchain install nightly-$(uname -m)-unknown-linux-musl
+
+# Build musl standard library
+cargo +nightly build -Zbuild-std --target $(uname -m)-unknown-linux-musl --no-default-features -F v2
+
+cargo +nightly build --target $(uname -m)-unknown-linux-musl --no-default-features -F v2
+```

--- a/crates/libcontainer/src/lib.rs
+++ b/crates/libcontainer/src/lib.rs
@@ -8,9 +8,11 @@ pub mod notify_socket;
 pub mod process;
 pub mod rootfs;
 pub mod rootless;
-pub mod seccomp;
 pub mod signal;
 pub mod syscall;
 pub mod tty;
 pub mod utils;
 pub mod workload;
+
+#[cfg(feature = "libseccomp")]
+pub mod seccomp;

--- a/crates/libcontainer/src/utils.rs
+++ b/crates/libcontainer/src/utils.rs
@@ -371,6 +371,7 @@ pub(crate) mod test_utils {
         message: String,
     }
 
+    #[allow(dead_code)]
     pub fn test_in_child_process<F: FnOnce() -> Result<()>>(cb: F) -> Result<()> {
         let (mut sender, mut receiver) = channel::channel::<TestResult>()?;
         match unsafe { nix::unistd::fork()? } {

--- a/scripts/features_test.sh
+++ b/scripts/features_test.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-
 set -eu
 
 # Build the different features individually
@@ -15,5 +14,19 @@ cargo test --no-default-features -F v2
 cargo test --no-default-features -F systemd
 cargo test --no-default-features -F v2 -F cgroupsv2_devices
 cargo test --no-default-features -F systemd -F cgroupsv2_devices
+
+# Build with musl: libcontainer
+cargo +nightly build \
+    -Zbuild-std \
+    --target $(uname -m)-unknown-linux-musl \
+    --package libcontainer \
+    --no-default-features -F v2
+
+# Test with musl: libcontainer
+cargo +nightly test \
+    -Zbuild-std \
+    --target $(uname -m)-unknown-linux-musl \
+    --package libcontainer \
+    --no-default-features -F v2
 
 exit 0


### PR DESCRIPTION
This is a better PR than https://github.com/containers/youki/pull/1472

This pull request introduces the following Cargo feature to libcontainer:

```toml
[features]
default = ["systemd", "v2", "v1", "libseccomp"]
libseccomp = ["dep:libseccomp"]
```

And turns on `libseccomp` dependency by default.

For situations such as building with musl we can remove libseccomp dependeny and log a `warn!()` during privileged operations where seccomp is not available.

We can address the seccomp dependency with musl libc in a follow up pull request, I do not believe that `warn!()` is secure, however that can be an additional feature.

Signed-off-by: Kris Nóva <kris@nivenly.com>