### PR TITLE
Add descriptors.json when creating checkpoint

### DIFF
--- a/tests/rust-integration-tests/integration_test/src/tests/lifecycle/checkpoint.rs
+++ b/tests/rust-integration-tests/integration_test/src/tests/lifecycle/checkpoint.rs
@@ -144,6 +144,13 @@ fn checkpoint(
         ));
     }
 
+    if !Path::new(&checkpoint_dir.join("descriptors.json")).exists() {
+        return TestResult::Failed(anyhow::anyhow!(
+            "resulting checkpoint does not seem to be complete. {:?}/descriptors.json is missing",
+            &checkpoint_dir,
+        ));
+    }
+
     let dump_log = match work_path {
         Some(wp) => Path::new(wp).join("dump.log"),
         _ => checkpoint_dir.join("dump.log"),


### PR DESCRIPTION
runc as well as crun create a file called descriptors.json in the checkpoint directory. descriptors.json contains a list of how the FDs 0, 1, 2 are connected before checkpointing:

$ cat descriptors.json # created by runc in this case ["/dev/null","pipe:[230688]","pipe:[230689]"]

With this information the FDs can be reconnected correctly during restore.

With this commit is it possible to do:

$ youki run container
$ youki checkpointt container
$ runc restore container

Now the checkpoint is in a format that can be handled by other container runtimes.