### PR TITLE
improving delete condition check

### DIFF
--- a/crates/libcontainer/src/container/container_delete.rs
+++ b/crates/libcontainer/src/container/container_delete.rs
@@ -1,4 +1,4 @@
-use super::{Container, ContainerStatus};
+use super::{Container};
 use crate::config::YoukiConfig;
 use crate::hooks;
 use anyhow::{bail, Context, Result};
@@ -27,9 +27,8 @@ impl Container {
     pub fn delete(&mut self, force: bool) -> Result<()> {
         self.refresh_status()
             .context("failed to refresh container status")?;
-        if self.can_kill() && force {
-            self.do_kill(signal::Signal::SIGKILL, true)?;
-            self.set_status(ContainerStatus::Stopped).save()?;
+        if self.can_kill() || force {
+            self.kill(signal::Signal::SIGKILL, false)?;
         }
         log::debug!("container status: {:?}", self.status());
         if self.can_delete() {

--- a/crates/libcontainer/src/container/container_delete.rs
+++ b/crates/libcontainer/src/container/container_delete.rs
@@ -1,4 +1,4 @@
-use super::{Container};
+use super::Container;
 use crate::config::YoukiConfig;
 use crate::hooks;
 use anyhow::{bail, Context, Result};


### PR DESCRIPTION
Hello maintiners.
When I was working on #1529, I met inconsist test result and did test step by step.
It's not for integration test but I got one tiny thing to keep synced with other low-level runtimes.
runc and crun seems to support to delete 'Created' status container without force option.
FYI,
- runc : https://github.com/opencontainers/runc/blob/main/delete.go#L76
- crun : https://github.com/containers/crun/blob/main/src/libcrun/container.c#L1584

Currently, for youki, it has to pass both conditions, status and force to be deleted.
So current process is like below.
```bash
./youki --root ./runtime create myid --bundle ./bundle #success
cannot ./youki --root ./runtime delete myid # cannot kill because 'myid could not be deleted because it was Created'
./youki --root ./runtime kill myid 9 # success
./youki --root ./runtime delete myid # success
```

I changed the condition checking part and kill 'all' parameter to 'false'.
Reasons I changed
1. It doesn't need freezing I think
2. It kills only 1 specified process
3. It fails (for example, deleting 12345 after creation)
```
[WARN crates/libcontainer/src/container/container_kill.rs:97] 2023-02-09T18:49:37.783291994+09:00 failed to freeze container 12345, error: failed to apply freezer
[DEBUG crates/libcgroups/src/common.rs:254] 2023-02-09T18:49:37.783314972+09:00 scan pids in folder: "/sys/fs/cgroup/:youki:12345"
[ERROR crates/youki/src/main.rs:138] 2023-02-09T18:49:37.783343118+09:00 error in executing command: failed to delete container 12345
```
