### PR TITLE
Make youki a cargo subcommand

### DIFF
--- a/crates/youki/Cargo.toml
+++ b/crates/youki/Cargo.toml
@@ -11,6 +11,14 @@ edition = "2021"
 build = "build.rs"
 keywords = ["youki", "container"]
 
+[[bin]]
+name = "youki"
+path = "src/main.rs"
+
+[[bin]]
+name = "cargo-youki"
+path = "src/main.rs"
+
 [features]
 systemd = ["libcgroups/systemd", "libcontainer/systemd", "v2"]
 v2 = ["libcgroups/v2", "libcontainer/v2"]

--- a/docs/src/user/basic_setup.md
+++ b/docs/src/user/basic_setup.md
@@ -43,7 +43,7 @@ $ sudo dnf install   \
 
 ### Getting the source
 
-Currently Youki can only be installed from the source code itself, so you will need to clone the Youki GitHub repository to get the source code for using it as a runtime. If you are using any crates of Youki as dependency you need to do this step, as Cargo will automatically clone the repository for you.
+To obtain the source code for Youki you will need to clone the Github repository. If you are using any crates of Youki as dependency you need to do this step, as Cargo will automatically clone the repository for you.
 
 To clone the repository, run
 
@@ -65,6 +65,9 @@ make youki-dev # or youki-release
 ```
 
 This will build the Youki binary, and put it at the root level of the cloned directory, that is in the youki/ .
+
+### Installing through Cargo
+Youki is published on [crates.io](https://crates.io/crates/youki) and can be installed using cargo, rust's package manager. To install this way run `cargo install youki` this will install youki as a subcommand of cargo, usually in the `~/.cargo/bin` directory, after this youki can be run through cargo ex:`cargo youki -h`, or if you add this directory to your path youki can be run directly ex:`PATH=$PATH:$HOME/.cargo/bin youki -h`. To update after a new youki version is released simply run `cargo install youki` again.
 
 ---
 


### PR DESCRIPTION
By adding the `[[bin]]` sections when a user runs `cargo install youki` both `youki` and `cargo-youki` will be installed into their cargo bin dir. This means a user can run `cargo youki` to execute youki. The bin section for `youki` was included so that if this dir is in a users path they can also simply run `youki`, and not need to run it via cargo.

This should be all that is necessary to Close #1562.

I believe this is all that is needed to make this work, but I'm not sure how to actually test it.