### PR TITLE
libcontainer: make device creation interfaces public

### DIFF
--- a/crates/libcontainer/src/rootfs/mod.rs
+++ b/crates/libcontainer/src/rootfs/mod.rs
@@ -5,7 +5,10 @@
 pub(crate) mod rootfs;
 pub use rootfs::RootFS;
 
-pub(super) mod device;
+pub mod device;
+pub use device::Device;
+
 pub(super) mod mount;
 pub(super) mod symlink;
-pub(super) mod utils;
+
+pub mod utils;


### PR DESCRIPTION
I'm investigating how to implement device file support to runwasi in this PR: https://github.com/containerd/runwasi/pull/68. In order to use libcontainer functions for device file creation, they would need to be public for use from other crates. I would be happy to hear feedback regarding whether or not this is the right way to approach this problem.

Another question has to do with the libcontainer test mocks. The libcontainer device creating functions, when compiled in test configuration, know how to mock system calls. Is there a way for exposing that to users outside of the crate too? Maybe having a different libcontainer feature selected in dev-dependencies?