### PR TITLE
[Do Not Merge]: Track runc missing options and commands

### DIFF
--- a/crates/liboci-cli/README.md
+++ b/crates/liboci-cli/README.md
@@ -16,6 +16,7 @@ Interface](https://github.com/opencontainers/runtime-tools/blob/master/docs/comm
 | checkpoint |            |                   | ✅   | ✅   |       |
 | events     | ✅         |                   | ✅   |      | ✅    |
 | exec       | ✅         |                   | ✅   | ✅   | ✅    |
+| features   | ✅         |                   | 🏴   |     |      |
 | list       | ✅         |                   | ✅   | ✅   | ✅    |
 | pause      | ✅         |                   | ✅   | ✅   | ✅    |
 | ps         | ✅         |                   | ✅   | ✅   | ✅    |
@@ -24,3 +25,6 @@ Interface](https://github.com/opencontainers/runtime-tools/blob/master/docs/comm
 | run        | ✅         |                   | ✅   | ✅   | ✅    |
 | spec       | ✅         |                   | ✅   | ✅   | ✅    |
 | update     |            |                   | ✅   | ✅   |       |
+
+🏴 The `features` subcommand is [implemented](https://github.com/opencontainers/runc/pull/3296)
+in `runc`, but not documented.

--- a/crates/liboci-cli/src/checkpoint.rs
+++ b/crates/liboci-cli/src/checkpoint.rs
@@ -2,29 +2,55 @@ use clap::Parser;
 use std::path::PathBuf;
 
 /// Checkpoint a running container
+/// Reference: https://github.com/opencontainers/runc/blob/main/man/runc-checkpoint.8.md
 #[derive(Parser, Debug)]
 pub struct Checkpoint {
-    #[clap(value_parser = clap::builder::NonEmptyStringValueParser::new(), required = true)]
-    pub container_id: String,
-    /// Allow external unix sockets
-    #[clap(long)]
-    pub ext_unix_sk: bool,
-    /// Allow file locks
-    #[clap(long)]
-    pub file_locks: bool,
     /// Path for saving criu image files
     #[clap(long, default_value = "checkpoint")]
     pub image_path: PathBuf,
-    /// Leave the process running after checkpointing
-    #[clap(long)]
-    pub leave_running: bool,
-    /// Allow shell jobs
-    #[clap(long)]
-    pub shell_job: bool,
-    /// Allow open tcp connections
-    #[clap(long)]
-    pub tcp_established: bool,
     /// Path for saving work files and logs
     #[clap(long)]
     pub work_path: Option<PathBuf>,
+    /// Path for previous criu image file in pre-dump
+    #[clap(long)]
+    pub parent_path: Option<PathBuf>,
+    /// Leave the process running after checkpointing
+    #[clap(long)]
+    pub leave_running: bool,
+    /// Allow open tcp connections
+    #[clap(long)]
+    pub tcp_established: bool,
+    /// Allow external unix sockets
+    #[clap(long)]
+    pub ext_unix_sk: bool,
+    /// Allow shell jobs
+    #[clap(long)]
+    pub shell_job: bool,
+    /// Use lazy migration mechanism
+    #[clap(long)]
+    pub lazy_pages: bool,
+    /// Pass a file descriptor fd to criu
+    #[clap(long)]
+    pub status_fd: Option<u32>, // TODO: Is u32 the right type?
+    /// Start a page server at the given URL
+    #[clap(long)]
+    pub page_server: Option<String>,
+    /// Allow file locks
+    #[clap(long)]
+    pub file_locks: bool,
+    /// Do a pre-dump
+    #[clap(long)]
+    pub pre_dump: bool,
+    /// Cgroups mode
+    #[clap(long)]
+    pub manage_cgroups_mode: Option<String>,
+    /// Checkpoint a namespace, but don't save its properties
+    #[clap(long)]
+    pub empty_ns: bool,
+    /// Enable auto-deduplication
+    #[clap(long)]
+    pub auto_dedup: bool,
+
+    #[clap(value_parser = clap::builder::NonEmptyStringValueParser::new(), required = true)]
+    pub container_id: String,
 }

--- a/crates/liboci-cli/src/create.rs
+++ b/crates/liboci-cli/src/create.rs
@@ -3,22 +3,30 @@ use clap::Parser;
 use std::path::PathBuf;
 
 /// Create a container
+/// Reference: https://github.com/opencontainers/runc/blob/main/man/runc-create.8.md
 #[derive(Parser, Debug)]
 pub struct Create {
-    /// File to write pid of the container created
-    // note that in the end, container is just another process
-    #[clap(short, long)]
-    pub pid_file: Option<PathBuf>,
-    /// path to the bundle directory, containing config.json and root filesystem
+    /// Path to the bundle directory, containing config.json and root filesystem
     #[clap(short, long, default_value = ".")]
     pub bundle: PathBuf,
     /// Unix socket (file) path , which will receive file descriptor of the writing end of the pseudoterminal
     #[clap(short, long)]
     pub console_socket: Option<PathBuf>,
+    /// File to write pid of the container created
+    // note that in the end, container is just another process
+    #[clap(short, long)]
+    pub pid_file: Option<PathBuf>,
+    /// Do not use pivot rool to jail process inside rootfs
+    #[clap(long)]
+    pub no_pivot: bool,
+    /// Do not create a new session keyring for the container.
+    #[clap(long)]
+    pub no_new_keyring: bool,
     /// Pass N additional file descriptors to the container (stdio + $LISTEN_FDS + N in total)
     #[clap(long, default_value = "0")]
     pub preserve_fds: i32,
-    /// name of the container instance to be started
+
+    /// Name of the container instance to be started
     #[clap(value_parser = clap::builder::NonEmptyStringValueParser::new(), required = true)]
     pub container_id: String,
 }

--- a/crates/liboci-cli/src/exec.rs
+++ b/crates/liboci-cli/src/exec.rs
@@ -4,6 +4,7 @@ use std::path::PathBuf;
 use clap::Parser;
 
 /// Execute a process within an existing container
+/// Reference: https://github.com/opencontainers/runc/blob/main/man/runc-exec.8.md
 #[derive(Parser, Debug)]
 pub struct Exec {
     /// Unix socket (file) path , which will receive file descriptor of the writing end of the pseudoterminal
@@ -20,6 +21,12 @@ pub struct Exec {
     /// Environment variables that should be set in the container
     #[clap(short, long, value_parser = parse_key_val::<String, String>, number_of_values = 1)]
     pub env: Vec<(String, String)>,
+    /// Run the command as a user
+    #[clap(short, long, value_parser = parse_colon_separated_pair::<u32, u32>)]
+    pub user: Option<(u32, Option<u32>)>,
+    /// Add additional group IDs. Can be specified multiple times
+    #[clap(long, short = 'g', number_of_values = 1)]
+    pub additional_gids: Vec<u32>,
     /// Prevent the process from gaining additional privileges
     #[clap(long)]
     pub no_new_privs: bool,
@@ -29,6 +36,24 @@ pub struct Exec {
     /// Detach from the container process
     #[clap(short, long)]
     pub detach: bool,
+    /// Set the asm process label for the process commonly used with selinux
+    #[clap(long)]
+    pub process_label: String,
+    /// Set the apparmor profile for the process
+    #[clap(long)]
+    pub apparmor: String,
+    /// Add a capability to teh bounding set for the process
+    #[clap(long, number_of_values = 1)]
+    pub cap: Vec<String>,
+    /// Pass N additional file descriptors to the containe
+    #[clap(long, default_value = "0")]
+    pub preserve_fds: i32,
+    /// Allow exec in a paused container
+    #[clap(long)]
+    pub ignore_paused: bool,
+    /// Execute a process in a sub-cgroup
+    #[clap(long)]
+    pub cgroup: Option<String>,
     /// Identifier of the container
     #[clap(value_parser = clap::builder::NonEmptyStringValueParser::new(), required = true)]
     pub container_id: String,
@@ -48,4 +73,20 @@ where
         .find('=')
         .ok_or_else(|| format!("invalid KEY=value: no `=` found in `{s}`"))?;
     Ok((s[..pos].parse()?, s[pos + 1..].parse()?))
+}
+
+fn parse_colon_separated_pair<T, U>(
+    s: &str,
+) -> Result<(T, Option<U>), Box<dyn Error + Send + Sync + 'static>>
+where
+    T: std::str::FromStr,
+    T::Err: Error + Send + Sync + 'static,
+    U: std::str::FromStr,
+    U::Err: Error + Send + Sync + 'static,
+{
+    if let Some(pos) = s.find(':') {
+        Ok((s[..pos].parse()?, Some(s[pos + 1..].parse()?)))
+    } else {
+        Ok((s.parse()?, None))
+    }
 }

--- a/crates/liboci-cli/src/features.rs
+++ b/crates/liboci-cli/src/features.rs
@@ -1,0 +1,7 @@
+use clap::Parser;
+
+/// Return the features list for a container
+/// This is not a documented subcommand of runc yet, but it was introduced by
+/// https://github.com/opencontainers/runc/pull/3296
+#[derive(Parser, Debug)]
+pub struct Features {}

--- a/crates/liboci-cli/src/lib.rs
+++ b/crates/liboci-cli/src/lib.rs
@@ -17,6 +17,7 @@ pub use {create::Create, delete::Delete, kill::Kill, start::Start, state::State}
 mod checkpoint;
 mod events;
 mod exec;
+mod features;
 mod list;
 mod pause;
 mod ps;
@@ -26,8 +27,8 @@ mod spec;
 mod update;
 
 pub use {
-    checkpoint::Checkpoint, events::Events, exec::Exec, list::List, pause::Pause, ps::Ps,
-    resume::Resume, run::Run, spec::Spec, update::Update,
+    checkpoint::Checkpoint, events::Events, exec::Exec, features::Features, list::List,
+    pause::Pause, ps::Ps, resume::Resume, run::Run, spec::Spec, update::Update,
 };
 
 // Subcommands parsed by liboci-cli, based on the [OCI
@@ -52,6 +53,7 @@ pub enum CommonCmd {
     Checkpointt(Checkpoint),
     Events(Events),
     Exec(Exec),
+    Features(Features),
     List(List),
     Pause(Pause),
     #[clap(allow_hyphen_values = true)]

--- a/crates/liboci-cli/src/list.rs
+++ b/crates/liboci-cli/src/list.rs
@@ -2,4 +2,12 @@ use clap::Parser;
 
 /// List created containers
 #[derive(Parser, Debug)]
-pub struct List {}
+pub struct List {
+    /// Specify the format (default or table)
+    #[clap(long, default_value = "table")]
+    pub format: String,
+
+    /// Only display container IDs
+    #[clap(long, short)]
+    pub quiet: bool,
+}

--- a/crates/liboci-cli/src/run.rs
+++ b/crates/liboci-cli/src/run.rs
@@ -4,19 +4,34 @@ use std::path::PathBuf;
 /// Create a container and immediately start it
 #[derive(Parser, Debug)]
 pub struct Run {
-    /// File to write pid of the container created
-    // note that in the end, container is just another process
-    #[clap(short, long)]
-    pub pid_file: Option<PathBuf>,
-    /// path to the bundle directory, containing config.json and root filesystem
+    /// Path to the bundle directory, containing config.json and root filesystem
     #[clap(short, long, default_value = ".")]
     pub bundle: PathBuf,
     /// Unix socket (file) path , which will receive file descriptor of the writing end of the pseudoterminal
     #[clap(short, long)]
     pub console_socket: Option<PathBuf>,
+    /// Detach from teh container process
+    #[clap(short, long)]
+    pub detach: bool,
+    /// File to write pid of the container created
+    // note that in the end, container is just another process
+    #[clap(short, long)]
+    pub pid_file: Option<PathBuf>,
+    /// Disable the use of the subreaper used to reap reparented processes
+    #[clap(long)]
+    pub no_subreaper: bool,
+    /// Do not use pivot root to jail process inside rootfs
+    #[clap(long)]
+    pub no_pivot: bool,
+    /// Do not create a new session keyring for the container. This will cause the container to inherit the calling processes session key.
+    #[clap(long)]
+    pub no_new_keyring: bool,
     /// Pass N additional file descriptors to the container (stdio + $LISTEN_FDS + N in total)
     #[clap(long, default_value = "0")]
     pub preserve_fds: i32,
+    // Keep container's state directory and cgroup
+    #[clap(long)]
+    pub keep: bool,
     /// name of the container instance to be started
     #[clap(value_parser = clap::builder::NonEmptyStringValueParser::new(), required = true)]
     pub container_id: String,

--- a/crates/liboci-cli/src/spec.rs
+++ b/crates/liboci-cli/src/spec.rs
@@ -1,8 +1,13 @@
 use clap::Parser;
+use std::path::PathBuf;
 
 /// Command generates a config.json
 #[derive(Parser, Debug)]
 pub struct Spec {
+    /// Set path to the root of the bundle directory
+    #[clap(long, short)]
+    pub bundle: Option<PathBuf>,
+
     /// Generate a configuration for a rootless container
     #[clap(long)]
     pub rootless: bool,

--- a/crates/liboci-cli/src/update.rs
+++ b/crates/liboci-cli/src/update.rs
@@ -4,15 +4,67 @@ use std::path::PathBuf;
 /// Update running container resource constraints
 #[derive(Parser, Debug)]
 pub struct Update {
-    #[clap(value_parser = clap::builder::NonEmptyStringValueParser::new(), required = true)]
-    pub container_id: String,
-
     /// Read the new resource limits from the given json file. Use - to read from stdin.
     /// If this option is used, all other options are ignored.
     #[clap(short, long)]
     pub resources: Option<PathBuf>,
 
+    /// Set a new I/O weight
+    #[clap(long)]
+    pub blkio_weight: Option<u64>,
+
+    /// Set CPU CFS period to be used for hardcapping (in microseconds)
+    #[clap(long)]
+    pub cpu_period: Option<u64>,
+
+    /// Set CPU usage limit within a given period (in microseconds)
+    #[clap(long)]
+    pub cpu_quota: Option<u64>,
+
+    /// Set CPU realtime period to be used for hardcapping (in microseconds)
+    #[clap(long)]
+    pub cpu_rt_period: Option<u64>,
+
+    /// Set CPU realtime hardcap limit (in microseconds)
+    #[clap(long)]
+    pub cpu_rt_runtime: Option<u64>,
+
+    /// Set CPU shares (relative weight vs. other containers)
+    #[clap(long)]
+    pub cpu_share: Option<u64>,
+
+    /// Set CPU(s) to use. The list can contain commas and ranges. For example: 0-3,7
+    #[clap(long)]
+    pub cpuset_cpus: Option<String>,
+
+    /// Set memory node(s) to use. The list format is the same as for --cpuset-cpus.
+    #[clap(long)]
+    pub cpuset_mems: Option<String>,
+
+    /// Set memory limit to num bytes.
+    #[clap(long)]
+    pub memory: Option<u64>,
+
+    /// Set memory reservation (or soft limit) to num bytes.
+    #[clap(long)]
+    pub memory_reservation: Option<u64>,
+
+    /// Set total memory + swap usage to num bytes. Use -1 to unset the limit (i.e. use unlimited swap).
+    #[clap(long)]
+    pub memory_swap: Option<i64>,
+
     /// Set the maximum number of processes allowed in the container
     #[clap(long)]
     pub pids_limit: Option<i64>,
+
+    /// Set the value for Intel RDT/CAT L3 cache schema.
+    #[clap(long)]
+    pub l3_cache_schema: Option<String>,
+
+    /// Set the Intel RDT/MBA memory bandwidth schema.
+    #[clap(long)]
+    pub mem_bw_schema: Option<String>,
+
+    #[clap(value_parser = clap::builder::NonEmptyStringValueParser::new(), required = true)]
+    pub container_id: String,
 }

--- a/crates/youki/src/commands/features.rs
+++ b/crates/youki/src/commands/features.rs
@@ -1,0 +1,8 @@
+//! Contains Functionality of `features` container command
+use anyhow::Result;
+use liboci_cli::Features;
+
+/// lists all existing containers
+pub fn features(_: Features) -> Result<()> {
+    Ok(())
+}

--- a/crates/youki/src/commands/mod.rs
+++ b/crates/youki/src/commands/mod.rs
@@ -13,6 +13,7 @@ pub mod create;
 pub mod delete;
 pub mod events;
 pub mod exec;
+pub mod features;
 pub mod info;
 pub mod kill;
 pub mod list;

--- a/crates/youki/src/main.rs
+++ b/crates/youki/src/main.rs
@@ -119,6 +119,7 @@ fn main() -> Result<()> {
                     std::process::exit(-1);
                 }
             },
+            CommonCmd::Features(features) => commands::features::features(features),
             CommonCmd::List(list) => commands::list::list(list, root_path),
             CommonCmd::Pause(pause) => commands::pause::pause(pause, root_path),
             CommonCmd::Ps(ps) => commands::ps::ps(ps, root_path),


### PR DESCRIPTION
DO NOT MERGE - FOR REFERENCE / CHERRY-PICKING ONLY

Add the missing command-line options and subcommands in `liboci-cli`, as documented for `runc`, including: 

* Missing options for [checkpoint](https://github.com/opencontainers/runc/blob/main/man/runc-checkpoint.8.md)
* Missing `no_pivot` option for [create](https://github.com/opencontainers/runc/blob/main/man/runc-create.8.md)
* Missing options for [exec](https://github.com/opencontainers/runc/blob/main/man/runc-exec.8.md)
* Missing options for [run](https://github.com/opencontainers/runc/blob/main/man/runc-run.8.md)
* Missing options for [update](https://github.com/opencontainers/runc/blob/main/man/runc-update.8.md)
* Missing options for [spec](https://github.com/opencontainers/runc/blob/main/man/runc-spec.8.md)

Also add the missing [undocumented `features` subcommand](https://github.com/opencontainers/runc/pull/3296) from `runc`

(This does not mean that they are necessarily implemented)

@adrianreber In case you need to sync the options for this command.

Context: The `ociplex` tool needs the additional options to be able to pass them down to some other runtime.