### PR TITLE
Fixed container init process not re-parent to youki main process

### DIFF
--- a/crates/libcontainer/src/container/builder_impl.rs
+++ b/crates/libcontainer/src/container/builder_impl.rs
@@ -128,8 +128,7 @@ impl<'a> ContainerBuilderImpl<'a> {
             detached: self.detached,
         };
 
-        let (intermediate, init_pid) =
-            process::container_main_process::container_main_process(&container_args)?;
+        let init_pid = process::container_main_process::container_main_process(&container_args)?;
 
         // if file to write the pid to is specified, write pid of the child
         if let Some(pid_file) = &self.pid_file {
@@ -146,7 +145,7 @@ impl<'a> ContainerBuilderImpl<'a> {
                 .context("Failed to save container state")?;
         }
 
-        Ok(intermediate)
+        Ok(init_pid)
     }
 
     fn cleanup_container(&self) -> Result<()> {

--- a/crates/libcontainer/src/container/init_builder.rs
+++ b/crates/libcontainer/src/container/init_builder.rs
@@ -90,10 +90,15 @@ impl<'a> InitContainerBuilder<'a> {
             notify_path,
             container: Some(container.clone()),
             preserve_fds: self.base.preserve_fds,
-            detached: false, // TODO this should be set properly based on how the command is given
+            // TODO: This should be set properly based on how the command is
+            // given. For now, set the detached to true because this is what
+            // `youki create` defaults to.
+            detached: true,
         };
 
-        builder_impl.create()?;
+        // TODO: Fix waiting on this pid (init process) when detached = false.
+        let _pid = builder_impl.create()?;
+
         container.refresh_state()?;
 
         Ok(container)

--- a/crates/youki/src/commands/run.rs
+++ b/crates/youki/src/commands/run.rs
@@ -6,6 +6,8 @@ use liboci_cli::Run;
 
 pub fn run(args: Run, root_path: PathBuf, systemd_cgroup: bool) -> Result<()> {
     let syscall = create_syscall();
+    // TODO: `youki run` should support passing in `detached` flags. Defaults to
+    // detached = true right now.
     let mut container = ContainerBuilder::new(args.container_id.clone(), syscall.as_ref())
         .with_pid_file(args.pid_file.as_ref())?
         .with_console_socket(args.console_socket.as_ref())


### PR DESCRIPTION
Fix #1601 

In this PR, I decided to clone `intermediate` process as child and then clone the container init process as sibling of the `intermediate` process and child of `youki main` process. In this way, when intermediate process exits, the container init process will not re-parent to pid 1 and become zombie. The caller of youki can decide to use subreaper flag to adopt the container init process when youki main process exits.

This method cleaner because youki main process is guaranteed to be the parent of both intermediate process and container init process at all time. There is no extra re-parenting.

This PR is only part of the fix. We do need to revisit the detached and foreground mode. Not everything is fixed, but this PR should maintain the old behavior on anything that it does not fix.