### PR TITLE
fix(libcontainer): Run test_is_executable with a more common file

### DIFF
--- a/crates/libcontainer/src/utils.rs
+++ b/crates/libcontainer/src/utils.rs
@@ -556,10 +556,12 @@ mod tests {
     #[test]
     fn test_is_executable() {
         let executable_path = PathBuf::from("/bin/sh");
-        let directory_path = PathBuf::from("/tmp");
-        // a file guaranteed to be on linux and not executable
-        let non_executable_path = PathBuf::from("/boot/initrd.img");
+        let directory_path =
+            create_temp_dir("test_is_executable").expect("create temp directory for test");
+        let non_executable_path = directory_path.join("non_executable_file");
         let non_existent_path = PathBuf::from("/some/non/existent/path");
+
+        File::create(non_executable_path.as_path()).unwrap();
 
         assert!(is_executable(&non_existent_path).is_err());
         assert!(is_executable(&executable_path).unwrap());


### PR DESCRIPTION
This test was failing on some popular Linux distros, like Fedora, because `/boot/initrd.img` doesn't exist. This change alters the test so that a more common file, `/etc/hosts`, is used.

After searching on the internet, there doesn't seem to be any one file that is always guaranteed to exist, other than the root filesystem path `/`. But `/etc/hosts` is very, very common, so I'm hopeful that this change means that the Youki build environment is more likely to build and pass its tests on more systems.

Relates to #1650.