### PR TITLE
[Trivial] Fix makefile targets to use PHONY

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,53 +2,71 @@ ROOT = $(shell git rev-parse --show-toplevel)
 
 # builds
 
+.PHONY:build
 build: youki-release
 
+.PHONY: youki
 youki: youki-dev # helper
 
+.PHONY: youki-dev
 youki-dev:
 	./scripts/build.sh -o $(ROOT) -c youki
 
+.PHONY: youki-release
 youki-release:
 	./scripts/build.sh -o $(ROOT) -r -c youki
 
+.PHONY: runtimetest
 runtimetest:
 	./scripts/build.sh -o $(ROOT) -r -c runtimetest
 
+.PHONY: rust-oci-tests-bin
 rust-oci-tests-bin:
 	./scripts/build.sh -o $(ROOT) -r -c integration-test
 
+.PHONY: all
 all: youki-release rust-oci-tests-bin runtimetest
 
 # Tests
+
+.PHONY: unittest
 unittest:
 	cd ./crates && LD_LIBRARY_PATH=${HOME}/.wasmedge/lib cargo test --all --all-targets --all-features
 
+.PHONY: featuretest
 featuretest:
 	./scripts/features_test.sh
 
+.PHONY: oci-tests
 oci-tests: youki-release
 	./scripts/oci_integration_tests.sh $(ROOT)
 
+.PHONY: rust-oci-tests
 rust-oci-tests: youki-release runtimetest rust-oci-tests-bin
 	./scripts/rust_integration_tests.sh $(ROOT)/youki
 
+.PHONY: validate-rust-oci-runc
 validate-rust-oci-runc: runtimetest rust-oci-tests-bin
 	./scripts/rust_integration_tests.sh runc
 
+.PHONY: containerd-test
 containerd-test: youki-dev
 	VAGRANT_VAGRANTFILE=Vagrantfile.containerd2youki vagrant up
 	VAGRANT_VAGRANTFILE=Vagrantfile.containerd2youki vagrant provision --provision-with test
 
+.PHONY: test-oci
 test-oci: oci-tests rust-oci-tests
 
+.PHONY: test-all
 test-all: unittest featuretest oci-tests containerd-test # currently not doing rust-oci here
 
 # Misc
 
+.PHONY: lint
 lint:
 	cargo fmt --all -- --check
 	cargo clippy --all-targets --all-features -- -D warnings
 
+.PHONY: clean
 clean:
 	./scripts/clean.sh $(ROOT)

--- a/crates/Makefile
+++ b/crates/Makefile
@@ -1,10 +1,11 @@
-.PHONY : debug release
-
+.PHONY: debug
 debug:
 	cargo build && cp ./target/debug/youki ./youki_bin
 
+.PHONY: release
 release:
 	cargo build --release && cp ./target/release/youki ./youki_bin
 
+.PHONY: clean
 clean:
 	rm ./youki_bin

--- a/tests/rust-integration-tests/Makefile
+++ b/tests/rust-integration-tests/Makefile
@@ -1,6 +1,3 @@
-.PHONY: runtimetest integration-test
-
-
 TGT = x86_64-unknown-linux-gnu
 FLAG = 
 ifeq ("$(FLAG)","--release")
@@ -9,14 +6,17 @@ else
 DIR = debug
 endif
 
-
+.PHONY: all
 all: runtimetest integration-test
 
+.PHONY: runtimetest
 runtimetest:
 	cd ./runtimetest && cargo build $(FLAG) && cp ./target/$(TGT)/$(DIR)/runtimetest ../runtimetest_bin
 
+.PHONY: integration-test
 integration-test:
 	cd ./integration_test && cargo build $(FLAG) && cp ./target/$(DIR)/integration_test ../integration_test_bin
 
+.PHONY: clean
 clean:
 	rm ./integration_test_bin && rm ./runtimetest_bin


### PR DESCRIPTION
Not all makefile target in Youki is using `.PHONY` target. We don't use any file targets, so fixing it properly for all makefile.

On a different note, there has been a lot of popularity in using `justfile` as command runner to invoke different command, especially for Rust projects. Since we use Makefile only as a command runner,  I want to bring `justfile` up to see if there is any interest. Note, Makefile is definitely good enough for us. The upside is that `justfile` is a little more ergonomic being used as a command runner. The downside is that we have to install `justfile` as part of the dependency, whereas Makefile is more readily available. Food for thought :)

Reference: https://github.com/casey/just