### PR TITLE
Fix stop container when prestart hook fails.

### DIFF
--- a/crates/libcontainer/src/container/container_start.rs
+++ b/crates/libcontainer/src/container/container_start.rs
@@ -54,7 +54,7 @@ impl Container {
                 .with_context(|| "failed to run pre start hooks");
             if ret.is_err() {
                 // In the case where prestart hook fails, the runtime must
-                // stop the container before generate an error on exits.
+                // stop the container before generating an error and exiting.
                 self.kill(signal::Signal::SIGKILL, true)?;
                 return ret;
             }


### PR DESCRIPTION
Fixes #498 

This is long overdue. This PR only aims to fix the pre-start hook case. I will review all the other hook case to match the lifecycle spec of the runtime spec.