### PR TITLE
Modify pointer type from i8 to c_char

### DIFF
--- a/crates/libcgroups/src/v2/devices/bpf.rs
+++ b/crates/libcgroups/src/v2/devices/bpf.rs
@@ -36,7 +36,7 @@ pub mod prog {
         let insns = insns as *const _ as *const bpf_insn;
         let opts = libbpf_sys::bpf_prog_load_opts {
             kern_version: 0,
-            log_buf: ptr::null_mut::<i8>(),
+            log_buf: ptr::null_mut::<::std::os::raw::c_char>(),
             log_size: 0,
             ..Default::default()
         };
@@ -44,8 +44,8 @@ pub mod prog {
         let prog_fd = unsafe {
             bpf_prog_load(
                 BPF_PROG_TYPE_CGROUP_DEVICE,
-                ptr::null::<i8>(),
-                license as *const _ as *const i8,
+                ptr::null::<::std::os::raw::c_char>(),
+                license as *const _ as *const ::std::os::raw::c_char,
                 insns,
                 insns_cnt as u64,
                 &opts,

--- a/crates/libcgroups/src/v2/devices/mocks.rs
+++ b/crates/libcgroups/src/v2/devices/mocks.rs
@@ -16,7 +16,7 @@ pub mod libc {
 pub mod libbpf_sys {
     pub fn bpf_prog_load(
         _type_: libbpf_sys::bpf_prog_type,
-        _name: *const i8,
+        _name: *const ::std::os::raw::c_char,
         _license: *const ::std::os::raw::c_char,
         _insns: *const libbpf_sys::bpf_insn,
         _insns_cnt: libbpf_sys::size_t,

--- a/tests/rust-integration-tests/integration_test/src/tests/mounts_recursive/mod.rs
+++ b/tests/rust-integration-tests/integration_test/src/tests/mounts_recursive/mod.rs
@@ -227,7 +227,12 @@ fn check_recursive_rsuid() -> TestResult {
         File::create(original_file_path.clone())?;
         // chmod +s /tmp/rsuid_dir/file && chmod +g /tmp/rsuid_dir/file
         let mode = libc::S_ISUID | libc::S_ISGID;
-        let result = unsafe { libc::chmod(original_file_path.as_ptr() as *const i8, mode) };
+        let result = unsafe {
+            libc::chmod(
+                original_file_path.as_ptr() as *const ::std::os::raw::c_char,
+                mode,
+            )
+        };
         if result == -1 {
             return Err(anyhow!(std::io::Error::last_os_error()));
         }
@@ -553,7 +558,12 @@ fn check_recursive_rnosymfollow() -> TestResult {
         let link_file_path = format!("{}/{}", rnosymfollow_dir_path.to_str().unwrap(), "link");
         println!("original file: {original_file_path:?},link file: {link_file_path:?}");
         let mode = libc::S_ISUID | libc::S_ISGID;
-        let result = unsafe { libc::chmod(original_file_path.as_ptr() as *const i8, mode) };
+        let result = unsafe {
+            libc::chmod(
+                original_file_path.as_ptr() as *const ::std::os::raw::c_char,
+                mode,
+            )
+        };
         if result == -1 {
             return Err(anyhow!(std::io::Error::last_os_error()));
         };


### PR DESCRIPTION
## [Environment Info]

```
root ➜ /workspaces/youki  $ uname -a
Linux 80f9ee1dbb2e 5.15.49-linuxkit  aarch64  GNU/Linux
```


## Description

When running the command: 

```
$ make unittest
```

I encountered the following error:

```
error[E0308]: mismatched types
  --> crates/libcgroups/src/v2/devices/bpf.rs:39:22
   |
39 |             log_buf: ptr::null_mut::<i8>(),
   |                      ^^^^^^^^^^^^^^^^^^^^^ expected `u8`, found `i8`
   |
   = note: expected raw pointer `*mut u8`
              found raw pointer `*mut i8`
```
I found a similar error in another repository, which can be found here: https://github.com/remacs/remacs/issues/1393#issuecomment-475803562

My understanding is that the pointer type on ARM and x86 is defined differently. Following the advice on the issue, I used the c_char type instead of i8.

I also noticed that while the issue uses libc::c_char, this repository uses ::std::os::raw::c_char in some other parts. After reading this thread: https://users.rust-lang.org/t/libc-c-char-vs-std-os-c-char/21198, I decided to use ::std::os::raw::*.

Therefore, I used ::std::os::raw::c_char in my modifications.


