### PR TITLE
Update version check in validate_spec to support 1.X.Y version. 

### DIFF
--- a/crates/libcontainer/src/container/init_builder.rs
+++ b/crates/libcontainer/src/container/init_builder.rs
@@ -132,9 +132,10 @@ impl<'a> InitContainerBuilder<'a> {
     }
 
     fn validate_spec(spec: &Spec) -> Result<()> {
-        if !spec.version().starts_with("1.0") {
+        let version = spec.version();
+        if !version.starts_with("1.") {
             bail!(
-                "runtime spec has incompatible version '{}'. Only 1.0.X is supported",
+                "runtime spec has incompatible version '{}'. Only 1.X.Y is supported",
                 spec.version()
             );
         }

--- a/tests/rust-integration-tests/integration_test/src/tests/cgroups/mod.rs
+++ b/tests/rust-integration-tests/integration_test/src/tests/cgroups/mod.rs
@@ -60,7 +60,6 @@ pub fn attach_controller(cgroup_root: &Path, cgroup_path: &Path, controller: &st
 
     let mut components = cgroup_path
         .components()
-        .into_iter()
         .filter(|c| c.ne(&RootDir))
         .peekable();
 

--- a/tests/rust-integration-tests/runtimetest/src/utils.rs
+++ b/tests/rust-integration-tests/runtimetest/src/utils.rs
@@ -442,8 +442,8 @@ pub fn test_mount_rsuid_option(path: &str) -> Result<(), std::io::Error> {
     if suid && sgid {
         return Ok(());
     }
-    return Err(std::io::Error::new(
+    Err(std::io::Error::new(
         std::io::ErrorKind::Other,
         format!("rsuid error {path:?}"),
-    ));
+    ))
 }


### PR DESCRIPTION
Previously, the validate_spec function only supported runtime spec versions that started with "1.0".
This commit updates the function to support all versions starting with "1." (e.g., 1.X.Y), making it compatible with a broader range of runtime spec versions.

https://github.com/containerd/runwasi/pull/78#issuecomment-1499597585