### PR TITLE
Refactor TestResult into proper rusty result type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2926,6 +2926,7 @@ version = "0.0.1"
 dependencies = [
  "anyhow",
  "crossbeam",
+ "thiserror",
 ]
 
 [[package]]

--- a/tests/rust-integration-tests/integration_test/src/tests/cgroups/blkio.rs
+++ b/tests/rust-integration-tests/integration_test/src/tests/cgroups/blkio.rs
@@ -480,7 +480,7 @@ fn validate_block_io(cgroup_name: &str, spec: &Spec) -> Result<()> {
     Ok(())
 }
 
-fn test_blkio(test_name: &str, rate: u64, empty: bool) -> TestResult {
+fn test_blkio(test_name: &str, rate: u64, empty: bool) -> TestResult<()> {
     // these "magic" numbers are taken from the original tests
     // https://github.com/opencontainers/runtime-tools/blob/1684d131456a6bc99b8e96aa4a99783f21e58d79/validation/linux_cgroups_blkio/linux_cgroups_blkio.go#L13-L20
     let weight: u16 = 500;
@@ -551,7 +551,7 @@ fn test_blkio(test_name: &str, rate: u64, empty: bool) -> TestResult {
     test_outside_container(spec.clone(), &|data| {
         test_result!(check_container_created(&data));
         test_result!(validate_block_io(test_name, &spec));
-        TestResult::Passed
+        Ok(())
     })
 }
 

--- a/tests/rust-integration-tests/integration_test/src/tests/cgroups/cpu/v1.rs
+++ b/tests/rust-integration-tests/integration_test/src/tests/cgroups/cpu/v1.rs
@@ -32,7 +32,7 @@ fn get_realtime_runtime() -> Option<i64> {
     None
 }
 
-fn test_cpu_cgroups() -> TestResult {
+fn test_cpu_cgroups() -> TestResult<()> {
     let cgroup_name = "test_cpu_cgroups";
     // Kernel counts 0 as a CPU, so on a system with 8 logical cores you will need `0-7` range set.
     let cpu_range = format!("0-{}", num_cpus::get().saturating_sub(1));
@@ -205,32 +205,30 @@ fn test_cpu_cgroups() -> TestResult {
 
     for case in cases.into_iter() {
         let spec = test_result!(create_spec(cgroup_name, case));
-        let test_result = test_outside_container(spec, &|data| {
+        test_outside_container(spec, &|data| {
             test_result!(check_container_created(&data));
 
-            TestResult::Passed
-        });
-
-        if let TestResult::Failed(_) = test_result {
-            return test_result;
-        }
+            Ok(())
+        })?;
     }
 
-    TestResult::Passed
+    Ok(())
 }
 
-fn test_empty_cpu() -> TestResult {
+fn test_empty_cpu() -> TestResult<()> {
     let cgroup_name = "test_empty_cpu";
     let spec = test_result!(create_empty_spec(cgroup_name));
 
     test_outside_container(spec, &|data| {
-        test_result!(check_container_created(&data));
-        TestResult::Passed
+        // test_result!(check_container_created(&data))?;
+        check_container_created(&data)?;
+
+        Ok(())
     })
 }
 
 // Tests if a cpu idle value can be set
-fn test_cpu_idle_set() -> TestResult {
+fn test_cpu_idle_set() -> TestResult<()> {
     let idle: i64 = 1;
     let realtime_period = get_realtime_period();
     let realtime_runtime = get_realtime_runtime();
@@ -251,12 +249,13 @@ fn test_cpu_idle_set() -> TestResult {
     let spec = test_result!(create_spec(cgroup_name, cpu));
     test_outside_container(spec, &|data| {
         test_result!(check_container_created(&data));
-        TestResult::Passed
+
+        Ok(())
     })
 }
 
 /// Tests default idle value
-fn test_cpu_idle_default() -> TestResult {
+fn test_cpu_idle_default() -> TestResult<()> {
     let realtime_period = get_realtime_period();
     let realtime_runtime = get_realtime_runtime();
 
@@ -275,7 +274,8 @@ fn test_cpu_idle_default() -> TestResult {
     let spec = test_result!(create_spec(cgroup_name, cpu));
     test_outside_container(spec, &|data| {
         test_result!(check_container_created(&data));
-        TestResult::Passed
+
+        Ok(())
     })
 }
 

--- a/tests/rust-integration-tests/integration_test/src/tests/cgroups/cpu/v2.rs
+++ b/tests/rust-integration-tests/integration_test/src/tests/cgroups/cpu/v2.rs
@@ -35,7 +35,7 @@ const CGROUP_CPU_IDLE: &str = "cpu.idle";
 // that it should be unchanged.
 
 /// Tests if a cpu idle value is successfully set
-fn test_cpu_idle_set() -> TestResult {
+fn test_cpu_idle_set() -> TestResult<()> {
     let idle: i64 = 1;
     let cpu = test_result!(LinuxCpuBuilder::default()
         .idle(idle)
@@ -46,12 +46,12 @@ fn test_cpu_idle_set() -> TestResult {
     test_outside_container(spec, &|data| {
         test_result!(check_container_created(&data));
         test_result!(check_cpu_idle("test_cpu_idle_set", idle));
-        TestResult::Passed
+        Ok(())
     })
 }
 
 /// Tests default idle value is correct
-fn test_cpu_idle_default() -> TestResult {
+fn test_cpu_idle_default() -> TestResult<()> {
     let default_idle = 0;
     let cpu = test_result!(LinuxCpuBuilder::default().build().context("build cpu spec"));
 
@@ -59,12 +59,12 @@ fn test_cpu_idle_default() -> TestResult {
     test_outside_container(spec, &|data| {
         test_result!(check_container_created(&data));
         test_result!(check_cpu_idle("test_cpu_idle_default", default_idle));
-        TestResult::Passed
+        Ok(())
     })
 }
 
 /// Tests if a cpu weight that is in the valid range [1, 10000] is successfully set
-fn test_cpu_weight_valid_set() -> TestResult {
+fn test_cpu_weight_valid_set() -> TestResult<()> {
     let cpu_weight = 22_000u64;
     let converted_cpu_weight = 840u64;
     let cpu = test_result!(LinuxCpuBuilder::default()
@@ -79,12 +79,12 @@ fn test_cpu_weight_valid_set() -> TestResult {
             "test_cpu_weight_valid_set",
             converted_cpu_weight
         ));
-        TestResult::Passed
+        Ok(())
     })
 }
 
 /// Tests if a cpu weight of zero is ignored
-fn test_cpu_weight_zero_ignored() -> TestResult {
+fn test_cpu_weight_zero_ignored() -> TestResult<()> {
     let cpu_weight = 0u64;
     let default_cpu_weight = 100;
     let cpu = test_result!(LinuxCpuBuilder::default()
@@ -99,12 +99,13 @@ fn test_cpu_weight_zero_ignored() -> TestResult {
             "test_cpu_weight_zero_ignored",
             default_cpu_weight
         ));
-        TestResult::Passed
+
+        Ok(())
     })
 }
 
 /// Tests if a cpu weight that is too high (over 10000 after conversion) is set to the maximum value
-fn test_cpu_weight_too_high_maximum_set() -> TestResult {
+fn test_cpu_weight_too_high_maximum_set() -> TestResult<()> {
     let cpu_weight = 500_000u64;
     let converted_cpu_weight = 10_000;
     let cpu = test_result!(LinuxCpuBuilder::default()
@@ -119,12 +120,12 @@ fn test_cpu_weight_too_high_maximum_set() -> TestResult {
             "test_cpu_weight_too_high_maximum_set",
             converted_cpu_weight
         ));
-        TestResult::Passed
+        Ok(())
     })
 }
 
 /// Tests if a valid cpu quota (x > 0) is set successfully
-fn test_cpu_quota_valid_set() -> TestResult {
+fn test_cpu_quota_valid_set() -> TestResult<()> {
     let cpu_quota = 250_000;
     let cpu = test_result!(LinuxCpuBuilder::default()
         .quota(cpu_quota)
@@ -139,12 +140,12 @@ fn test_cpu_quota_valid_set() -> TestResult {
             cpu_quota,
             DEFAULT_PERIOD
         ));
-        TestResult::Passed
+        Ok(())
     })
 }
 
 /// Tests if the cpu quota is the defalt value (max) if a cpu quota of zero has been specified
-fn test_cpu_quota_zero_default_set() -> TestResult {
+fn test_cpu_quota_zero_default_set() -> TestResult<()> {
     let cpu_quota = 0;
     let cpu = test_result!(LinuxCpuBuilder::default()
         .quota(cpu_quota)
@@ -159,12 +160,12 @@ fn test_cpu_quota_zero_default_set() -> TestResult {
             i64::MAX,
             DEFAULT_PERIOD
         ));
-        TestResult::Passed
+        Ok(())
     })
 }
 
 /// Tests if the cpu quota is the default value (max) if a negative cpu quota has been specified
-fn test_cpu_quota_negative_default_set() -> TestResult {
+fn test_cpu_quota_negative_default_set() -> TestResult<()> {
     let cpu_quota = -9999;
     let cpu = test_result!(LinuxCpuBuilder::default()
         .quota(cpu_quota)
@@ -182,13 +183,13 @@ fn test_cpu_quota_negative_default_set() -> TestResult {
             i64::MAX,
             DEFAULT_PERIOD
         ));
-        TestResult::Passed
+        Ok(())
     })
 }
 
 /// Tests if a valid cpu period (x > 0) is set successfully. Cpu quota needs to
 /// remain unchanged
-fn test_cpu_period_valid_set() -> TestResult {
+fn test_cpu_period_valid_set() -> TestResult<()> {
     let quota = 250_000;
     let expected_period = 250_000;
     let cpu = test_result!(LinuxCpuBuilder::default()
@@ -210,13 +211,13 @@ fn test_cpu_period_valid_set() -> TestResult {
             quota,
             expected_period
         ));
-        TestResult::Passed
+        Ok(())
     })
 }
 
 /// Tests if the cpu period is unchanged if the cpu period is unspecified. Cpu quota needs
 /// to be unchanged as well
-fn test_cpu_quota_period_unspecified_unchanged() -> TestResult {
+fn test_cpu_quota_period_unspecified_unchanged() -> TestResult<()> {
     let quota = 250_000;
     let expected_period = 250_000;
     let cpu = test_result!(LinuxCpuBuilder::default().build().context("build cpu spec"));
@@ -235,11 +236,11 @@ fn test_cpu_quota_period_unspecified_unchanged() -> TestResult {
             quota,
             expected_period
         ));
-        TestResult::Passed
+        Ok(())
     })
 }
 
-fn test_cpu_period_and_quota_valid_set() -> TestResult {
+fn test_cpu_period_and_quota_valid_set() -> TestResult<()> {
     let expected_quota = 250_000;
     let expected_period = 250_000;
     let cpu = test_result!(LinuxCpuBuilder::default()
@@ -257,7 +258,7 @@ fn test_cpu_period_and_quota_valid_set() -> TestResult {
             expected_quota,
             expected_period
         ));
-        TestResult::Passed
+        Ok(())
     })
 }
 

--- a/tests/rust-integration-tests/integration_test/src/tests/cgroups/memory.rs
+++ b/tests/rust-integration-tests/integration_test/src/tests/cgroups/memory.rs
@@ -37,7 +37,7 @@ fn create_spec(cgroup_name: &str, limit: i64, swappiness: u64) -> Result<Spec> {
     Ok(spec)
 }
 
-fn test_memory_cgroups() -> TestResult {
+fn test_memory_cgroups() -> TestResult<()> {
     let cgroup_name = "test_memory_cgroups";
 
     let cases = vec![
@@ -50,17 +50,14 @@ fn test_memory_cgroups() -> TestResult {
     ];
 
     for spec in cases.into_iter() {
-        let test_result = test_outside_container(spec, &|data| {
+        test_outside_container(spec, &|data| {
             test_result!(check_container_created(&data));
 
-            TestResult::Passed
-        });
-        if let TestResult::Failed(_) = test_result {
-            return test_result;
-        }
+            Ok(())
+        })?;
     }
 
-    TestResult::Passed
+    Ok(())
 }
 
 fn can_run() -> bool {

--- a/tests/rust-integration-tests/integration_test/src/tests/cgroups/network.rs
+++ b/tests/rust-integration-tests/integration_test/src/tests/cgroups/network.rs
@@ -70,7 +70,7 @@ fn get_network_interfaces() -> Option<(String, String)> {
     Some((lo_if_name.to_string(), eth_if_name.to_string()))
 }
 
-fn test_network_cgroups() -> TestResult {
+fn test_network_cgroups() -> TestResult<()> {
     let cgroup_name = "test_network_cgroups";
 
     let interfaces = test_result!(get_network_interfaces()
@@ -115,17 +115,14 @@ fn test_network_cgroups() -> TestResult {
     ];
 
     for spec in cases.into_iter() {
-        let test_result = test_outside_container(spec, &|data| {
+        test_outside_container(spec, &|data| {
             test_result!(check_container_created(&data));
 
-            TestResult::Passed
-        });
-        if let TestResult::Failed(_) = test_result {
-            return test_result;
-        }
+            Ok(())
+        })?;
     }
 
-    TestResult::Passed
+    Ok(())
 }
 
 fn can_run() -> bool {

--- a/tests/rust-integration-tests/integration_test/src/tests/cgroups/pids.rs
+++ b/tests/rust-integration-tests/integration_test/src/tests/cgroups/pids.rs
@@ -41,7 +41,7 @@ fn create_spec(cgroup_name: &str, limit: i64) -> Result<Spec> {
 }
 
 // Tests if a specified limit was successfully set
-fn test_positive_limit() -> TestResult {
+fn test_positive_limit() -> TestResult<()>{
     let cgroup_name = "test_positive_limit";
     let limit = 50;
     let spec = test_result!(create_spec(cgroup_name, limit));
@@ -49,12 +49,12 @@ fn test_positive_limit() -> TestResult {
     test_outside_container(spec, &|data| {
         test_result!(check_container_created(&data));
         test_result!(check_pid_limit_set(cgroup_name, limit));
-        TestResult::Passed
+        Ok(())
     })
 }
 
 // Tests if a specified limit of zero sets the pid limit to unlimited
-fn test_zero_limit() -> TestResult {
+fn test_zero_limit() -> TestResult<()>{
     let cgroup_name = "test_zero_limit";
     let limit = 0;
     let spec = test_result!(create_spec(cgroup_name, limit));
@@ -62,12 +62,12 @@ fn test_zero_limit() -> TestResult {
     test_outside_container(spec, &|data| {
         test_result!(check_container_created(&data));
         test_result!(check_pids_are_unlimited(cgroup_name));
-        TestResult::Passed
+        Ok(())
     })
 }
 
 // Tests if a specified negative limit sets the pid limit to unlimited
-fn test_negative_limit() -> TestResult {
+fn test_negative_limit() -> TestResult<()>{
     let cgroup_name = "test_negative_limit";
     let limit = -1;
     let spec = test_result!(create_spec(cgroup_name, limit));
@@ -75,7 +75,7 @@ fn test_negative_limit() -> TestResult {
     test_outside_container(spec, &|data| {
         test_result!(check_container_created(&data));
         test_result!(check_pids_are_unlimited(cgroup_name));
-        TestResult::Passed
+        Ok(())
     })
 }
 

--- a/tests/rust-integration-tests/integration_test/src/tests/hooks/invoke.rs
+++ b/tests/rust-integration-tests/integration_test/src/tests/hooks/invoke.rs
@@ -1,7 +1,7 @@
 use anyhow::anyhow;
 use oci_spec::runtime::{Hook, HookBuilder, HooksBuilder, ProcessBuilder, Spec, SpecBuilder};
 use std::{fs::File, io::Read};
-use test_framework::{Test, TestGroup, TestResult};
+use test_framework::{Test, TestGroup, testable::TestError};
 
 use crate::utils::{
     create_container, delete_container, generate_uuid, prepare_bundle, set_config,
@@ -84,11 +84,11 @@ fn get_test(test_name: &'static str) -> Test {
             };
             delete_hook_output_file();
             if log != "pre-start1 called\npre-start2 called\npost-start1 called\npost-start2 called\npost-stop1 called\npost-stop2 called\n" {
-                return TestResult::Failed(anyhow!(
+                return Err(TestError::Failed(anyhow!(
                         "error : hooks must be called in the listed order, {log:?}"
-                        ));
+                        )));
             }
-            TestResult::Passed
+            Ok(())
         }),
     )
 }

--- a/tests/rust-integration-tests/integration_test/src/tests/hostname/mod.rs
+++ b/tests/rust-integration-tests/integration_test/src/tests/hostname/mod.rs
@@ -23,7 +23,7 @@ fn create_spec(hostname: &str) -> Spec {
         .unwrap()
 }
 
-fn hostname_test() -> TestResult {
+fn hostname_test() -> TestResult<()>{
     let spec = create_spec("hostname-specific");
     test_inside_container(spec, &|_| {
         // As long as the container is created, we expect the hostname to be determined
@@ -32,7 +32,7 @@ fn hostname_test() -> TestResult {
     })
 }
 
-fn empty_hostname() -> TestResult {
+fn empty_hostname() -> TestResult<()>{
     let spec = create_spec("");
     test_inside_container(spec, &|_| {
         // As long as the container is created, we expect the hostname to be determined

--- a/tests/rust-integration-tests/integration_test/src/tests/lifecycle/container_create.rs
+++ b/tests/rust-integration-tests/integration_test/src/tests/lifecycle/container_create.rs
@@ -1,7 +1,8 @@
 use super::{create, delete, kill};
 use crate::utils::TempDir;
 use crate::utils::{generate_uuid, prepare_bundle};
-use test_framework::{TestResult, TestableGroup};
+use test_framework::testable::TestError;
+use test_framework::{TestResult, TestableGroup, TestGroup, Test};
 
 pub struct ContainerCreate {
     project_path: TempDir,
@@ -25,40 +26,39 @@ impl ContainerCreate {
     }
 
     // runtime should not create container with empty id
-    fn create_empty_id(&self) -> TestResult {
-        let temp = create::create(&self.project_path, "");
-        match temp {
-            TestResult::Passed => TestResult::Failed(anyhow::anyhow!(
+    fn create_empty_id(&self) -> TestResult<()> {
+        match create::create(&self.project_path, "") {
+            Ok(()) => Err(TestError::Failed(anyhow::anyhow!(
                 "Container should not have been created with empty id, but was created."
-            )),
-            TestResult::Failed(_) => TestResult::Passed,
-            TestResult::Skipped => TestResult::Skipped,
+            ))),
+            Err(TestError::Failed(_)) => Ok(()),
+            Err(TestError::Skipped) => Err(TestError::Skipped),
         }
     }
 
     // runtime should create container with valid id
-    fn create_valid_id(&self) -> TestResult {
-        let temp = create::create(&self.project_path, &self.container_id);
-        if let TestResult::Passed = temp {
-            kill::kill(&self.project_path, &self.container_id);
-            delete::delete(&self.project_path, &self.container_id);
+    fn create_valid_id(&self) -> TestResult<()> {
+        let ret = create::create(&self.project_path, &self.container_id);
+        if ret.is_ok() {
+            kill::kill(&self.project_path, &self.container_id)?;
+            delete::delete(&self.project_path, &self.container_id)?;
         }
-        temp
+        ret
     }
 
     // runtime should not create container with is that already exists
-    fn create_duplicate_id(&self) -> TestResult {
+    fn create_duplicate_id(&self) -> TestResult<()> {
         let id = generate_uuid().to_string();
         let _ = create::create(&self.project_path, &id);
-        let temp = create::create(&self.project_path, &id);
-        kill::kill(&self.project_path, &id);
-        delete::delete(&self.project_path, &id);
-        match temp {
-            TestResult::Passed => TestResult::Failed(anyhow::anyhow!(
+        let ret = create::create(&self.project_path, &id);
+        kill::kill(&self.project_path, &id)?;
+        delete::delete(&self.project_path, &id)?;
+        match ret {
+            Ok(()) => Err(TestError::Failed(anyhow::anyhow!(
                 "Container should not have been created with same id, but was created."
-            )),
-            TestResult::Failed(_) => TestResult::Passed,
-            TestResult::Skipped => TestResult::Skipped,
+            ))),
+            Err(TestError::Failed(_)) => Ok(()),
+            Err(TestError::Skipped) => Err(TestError::Skipped),
         }
     }
 }
@@ -68,7 +68,7 @@ impl TestableGroup for ContainerCreate {
         "create"
     }
 
-    fn run_all(&self) -> Vec<(&'static str, TestResult)> {
+    fn run_all(&self) -> Vec<(&'static str, TestResult<()>)> {
         vec![
             ("empty_id", self.create_empty_id()),
             ("valid_id", self.create_valid_id()),
@@ -76,7 +76,7 @@ impl TestableGroup for ContainerCreate {
         ]
     }
 
-    fn run_selected(&self, selected: &[&str]) -> Vec<(&'static str, TestResult)> {
+    fn run_selected(&self, selected: &[&str]) -> Vec<(&'static str, TestResult<()>)> {
         let mut ret = Vec::new();
         for name in selected {
             match *name {

--- a/tests/rust-integration-tests/integration_test/src/tests/lifecycle/container_lifecycle.rs
+++ b/tests/rust-integration-tests/integration_test/src/tests/lifecycle/container_lifecycle.rs
@@ -31,24 +31,23 @@ impl ContainerLifecycle {
         }
     }
 
-    pub fn create(&self) -> TestResult {
+    pub fn create(&self) -> TestResult<()> {
         create::create(&self.project_path, &self.container_id)
     }
 
-    #[allow(dead_code)]
-    pub fn exec(&self, cmd: Vec<&str>, expected_output: Option<&str>) -> TestResult {
+    pub fn exec(&self, cmd: Vec<&str>, expected_output: Option<&str>) -> TestResult<()> {
         exec::exec(&self.project_path, &self.container_id, cmd, expected_output)
     }
 
-    pub fn start(&self) -> TestResult {
+    pub fn start(&self) -> TestResult<()> {
         start::start(&self.project_path, &self.container_id)
     }
 
-    pub fn state(&self) -> TestResult {
+    pub fn state(&self) -> TestResult<()> {
         state::state(&self.project_path, &self.container_id)
     }
 
-    pub fn kill(&self) -> TestResult {
+    pub fn kill(&self) -> TestResult<()> {
         let ret = kill::kill(&self.project_path, &self.container_id);
         // sleep a little, so the youki process actually gets the signal and shuts down
         // otherwise, the tester moves on to next tests before the youki has gotten signal, and delete test can fail
@@ -56,15 +55,15 @@ impl ContainerLifecycle {
         ret
     }
 
-    pub fn delete(&self) -> TestResult {
+    pub fn delete(&self) -> TestResult<()> {
         delete::delete(&self.project_path, &self.container_id)
     }
 
-    pub fn checkpoint_leave_running(&self) -> TestResult {
+    pub fn checkpoint_leave_running(&self) -> TestResult<()> {
         checkpoint::checkpoint_leave_running(&self.project_path, &self.container_id)
     }
 
-    pub fn checkpoint_leave_running_work_path_tmp(&self) -> TestResult {
+    pub fn checkpoint_leave_running_work_path_tmp(&self) -> TestResult<()> {
         checkpoint::checkpoint_leave_running_work_path_tmp(&self.project_path, &self.container_id)
     }
 }
@@ -74,7 +73,7 @@ impl TestableGroup for ContainerLifecycle {
         "lifecycle"
     }
 
-    fn run_all(&self) -> Vec<(&'static str, TestResult)> {
+    fn run_all(&self) -> Vec<(&'static str, TestResult<()>)> {
         vec![
             ("create", self.create()),
             ("start", self.start()),
@@ -96,7 +95,7 @@ impl TestableGroup for ContainerLifecycle {
         ]
     }
 
-    fn run_selected(&self, selected: &[&str]) -> Vec<(&'static str, TestResult)> {
+    fn run_selected(&self, selected: &[&str]) -> Vec<(&'static str, TestResult<()>)> {
         let mut ret = Vec::new();
         for name in selected {
             match *name {

--- a/tests/rust-integration-tests/integration_test/src/tests/lifecycle/container_lifecycle.rs
+++ b/tests/rust-integration-tests/integration_test/src/tests/lifecycle/container_lifecycle.rs
@@ -78,7 +78,10 @@ impl TestableGroup for ContainerLifecycle {
         vec![
             ("create", self.create()),
             ("start", self.start()),
-            // ("exec", self.exec(vec!["echo", "Hello"], Some("Hello\n"))),
+            (
+                "exec",
+                self.exec(vec!["/bin/echo", "Hello"], Some("Hello\n")),
+            ),
             (
                 "checkpoint and leave running with --work-path /tmp",
                 self.checkpoint_leave_running_work_path_tmp(),

--- a/tests/rust-integration-tests/integration_test/src/tests/lifecycle/create.rs
+++ b/tests/rust-integration-tests/integration_test/src/tests/lifecycle/create.rs
@@ -3,12 +3,13 @@ use std::io;
 use std::path::Path;
 use std::process::{Command, Stdio};
 use test_framework::TestResult;
+use test_framework::testable::TestError;
 
 // There are still some issues here
 // in case we put stdout and stderr as piped
 // the youki process created halts indefinitely
 // which is why we pass null, and use wait instead of wait_with_output
-pub fn create(project_path: &Path, id: &str) -> TestResult {
+pub fn create(project_path: &Path, id: &str) -> TestResult<()> {
     let res = Command::new(get_runtime_path())
         .stdin(Stdio::null())
         .stdout(Stdio::null())
@@ -25,14 +26,14 @@ pub fn create(project_path: &Path, id: &str) -> TestResult {
     match res {
         io::Result::Ok(status) => {
             if status.success() {
-                TestResult::Passed
+                Ok(())
             } else {
-                TestResult::Failed(anyhow::anyhow!(
+                Err(TestError::Failed(anyhow::anyhow!(
                     "Error : create exited with nonzero status : {}",
                     status
-                ))
+                )))
             }
         }
-        io::Result::Err(e) => TestResult::Failed(anyhow::Error::new(e)),
+        io::Result::Err(e) => Err(TestError::Failed(anyhow::Error::new(e))),
     }
 }

--- a/tests/rust-integration-tests/integration_test/src/tests/lifecycle/delete.rs
+++ b/tests/rust-integration-tests/integration_test/src/tests/lifecycle/delete.rs
@@ -3,7 +3,7 @@ use crate::utils::delete_container;
 use std::path::Path;
 use test_framework::TestResult;
 
-pub fn delete(project_path: &Path, id: &str) -> TestResult {
+pub fn delete(project_path: &Path, id: &str) -> TestResult<()> {
     let res = delete_container(id, project_path)
         .expect("failed to execute delete command")
         .wait_with_output();

--- a/tests/rust-integration-tests/integration_test/src/tests/lifecycle/exec.rs
+++ b/tests/rust-integration-tests/integration_test/src/tests/lifecycle/exec.rs
@@ -9,7 +9,7 @@ pub fn exec(
     id: &str,
     exec_cmd: Vec<&str>,
     expected_output: Option<&str>,
-) -> TestResult {
+) -> TestResult<()> {
     let res = Command::new(get_runtime_path())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())

--- a/tests/rust-integration-tests/integration_test/src/tests/lifecycle/kill.rs
+++ b/tests/rust-integration-tests/integration_test/src/tests/lifecycle/kill.rs
@@ -3,7 +3,7 @@ use crate::utils::kill_container;
 use std::path::Path;
 use test_framework::TestResult;
 
-pub fn kill(project_path: &Path, id: &str) -> TestResult {
+pub fn kill(project_path: &Path, id: &str) -> TestResult<()> {
     let res = kill_container(id, project_path)
         .expect("failed to execute kill command")
         .wait_with_output();

--- a/tests/rust-integration-tests/integration_test/src/tests/lifecycle/start.rs
+++ b/tests/rust-integration-tests/integration_test/src/tests/lifecycle/start.rs
@@ -3,7 +3,7 @@ use crate::utils::test_utils::start_container;
 use std::path::Path;
 use test_framework::TestResult;
 
-pub fn start(project_path: &Path, id: &str) -> TestResult {
+pub fn start(project_path: &Path, id: &str) -> TestResult<()> {
     let res = start_container(id, project_path)
         .expect("failed to execute start command")
         .wait_with_output();

--- a/tests/rust-integration-tests/integration_test/src/tests/lifecycle/state.rs
+++ b/tests/rust-integration-tests/integration_test/src/tests/lifecycle/state.rs
@@ -1,24 +1,33 @@
 use crate::utils::get_state;
-use anyhow::{anyhow, Result};
+use anyhow::anyhow;
 use std::path::Path;
-use test_framework::TestResult;
+use test_framework::{testable::TestError, TestResult};
 
-pub fn state(project_path: &Path, id: &str) -> TestResult {
+pub fn state(project_path: &Path, id: &str) -> TestResult<()> {
     match get_state(id, project_path) {
-        Result::Ok((stdout, stderr)) => {
+        Ok((stdout, stderr)) => {
             if stderr.contains("Error") || stderr.contains("error") {
-                TestResult::Failed(anyhow!("Error :\nstdout : {}\nstderr : {}", stdout, stderr))
+                return Err(TestError::Failed(anyhow!(
+                    "Error :\nstdout : {}\nstderr : {}",
+                    stdout,
+                    stderr
+                )));
+            }
+
+            // confirm that the status is stopped, as this is executed after the kill command
+            if !(stdout.contains(&format!(r#""id": "{id}""#))
+                && stdout.contains(r#""status": "stopped""#))
+            {
+                Err(TestError::Failed(anyhow!(
+                    "Expected state stopped, got : {}",
+                    stdout
+                )))
             } else {
-                // confirm that the status is stopped, as this is executed after the kill command
-                if !(stdout.contains(&format!(r#""id": "{id}""#))
-                    && stdout.contains(r#""status": "stopped""#))
-                {
-                    TestResult::Failed(anyhow!("Expected state stopped, got : {}", stdout))
-                } else {
-                    TestResult::Passed
-                }
+                Ok(())
             }
         }
-        Result::Err(e) => TestResult::Failed(e.context("failed to get container state")),
+        Err(e) => Err(TestError::Failed(
+            e.context("failed to get container state"),
+        )),
     }
 }

--- a/tests/rust-integration-tests/integration_test/src/tests/lifecycle/util.rs
+++ b/tests/rust-integration-tests/integration_test/src/tests/lifecycle/util.rs
@@ -1,21 +1,21 @@
 use std::{io, process};
-use test_framework::TestResult;
+use test_framework::{TestResult, testable::TestError};
 
-pub fn get_result_from_output(res: io::Result<process::Output>) -> TestResult {
+pub fn get_result_from_output(res: io::Result<process::Output>) -> TestResult<()> {
     match res {
-        io::Result::Ok(output) => {
+        Ok(output) => {
             let stderr = String::from_utf8(output.stderr).unwrap();
             if stderr.contains("Error") || stderr.contains("error") {
                 let stdout = String::from_utf8(output.stdout).unwrap();
-                TestResult::Failed(anyhow::anyhow!(
+                Err(TestError::Failed(anyhow::anyhow!(
                     "Error :\nstdout : {}\nstderr : {}",
                     stdout,
                     stderr
-                ))
+                )))
             } else {
-                TestResult::Passed
+                Ok(())
             }
         }
-        io::Result::Err(e) => TestResult::Failed(anyhow::Error::new(e)),
+        Err(e) => Err(TestError::Failed(anyhow::Error::new(e))),
     }
 }

--- a/tests/rust-integration-tests/integration_test/src/tests/mounts_recursive/mod.rs
+++ b/tests/rust-integration-tests/integration_test/src/tests/mounts_recursive/mod.rs
@@ -92,7 +92,7 @@ fn clean_mount(mount_dir: &Path, sub_mount_dir: &Path) {
     fs::remove_dir_all(mount_dir).unwrap();
 }
 
-fn check_recursive_readonly() -> TestResult {
+fn check_recursive_readonly() -> TestResult<()> {
     let rro_test_base_dir = PathBuf::from_str("/tmp").unwrap();
     let rro_dir_path = rro_test_base_dir.join("rro_dir");
     let rro_subdir_path = rro_dir_path.join("rro_subdir");
@@ -120,7 +120,7 @@ fn check_recursive_readonly() -> TestResult {
     result
 }
 
-fn check_recursive_nosuid() -> TestResult {
+fn check_recursive_nosuid() -> TestResult<()> {
     let rnosuid_test_base_dir = PathBuf::from_str("/tmp").unwrap();
     let rnosuid_dir_path = rnosuid_test_base_dir.join("rnosuid_dir");
     let rnosuid_subdir_path = rnosuid_dir_path.join("rnosuid_subdir");
@@ -206,7 +206,7 @@ fn check_recursive_nosuid() -> TestResult {
     result
 }
 
-fn check_recursive_rsuid() -> TestResult {
+fn check_recursive_rsuid() -> TestResult<()> {
     let rsuid_dir_path = PathBuf::from_str("/tmp/rsuid_dir").unwrap();
     let mount_dest_path = PathBuf::from_str("/mnt/rsuid_dir").unwrap();
     fs::create_dir_all(rsuid_dir_path.clone()).unwrap();
@@ -242,7 +242,7 @@ fn check_recursive_rsuid() -> TestResult {
     result
 }
 
-fn check_recursive_noexec() -> TestResult {
+fn check_recursive_noexec() -> TestResult<()> {
     let rnoexec_test_base_dir = PathBuf::from_str("/tmp").unwrap();
     let rnoexec_dir_path = rnoexec_test_base_dir.join("rnoexec_dir");
     let rnoexec_subdir_path = rnoexec_dir_path.join("rnoexec_subdir");
@@ -283,7 +283,7 @@ fn check_recursive_noexec() -> TestResult {
     result
 }
 
-fn check_recursive_rexec() -> TestResult {
+fn check_recursive_rexec() -> TestResult<()> {
     let rnoexec_test_base_dir = PathBuf::from_str("/tmp").unwrap();
     let rnoexec_dir_path = rnoexec_test_base_dir.join("rexec_dir");
     let rnoexec_subdir_path = rnoexec_dir_path.join("rexec_subdir");
@@ -325,7 +325,7 @@ fn check_recursive_rexec() -> TestResult {
 }
 
 /// rdiratime If set in attr_clr, removes the restriction that prevented updating access time for directories.
-fn check_recursive_rdiratime() -> TestResult {
+fn check_recursive_rdiratime() -> TestResult<()> {
     let rdiratime_base_dir = PathBuf::from_str("/tmp/rdiratime").unwrap();
     let mount_dest_path = PathBuf::from_str("/rdiratime").unwrap();
     fs::create_dir(rdiratime_base_dir.clone()).unwrap();
@@ -349,7 +349,7 @@ fn check_recursive_rdiratime() -> TestResult {
 }
 
 /// If set in attr_set, prevents updating access time for directories on this mount
-fn check_recursive_rnodiratime() -> TestResult {
+fn check_recursive_rnodiratime() -> TestResult<()> {
     let rnodiratime_base_dir = PathBuf::from_str("/tmp/rnodiratime").unwrap();
     let mount_dest_path = PathBuf::from_str("/rnodiratime").unwrap();
     fs::create_dir(rnodiratime_base_dir.clone()).unwrap();
@@ -371,7 +371,7 @@ fn check_recursive_rnodiratime() -> TestResult {
     result
 }
 
-fn check_recursive_rdev() -> TestResult {
+fn check_recursive_rdev() -> TestResult<()> {
     let rdev_base_dir = PathBuf::from_str("/dev").unwrap();
     let mount_dest_path = PathBuf::from_str("/rdev").unwrap();
 
@@ -390,7 +390,7 @@ fn check_recursive_rdev() -> TestResult {
     test_inside_container(spec, &|_| Ok(()))
 }
 
-fn check_recursive_rnodev() -> TestResult {
+fn check_recursive_rnodev() -> TestResult<()> {
     let rnodev_base_dir = PathBuf::from_str("/dev").unwrap();
     let mount_dest_path = PathBuf::from_str("/rnodev").unwrap();
 
@@ -409,7 +409,7 @@ fn check_recursive_rnodev() -> TestResult {
     test_inside_container(spec, &|_| Ok(()))
 }
 
-fn check_recursive_readwrite() -> TestResult {
+fn check_recursive_readwrite() -> TestResult<()> {
     let rrw_test_base_dir = PathBuf::from_str("/tmp").unwrap();
     let rrw_dir_path = rrw_test_base_dir.join("rrw_dir");
     let rrw_subdir_path = rrw_dir_path.join("rrw_subdir");
@@ -437,7 +437,7 @@ fn check_recursive_readwrite() -> TestResult {
     result
 }
 
-fn check_recursive_rrelatime() -> TestResult {
+fn check_recursive_rrelatime() -> TestResult<()> {
     let rrelatime_base_dir = PathBuf::from_str("/tmp").unwrap();
     let rrelatime_dir_path = rrelatime_base_dir.join("rrelatime_dir");
     let rrelatime_suddir_path = rrelatime_dir_path.join("rrelatime_subdir");
@@ -461,7 +461,7 @@ fn check_recursive_rrelatime() -> TestResult {
     result
 }
 
-fn check_recursive_rnorelatime() -> TestResult {
+fn check_recursive_rnorelatime() -> TestResult<()> {
     let rnorelatime_base_dir = PathBuf::from_str("/tmp").unwrap();
     let rnorelatime_dir_path = rnorelatime_base_dir.join("rnorelatime_dir");
     let mount_dest_path = PathBuf::from_str("/rnorelatime").unwrap();
@@ -485,7 +485,7 @@ fn check_recursive_rnorelatime() -> TestResult {
     result
 }
 
-fn check_recursive_rnoatime() -> TestResult {
+fn check_recursive_rnoatime() -> TestResult<()> {
     let rnoatime_base_dir = PathBuf::from_str("/tmp").unwrap();
     let rnoatime_dir_path = rnoatime_base_dir.join("rnoatime_dir");
     let mount_dest_path = PathBuf::from_str("/rnoatime").unwrap();
@@ -509,7 +509,7 @@ fn check_recursive_rnoatime() -> TestResult {
     result
 }
 
-fn check_recursive_rstrictatime() -> TestResult {
+fn check_recursive_rstrictatime() -> TestResult<()> {
     let rstrictatime_base_dir = PathBuf::from_str("/tmp").unwrap();
     let rstrictatime_dir_path = rstrictatime_base_dir.join("rstrictatime_dir");
     let mount_dest_path = PathBuf::from_str("/rstrictatime").unwrap();
@@ -532,7 +532,7 @@ fn check_recursive_rstrictatime() -> TestResult {
     result
 }
 
-fn check_recursive_rnosymfollow() -> TestResult {
+fn check_recursive_rnosymfollow() -> TestResult<()> {
     let rnosymfollow_dir_path = PathBuf::from_str("/tmp/rnosymfollow").unwrap();
     let mount_dest_path = PathBuf::from_str("/mnt/rnosymfollow").unwrap();
     fs::create_dir_all(rnosymfollow_dir_path.clone()).unwrap();

--- a/tests/rust-integration-tests/integration_test/src/utils/support.rs
+++ b/tests/rust-integration-tests/integration_test/src/utils/support.rs
@@ -18,7 +18,7 @@ pub fn set_runtime_path(path: &Path) {
 }
 
 pub fn get_runtime_path() -> &'static PathBuf {
-    RUNTIME_PATH.get().expect("Runtime path is not set")
+    RUNTIME_PATH.get().expect("runtime path is not set")
 }
 
 pub fn set_runtimetest_path(path: &Path) {
@@ -26,7 +26,7 @@ pub fn set_runtimetest_path(path: &Path) {
 }
 
 pub fn get_runtimetest_path() -> &'static PathBuf {
-    RUNTIMETEST_PATH.get().expect("Runtimetest path is not set")
+    RUNTIMETEST_PATH.get().expect("runtimetest path is not set")
 }
 
 #[allow(dead_code)]

--- a/tests/rust-integration-tests/test_framework/Cargo.toml
+++ b/tests/rust-integration-tests/test_framework/Cargo.toml
@@ -8,3 +8,4 @@ edition = "2021"
 [dependencies]
 anyhow = "1.0.70"
 crossbeam = "0.8.2"
+thiserror = "1.0"

--- a/tests/rust-integration-tests/test_framework/src/conditional_test.rs
+++ b/tests/rust-integration-tests/test_framework/src/conditional_test.rs
@@ -2,7 +2,7 @@
 use crate::testable::{TestResult, Testable};
 
 // type aliases for test function signature
-type TestFn = dyn Fn() -> TestResult + Sync + Send;
+type TestFn = dyn Fn() -> TestResult<()> + Sync + Send;
 // type alias for function signature for function which checks if a test can be run or not
 type CheckFn = dyn Fn() -> bool + Sync + Send;
 
@@ -36,7 +36,7 @@ impl Testable for ConditionalTest {
         (self.check_fn)()
     }
 
-    fn run(&self) -> TestResult {
+    fn run(&self) -> TestResult<()> {
         (self.test_fn)()
     }
 }

--- a/tests/rust-integration-tests/test_framework/src/test.rs
+++ b/tests/rust-integration-tests/test_framework/src/test.rs
@@ -2,7 +2,7 @@
 use crate::testable::{TestResult, Testable};
 
 // type alias for the test function
-type TestFn = dyn Sync + Send + Fn() -> TestResult;
+type TestFn = dyn Sync + Send + Fn() -> TestResult<()>;
 
 /// Basic Template structure for a test
 pub struct Test {
@@ -24,7 +24,7 @@ impl Testable for Test {
         self.name
     }
 
-    fn run(&self) -> TestResult {
+    fn run(&self) -> TestResult<()> {
         (self.test_fn)()
     }
 }

--- a/tests/rust-integration-tests/test_framework/src/test_manager.rs
+++ b/tests/rust-integration-tests/test_framework/src/test_manager.rs
@@ -1,5 +1,5 @@
 ///! This exposes the main control wrapper to control the tests
-use crate::testable::{TestResult, TestableGroup};
+use crate::testable::{TestResult, TestableGroup, TestError};
 use anyhow::Result;
 use crossbeam::thread;
 use std::collections::BTreeMap;
@@ -38,19 +38,19 @@ impl TestManager {
 
     /// Prints the given test results, usually used to print
     /// results of a test group
-    fn print_test_result(&self, name: &str, res: &[(&'static str, TestResult)]) {
+    fn print_test_result(&self, name: &str, res: &[(&'static str, TestResult<()>)]) {
         println!("# Start group {name}");
         let len = res.len();
         for (idx, (name, res)) in res.iter().enumerate() {
             print!("{} / {} : {} : ", idx + 1, len, name);
             match res {
-                TestResult::Passed => {
+                Ok(()) => {
                     println!("ok");
                 }
-                TestResult::Skipped => {
+                Err(TestError::Skipped) => {
                     println!("skipped");
                 }
-                TestResult::Failed(e) => {
+                Err(TestError::Failed(e)) => {
                     println!("not ok\n\t{e}");
                 }
             }


### PR DESCRIPTION
This PR refactored the `TestResult` into a rusty `std::Result<T, TestError>`. In this way, the handling of `TestResult` can follow how rust handles error, such as using `?`. We further use `thiserror` to generate proper `TestError` for the cases the `TestResult` was handling. For simplicity, for now, we wrap `TestError::Failed` with `anyhow::Error` to maintain backward compatibility.