### PR TITLE
Refactor the lifecycle test

### DIFF
--- a/tests/rust-integration-tests/integration_test/src/tests/lifecycle/checkpoint.rs
+++ b/tests/rust-integration-tests/integration_test/src/tests/lifecycle/checkpoint.rs
@@ -131,9 +131,10 @@ fn checkpoint(
         .expect("failed to execute checkpoint command")
         .wait_with_output();
 
-    let result = get_result_from_output(checkpoint);
-    if let TestResult::Failed(_) = result {
-        return result;
+    if let Err(e) = get_result_from_output(checkpoint)  {
+        return TestResult::Failed(anyhow::anyhow!(
+            "failed to execute checkpoint command: {e}"
+        ));
     }
 
     // Check for complete checkpoint

--- a/tests/rust-integration-tests/integration_test/src/tests/lifecycle/checkpoint.rs
+++ b/tests/rust-integration-tests/integration_test/src/tests/lifecycle/checkpoint.rs
@@ -131,10 +131,8 @@ fn checkpoint(
         .expect("failed to execute checkpoint command")
         .wait_with_output();
 
-    if let Err(e) = get_result_from_output(checkpoint)  {
-        return TestResult::Failed(anyhow::anyhow!(
-            "failed to execute checkpoint command: {e}"
-        ));
+    if let Err(e) = get_result_from_output(checkpoint) {
+        return TestResult::Failed(anyhow::anyhow!("failed to execute checkpoint command: {e}"));
     }
 
     // Check for complete checkpoint

--- a/tests/rust-integration-tests/integration_test/src/tests/lifecycle/container_create.rs
+++ b/tests/rust-integration-tests/integration_test/src/tests/lifecycle/container_create.rs
@@ -28,7 +28,7 @@ impl ContainerCreate {
     fn create_empty_id(&self) -> TestResult {
         match create::create(&self.project_path, "") {
             Ok(()) => TestResult::Failed(anyhow::anyhow!(
-                "Container should not have been created with empty id, but was created."
+                "container should not have been created with empty id, but was created."
             )),
             Err(_) => TestResult::Passed,
         }
@@ -57,7 +57,7 @@ impl ContainerCreate {
         if let Err(err) = create::create(&self.project_path, &id) {
             return TestResult::Failed(
                 err.context(
-                    "Container should have been created with valid id, but was not created",
+                    "container should have been created with valid id, but was not created",
                 ),
             );
         }
@@ -69,7 +69,7 @@ impl ContainerCreate {
         let _ = delete::delete(&self.project_path, &id);
         match ret {
             Ok(()) => TestResult::Failed(anyhow::anyhow!(
-                "Container should not have been created with same id, but was created."
+                "container should not have been created with same id, but was created."
             )),
             Err(_) => TestResult::Passed,
         }

--- a/tests/rust-integration-tests/integration_test/src/tests/lifecycle/container_create.rs
+++ b/tests/rust-integration-tests/integration_test/src/tests/lifecycle/container_create.rs
@@ -38,8 +38,8 @@ impl ContainerCreate {
     fn create_valid_id(&self) -> TestResult {
         match create::create(&self.project_path, &self.container_id) {
             Ok(_) => {
-                kill::kill(&self.project_path, &self.container_id);
-                delete::delete(&self.project_path, &self.container_id);
+                let _ = kill::kill(&self.project_path, &self.container_id);
+                let _ = delete::delete(&self.project_path, &self.container_id);
                 TestResult::Passed
             }
             Err(_) => TestResult::Failed(anyhow::anyhow!(
@@ -54,15 +54,15 @@ impl ContainerCreate {
         let _ = create::create(&self.project_path, &id);
         match create::create(&self.project_path, &id) {
             Ok(()) => {
-                kill::kill(&self.project_path, &id);
-                delete::delete(&self.project_path, &id);
+                let _ = kill::kill(&self.project_path, &id);
+                let _ = delete::delete(&self.project_path, &id);
                 TestResult::Failed(anyhow::anyhow!(
                     "Container should not have been created with same id, but was created."
                 ))
             }
             Err(_) => {
-                kill::kill(&self.project_path, &id);
-                delete::delete(&self.project_path, &id);
+                let _ = kill::kill(&self.project_path, &id);
+                let _ = delete::delete(&self.project_path, &id);
                 TestResult::Passed
             }
         }

--- a/tests/rust-integration-tests/integration_test/src/tests/lifecycle/container_lifecycle.rs
+++ b/tests/rust-integration-tests/integration_test/src/tests/lifecycle/container_lifecycle.rs
@@ -32,7 +32,10 @@ impl ContainerLifecycle {
     }
 
     pub fn create(&self) -> TestResult {
-        create::create(&self.project_path, &self.container_id)
+        match create::create(&self.project_path, &self.container_id) {
+            Ok(_) => TestResult::Passed,
+            Err(err) => TestResult::Failed(err),
+        }
     }
 
     #[allow(dead_code)]

--- a/tests/rust-integration-tests/integration_test/src/tests/lifecycle/container_lifecycle.rs
+++ b/tests/rust-integration-tests/integration_test/src/tests/lifecycle/container_lifecycle.rs
@@ -32,19 +32,16 @@ impl ContainerLifecycle {
     }
 
     pub fn create(&self) -> TestResult {
-        match create::create(&self.project_path, &self.container_id) {
-            Ok(_) => TestResult::Passed,
-            Err(err) => TestResult::Failed(err),
-        }
+        create::create(&self.project_path, &self.container_id).into()
     }
 
     #[allow(dead_code)]
     pub fn exec(&self, cmd: Vec<&str>, expected_output: Option<&str>) -> TestResult {
-        exec::exec(&self.project_path, &self.container_id, cmd, expected_output)
+        exec::exec(&self.project_path, &self.container_id, cmd, expected_output).into()
     }
 
     pub fn start(&self) -> TestResult {
-        start::start(&self.project_path, &self.container_id)
+        start::start(&self.project_path, &self.container_id).into()
     }
 
     pub fn state(&self) -> TestResult {
@@ -56,11 +53,11 @@ impl ContainerLifecycle {
         // sleep a little, so the youki process actually gets the signal and shuts down
         // otherwise, the tester moves on to next tests before the youki has gotten signal, and delete test can fail
         sleep(SLEEP_TIME);
-        ret
+        ret.into()
     }
 
     pub fn delete(&self) -> TestResult {
-        delete::delete(&self.project_path, &self.container_id)
+        delete::delete(&self.project_path, &self.container_id).into()
     }
 
     pub fn checkpoint_leave_running(&self) -> TestResult {

--- a/tests/rust-integration-tests/integration_test/src/tests/lifecycle/container_lifecycle.rs
+++ b/tests/rust-integration-tests/integration_test/src/tests/lifecycle/container_lifecycle.rs
@@ -45,7 +45,7 @@ impl ContainerLifecycle {
     }
 
     pub fn state(&self) -> TestResult {
-        state::state(&self.project_path, &self.container_id)
+        state::state(&self.project_path, &self.container_id).into()
     }
 
     pub fn kill(&self) -> TestResult {

--- a/tests/rust-integration-tests/integration_test/src/tests/lifecycle/create.rs
+++ b/tests/rust-integration-tests/integration_test/src/tests/lifecycle/create.rs
@@ -1,14 +1,13 @@
 use crate::utils::get_runtime_path;
+use anyhow::{bail, Result};
 use std::io;
 use std::path::Path;
 use std::process::{Command, Stdio};
-use test_framework::TestResult;
 
-// There are still some issues here
-// in case we put stdout and stderr as piped
-// the youki process created halts indefinitely
-// which is why we pass null, and use wait instead of wait_with_output
-pub fn create(project_path: &Path, id: &str) -> TestResult {
+// There are still some issues here in case we put stdout and stderr as piped
+// the youki process created halts indefinitely which is why we pass null, and
+// use wait instead of wait_with_output
+pub fn create(project_path: &Path, id: &str) -> Result<()> {
     let res = Command::new(get_runtime_path())
         .stdin(Stdio::null())
         .stdout(Stdio::null())
@@ -25,14 +24,11 @@ pub fn create(project_path: &Path, id: &str) -> TestResult {
     match res {
         io::Result::Ok(status) => {
             if status.success() {
-                TestResult::Passed
+                Ok(())
             } else {
-                TestResult::Failed(anyhow::anyhow!(
-                    "Error : create exited with nonzero status : {}",
-                    status
-                ))
+                bail!("create exited with nonzero status : {}", status)
             }
         }
-        io::Result::Err(e) => TestResult::Failed(anyhow::Error::new(e)),
+        io::Result::Err(e) => bail!("create failed : {}", e),
     }
 }

--- a/tests/rust-integration-tests/integration_test/src/tests/lifecycle/delete.rs
+++ b/tests/rust-integration-tests/integration_test/src/tests/lifecycle/delete.rs
@@ -1,9 +1,9 @@
 use super::get_result_from_output;
 use crate::utils::delete_container;
+use anyhow::Result;
 use std::path::Path;
-use anyhow::{bail, Result};
 
-pub fn delete(project_path: &Path, id: &str) -> Result<()>{
+pub fn delete(project_path: &Path, id: &str) -> Result<()> {
     let res = delete_container(id, project_path)
         .expect("failed to execute delete command")
         .wait_with_output();

--- a/tests/rust-integration-tests/integration_test/src/tests/lifecycle/delete.rs
+++ b/tests/rust-integration-tests/integration_test/src/tests/lifecycle/delete.rs
@@ -1,9 +1,9 @@
 use super::get_result_from_output;
 use crate::utils::delete_container;
 use std::path::Path;
-use test_framework::TestResult;
+use anyhow::{bail, Result};
 
-pub fn delete(project_path: &Path, id: &str) -> TestResult {
+pub fn delete(project_path: &Path, id: &str) -> Result<()>{
     let res = delete_container(id, project_path)
         .expect("failed to execute delete command")
         .wait_with_output();

--- a/tests/rust-integration-tests/integration_test/src/tests/lifecycle/exec.rs
+++ b/tests/rust-integration-tests/integration_test/src/tests/lifecycle/exec.rs
@@ -2,14 +2,15 @@ use super::get_result_from_output;
 use crate::utils::get_runtime_path;
 use std::path::Path;
 use std::process::{Command, Stdio};
-use test_framework::{assert_result_eq, TestResult};
+use anyhow::Result;
+use test_framework::{assert_result_eq};
 
 pub fn exec(
     project_path: &Path,
     id: &str,
     exec_cmd: Vec<&str>,
     expected_output: Option<&str>,
-) -> TestResult {
+) -> Result<()>{
     let res = Command::new(get_runtime_path())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())

--- a/tests/rust-integration-tests/integration_test/src/tests/lifecycle/exec.rs
+++ b/tests/rust-integration-tests/integration_test/src/tests/lifecycle/exec.rs
@@ -1,16 +1,16 @@
 use super::get_result_from_output;
 use crate::utils::get_runtime_path;
+use anyhow::Result;
 use std::path::Path;
 use std::process::{Command, Stdio};
-use anyhow::Result;
-use test_framework::{assert_result_eq};
+use test_framework::assert_result_eq;
 
 pub fn exec(
     project_path: &Path,
     id: &str,
     exec_cmd: Vec<&str>,
     expected_output: Option<&str>,
-) -> Result<()>{
+) -> Result<()> {
     let res = Command::new(get_runtime_path())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())

--- a/tests/rust-integration-tests/integration_test/src/tests/lifecycle/kill.rs
+++ b/tests/rust-integration-tests/integration_test/src/tests/lifecycle/kill.rs
@@ -1,9 +1,10 @@
+use anyhow::Result;
+
 use super::get_result_from_output;
 use crate::utils::kill_container;
 use std::path::Path;
-use test_framework::TestResult;
 
-pub fn kill(project_path: &Path, id: &str) -> TestResult {
+pub fn kill(project_path: &Path, id: &str) -> Result<()>{
     let res = kill_container(id, project_path)
         .expect("failed to execute kill command")
         .wait_with_output();

--- a/tests/rust-integration-tests/integration_test/src/tests/lifecycle/kill.rs
+++ b/tests/rust-integration-tests/integration_test/src/tests/lifecycle/kill.rs
@@ -4,7 +4,7 @@ use super::get_result_from_output;
 use crate::utils::kill_container;
 use std::path::Path;
 
-pub fn kill(project_path: &Path, id: &str) -> Result<()>{
+pub fn kill(project_path: &Path, id: &str) -> Result<()> {
     let res = kill_container(id, project_path)
         .expect("failed to execute kill command")
         .wait_with_output();

--- a/tests/rust-integration-tests/integration_test/src/tests/lifecycle/start.rs
+++ b/tests/rust-integration-tests/integration_test/src/tests/lifecycle/start.rs
@@ -1,9 +1,9 @@
 use super::get_result_from_output;
 use crate::utils::test_utils::start_container;
 use std::path::Path;
-use test_framework::TestResult;
+use anyhow::Result;
 
-pub fn start(project_path: &Path, id: &str) -> TestResult {
+pub fn start(project_path: &Path, id: &str) -> Result<()> {
     let res = start_container(id, project_path)
         .expect("failed to execute start command")
         .wait_with_output();

--- a/tests/rust-integration-tests/integration_test/src/tests/lifecycle/start.rs
+++ b/tests/rust-integration-tests/integration_test/src/tests/lifecycle/start.rs
@@ -1,7 +1,7 @@
 use super::get_result_from_output;
 use crate::utils::test_utils::start_container;
-use std::path::Path;
 use anyhow::Result;
+use std::path::Path;
 
 pub fn start(project_path: &Path, id: &str) -> Result<()> {
     let res = start_container(id, project_path)

--- a/tests/rust-integration-tests/integration_test/src/tests/lifecycle/state.rs
+++ b/tests/rust-integration-tests/integration_test/src/tests/lifecycle/state.rs
@@ -1,7 +1,6 @@
 use crate::utils::get_state;
 use anyhow::{Result, bail};
 use std::path::Path;
-use test_framework::TestResult;
 
 pub fn state(project_path: &Path, id: &str) -> Result<()> {
     match get_state(id, project_path) {

--- a/tests/rust-integration-tests/integration_test/src/tests/lifecycle/state.rs
+++ b/tests/rust-integration-tests/integration_test/src/tests/lifecycle/state.rs
@@ -1,5 +1,5 @@
 use crate::utils::get_state;
-use anyhow::{Result, bail};
+use anyhow::{bail, Result};
 use std::path::Path;
 
 pub fn state(project_path: &Path, id: &str) -> Result<()> {

--- a/tests/rust-integration-tests/integration_test/src/tests/lifecycle/util.rs
+++ b/tests/rust-integration-tests/integration_test/src/tests/lifecycle/util.rs
@@ -1,21 +1,21 @@
 use std::{io, process};
-use test_framework::TestResult;
+use anyhow::{Result, bail};
 
-pub fn get_result_from_output(res: io::Result<process::Output>) -> TestResult {
+pub fn get_result_from_output(res: io::Result<process::Output>) -> Result<()>{
     match res {
         io::Result::Ok(output) => {
             let stderr = String::from_utf8(output.stderr).unwrap();
             if stderr.contains("Error") || stderr.contains("error") {
                 let stdout = String::from_utf8(output.stdout).unwrap();
-                TestResult::Failed(anyhow::anyhow!(
+                bail!(
                     "Error :\nstdout : {}\nstderr : {}",
                     stdout,
                     stderr
-                ))
+                )
             } else {
-                TestResult::Passed
+                Ok(())
             }
         }
-        io::Result::Err(e) => TestResult::Failed(anyhow::Error::new(e)),
+        io::Result::Err(e) => Err(anyhow::Error::new(e)),
     }
 }

--- a/tests/rust-integration-tests/integration_test/src/tests/lifecycle/util.rs
+++ b/tests/rust-integration-tests/integration_test/src/tests/lifecycle/util.rs
@@ -1,17 +1,13 @@
+use anyhow::{bail, Result};
 use std::{io, process};
-use anyhow::{Result, bail};
 
-pub fn get_result_from_output(res: io::Result<process::Output>) -> Result<()>{
+pub fn get_result_from_output(res: io::Result<process::Output>) -> Result<()> {
     match res {
         io::Result::Ok(output) => {
             let stderr = String::from_utf8(output.stderr).unwrap();
             if stderr.contains("Error") || stderr.contains("error") {
                 let stdout = String::from_utf8(output.stdout).unwrap();
-                bail!(
-                    "Error :\nstdout : {}\nstderr : {}",
-                    stdout,
-                    stderr
-                )
+                bail!("Error :\nstdout : {}\nstderr : {}", stdout, stderr)
             } else {
                 Ok(())
             }


### PR DESCRIPTION
As previously discussed in #1827 , the `TestResult` is meant to be used in the test cases and not utility functions. Before this PR, the lifecycle test calls other tests using `TestResult` which is not inline with our intention. This PR fix this by refactoring all tests to not call other tests in test cases.