### PR TITLE
convert youki to use tracing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1756,7 +1756,6 @@ dependencies = [
  "flate2",
  "libcgroups",
  "libcontainer",
- "log",
  "nix",
  "num_cpus",
  "oci-spec",
@@ -1770,6 +1769,8 @@ dependencies = [
  "tar",
  "tempfile",
  "test_framework",
+ "tracing",
+ "tracing-subscriber",
  "uuid",
  "which",
 ]
@@ -1930,7 +1931,6 @@ dependencies = [
  "fixedbitset",
  "libbpf-sys",
  "libc",
- "log",
  "mockall",
  "nix",
  "oci-spec",
@@ -1942,6 +1942,7 @@ dependencies = [
  "serial_test",
  "tempfile",
  "thiserror",
+ "tracing",
 ]
 
 [[package]]
@@ -1959,7 +1960,6 @@ dependencies = [
  "libc",
  "libcgroups",
  "libseccomp",
- "log",
  "mio",
  "nix",
  "oci-spec",
@@ -1977,6 +1977,7 @@ dependencies = [
  "syscalls",
  "tempfile",
  "thiserror",
+ "tracing",
 ]
 
 [[package]]
@@ -2085,6 +2086,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b823e83b2affd8f40a9ee8c29dbc56404c1e34cd2710921f2801e2cf29527afa"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata",
 ]
 
 [[package]]
@@ -2265,6 +2275,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
 
 [[package]]
+name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [
+ "overload",
+ "winapi",
+]
+
+[[package]]
 name = "num-derive"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2400,6 +2420,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "parking_lot"
@@ -2880,8 +2906,23 @@ checksum = "af83e617f331cc6ae2da5443c602dfa5af81e517212d9d611a5b3ba1777b5370"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax",
+ "regex-syntax 0.7.1",
 ]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax 0.6.29",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
@@ -3336,6 +3377,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "900fba806f70c630b0a382d0d825e17a0f19fcd059a2ade1ff237bcddf446b31"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shellexpand"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3638,6 +3688,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
+dependencies = [
+ "cfg-if 1.0.0",
+ "once_cell",
+]
+
+[[package]]
 name = "time"
 version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3854,6 +3914,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24eb03ba0eab1fd845050058ce5e616558e8f8d8fca633e6b163fe25c797213a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78ddad33d2d10b1ed7eb9d1f518a5674713876e97e5bb9b7345a7984fbb4f922"
+dependencies = [
+ "lazy_static",
+ "log",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-serde"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc6b213177105856957181934e4920de57730fc69bf42c37ee5bb664d406d9e1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a651bc37f915e81f087d86e62a18eec5f79550c7faff886f7090b4ea757c77"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]
@@ -3977,6 +4080,12 @@ name = "uuid"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4dad5567ad0cf5b760e5665964bec1b47dfd077ba8a2544b513f3556d3d239a2"
+
+[[package]]
+name = "valuable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "vcpkg"
@@ -5320,7 +5429,6 @@ dependencies = [
  "libcgroups",
  "libcontainer",
  "liboci-cli",
- "log",
  "nix",
  "oci-spec",
  "once_cell",
@@ -5332,6 +5440,8 @@ dependencies = [
  "serial_test",
  "tabwriter",
  "tempfile",
+ "tracing",
+ "tracing-subscriber",
  "vergen",
  "wasmedge-sdk",
  "wasmer",

--- a/crates/libcgroups/Cargo.toml
+++ b/crates/libcgroups/Cargo.toml
@@ -22,7 +22,6 @@ cgroupsv2_devices = ["rbpf", "libbpf-sys", "errno", "libc"]
 [dependencies]
 nix = "0.26.2"
 procfs = "0.15.1"
-log = "0.4"
 oci-spec = { version = "^0.6.0", features = ["runtime"] }
 dbus = { version = "0.9.7", optional = true }
 fixedbitset = "0.4.2"
@@ -32,6 +31,7 @@ libbpf-sys = { version = "1.1.1", optional = true }
 errno = { version = "0.3.1", optional = true }
 libc = { version = "0.2.144", optional = true }
 thiserror = "1.0.40"
+tracing = { version = "0.1.37", features = ["attributes"]}
 
 [dev-dependencies]
 anyhow = "1.0"

--- a/crates/libcgroups/src/common.rs
+++ b/crates/libcgroups/src/common.rs
@@ -349,7 +349,7 @@ pub fn create_cgroup_manager<P: Into<PathBuf>>(
 fn create_v1_cgroup_manager(
     cgroup_path: PathBuf,
 ) -> Result<v1::manager::Manager, v1::manager::V1ManagerError> {
-    log::info!("cgroup manager V1 will be used");
+    tracing::info!("cgroup manager V1 will be used");
     v1::manager::Manager::new(cgroup_path)
 }
 
@@ -362,7 +362,7 @@ fn create_v1_cgroup_manager(_cgroup_path: PathBuf) -> Result<Box<dyn CgroupManag
 fn create_v2_cgroup_manager(
     cgroup_path: PathBuf,
 ) -> Result<v2::manager::Manager, v2::manager::V2ManagerError> {
-    log::info!("cgroup manager V2 will be used");
+    tracing::info!("cgroup manager V2 will be used");
     v2::manager::Manager::new(DEFAULT_CGROUP_ROOT.into(), cgroup_path)
 }
 
@@ -384,7 +384,7 @@ fn create_systemd_cgroup_manager(
 
     let use_system = nix::unistd::geteuid().is_root();
 
-    log::info!(
+    tracing::info!(
         "systemd cgroup manager with system bus {} will be used",
         use_system
     );
@@ -405,7 +405,7 @@ fn create_systemd_cgroup_manager(
 }
 
 pub fn get_all_pids(path: &Path) -> Result<Vec<Pid>, WrappedIoError> {
-    log::debug!("scan pids in folder: {:?}", path);
+    tracing::debug!("scan pids in folder: {:?}", path);
     let mut result = vec![];
     walk_dir(path, &mut |p| {
         let file_path = p.join(CGROUP_PROCS);

--- a/crates/libcgroups/src/systemd/cpu.rs
+++ b/crates/libcgroups/src/systemd/cpu.rs
@@ -28,7 +28,7 @@ impl Controller for Cpu {
         properties: &mut HashMap<&str, Box<dyn RefArg>>,
     ) -> Result<(), Self::Error> {
         if let Some(cpu) = options.resources.cpu() {
-            log::debug!("Applying cpu resource restrictions");
+            tracing::debug!("Applying cpu resource restrictions");
             Self::apply(cpu, properties)?;
         }
 

--- a/crates/libcgroups/src/systemd/cpuset.rs
+++ b/crates/libcgroups/src/systemd/cpuset.rs
@@ -32,7 +32,7 @@ impl Controller for CpuSet {
         properties: &mut HashMap<&str, Box<dyn RefArg>>,
     ) -> Result<(), Self::Error> {
         if let Some(cpu) = options.resources.cpu() {
-            log::debug!("Applying cpuset resource restrictions");
+            tracing::debug!("Applying cpuset resource restrictions");
             return Self::apply(cpu, systemd_version, properties);
         }
 

--- a/crates/libcgroups/src/systemd/dbus/client.rs
+++ b/crates/libcgroups/src/systemd/dbus/client.rs
@@ -137,7 +137,7 @@ impl SystemdClient for Client {
         properties.push(("DefaultDependencies", Variant(Box::new(false))));
         properties.push(("PIDs", Variant(Box::new(vec![pid]))));
 
-        log::debug!("Starting transient unit: {:?}", properties);
+        tracing::debug!("Starting transient unit: {:?}", properties);
         proxy
             .start_transient_unit(unit_name, "replace", properties, vec![])
             .map_err(|err| SystemdClientError::FailedTransient {

--- a/crates/libcgroups/src/systemd/manager.rs
+++ b/crates/libcgroups/src/systemd/manager.rs
@@ -293,7 +293,7 @@ impl Manager {
         while let Some(component) = components.next() {
             current_path = current_path.join(component);
             if !current_path.exists() {
-                log::warn!(
+                tracing::warn!(
                     "{:?} does not exist. Resource restrictions might not work correctly",
                     current_path
                 );
@@ -357,7 +357,7 @@ impl CgroupManager for Manager {
             return Ok(());
         }
 
-        log::debug!("Starting {:?}", self.unit_name);
+        tracing::debug!("Starting {:?}", self.unit_name);
         self.client.start_transient_unit(
             &self.container_name,
             pid.as_raw() as u32,
@@ -394,7 +394,7 @@ impl CgroupManager for Manager {
         }
 
         Unified::apply(controller_opt, systemd_version, &mut properties)?;
-        log::debug!("{:?}", properties);
+        tracing::debug!("{:?}", properties);
 
         if !properties.is_empty() {
             self.ensure_controllers_attached()?;
@@ -407,7 +407,7 @@ impl CgroupManager for Manager {
     }
 
     fn remove(&self) -> Result<(), Self::Error> {
-        log::debug!("remove {}", self.unit_name);
+        tracing::debug!("remove {}", self.unit_name);
         if self.client.transient_unit_exists(&self.unit_name) {
             self.client.stop_transient_unit(&self.unit_name)?;
         }

--- a/crates/libcgroups/src/systemd/memory.rs
+++ b/crates/libcgroups/src/systemd/memory.rs
@@ -34,7 +34,7 @@ impl Controller for Memory {
         properties: &mut HashMap<&str, Box<dyn RefArg>>,
     ) -> Result<(), Self::Error> {
         if let Some(memory) = options.resources.memory() {
-            log::debug!("applying memory resource restrictions");
+            tracing::debug!("applying memory resource restrictions");
             return Self::apply(memory, properties);
         }
 

--- a/crates/libcgroups/src/systemd/pids.rs
+++ b/crates/libcgroups/src/systemd/pids.rs
@@ -20,7 +20,7 @@ impl Controller for Pids {
         properties: &mut HashMap<&str, Box<dyn RefArg>>,
     ) -> Result<(), Self::Error> {
         if let Some(pids) = options.resources.pids() {
-            log::debug!("Applying pids resource restrictions");
+            tracing::debug!("Applying pids resource restrictions");
             Self::apply(pids, properties);
         }
 

--- a/crates/libcgroups/src/systemd/unified.rs
+++ b/crates/libcgroups/src/systemd/unified.rs
@@ -44,7 +44,7 @@ impl Controller for Unified {
         properties: &mut HashMap<&str, Box<dyn RefArg>>,
     ) -> Result<(), Self::Error> {
         if let Some(unified) = options.resources.unified() {
-            log::debug!("applying unified resource restrictions");
+            tracing::debug!("applying unified resource restrictions");
             Self::apply(unified, systemd_version, properties)?;
         }
 
@@ -138,7 +138,7 @@ impl Unified {
                     properties.insert(pids::TASKS_MAX, Box::new(pids as u64));
                 }
 
-                unknown => log::warn!("could not apply {}. Unknown property.", unknown),
+                unknown => tracing::warn!("could not apply {}. Unknown property.", unknown),
             }
         }
 

--- a/crates/libcgroups/src/v1/blkio.rs
+++ b/crates/libcgroups/src/v1/blkio.rs
@@ -83,7 +83,7 @@ impl Controller for Blkio {
     type Resource = LinuxBlockIo;
 
     fn apply(controller_opt: &ControllerOpt, cgroup_root: &Path) -> Result<(), Self::Error> {
-        log::debug!("Apply blkio cgroup config");
+        tracing::debug!("Apply blkio cgroup config");
 
         if let Some(blkio) = Self::needs_to_handle(controller_opt) {
             Self::apply(cgroup_root, blkio)?;

--- a/crates/libcgroups/src/v1/cpu.rs
+++ b/crates/libcgroups/src/v1/cpu.rs
@@ -25,7 +25,7 @@ impl Controller for Cpu {
     type Resource = LinuxCpu;
 
     fn apply(controller_opt: &ControllerOpt, cgroup_root: &Path) -> Result<(), Self::Error> {
-        log::debug!("Apply Cpu cgroup config");
+        tracing::debug!("Apply Cpu cgroup config");
 
         if let Some(cpu) = Self::needs_to_handle(controller_opt) {
             Self::apply(cgroup_root, cpu)?;

--- a/crates/libcgroups/src/v1/cpuset.rs
+++ b/crates/libcgroups/src/v1/cpuset.rs
@@ -50,7 +50,7 @@ impl Controller for CpuSet {
     }
 
     fn apply(controller_opt: &ControllerOpt, cgroup_path: &Path) -> Result<(), Self::Error> {
-        log::debug!("Apply CpuSet cgroup config");
+        tracing::debug!("Apply CpuSet cgroup config");
 
         if let Some(cpuset) = Self::needs_to_handle(controller_opt) {
             Self::apply(cgroup_path, cpuset)?;

--- a/crates/libcgroups/src/v1/devices.rs
+++ b/crates/libcgroups/src/v1/devices.rs
@@ -11,7 +11,7 @@ impl Controller for Devices {
     type Resource = ();
 
     fn apply(controller_opt: &ControllerOpt, cgroup_root: &Path) -> Result<(), Self::Error> {
-        log::debug!("Apply Devices cgroup config");
+        tracing::debug!("Apply Devices cgroup config");
 
         if let Some(devices) = controller_opt.resources.devices().as_ref() {
             for d in devices {

--- a/crates/libcgroups/src/v1/freezer.rs
+++ b/crates/libcgroups/src/v1/freezer.rs
@@ -28,7 +28,7 @@ impl Controller for Freezer {
     type Resource = FreezerState;
 
     fn apply(controller_opt: &ControllerOpt, cgroup_root: &Path) -> Result<(), Self::Error> {
-        log::debug!("Apply Freezer cgroup config");
+        tracing::debug!("Apply Freezer cgroup config");
         std::fs::create_dir_all(cgroup_root).wrap_create_dir(cgroup_root)?;
 
         if let Some(freezer_state) = Self::needs_to_handle(controller_opt) {
@@ -87,7 +87,7 @@ impl Freezer {
                             }
                             FREEZER_STATE_FROZEN => {
                                 if i > 1 {
-                                    log::debug!("frozen after {} retries", i)
+                                    tracing::debug!("frozen after {} retries", i)
                                 }
                                 return Ok(());
                             }

--- a/crates/libcgroups/src/v1/hugetlb.rs
+++ b/crates/libcgroups/src/v1/hugetlb.rs
@@ -30,7 +30,7 @@ impl Controller for HugeTlb {
         controller_opt: &ControllerOpt,
         cgroup_root: &std::path::Path,
     ) -> Result<(), Self::Error> {
-        log::debug!("Apply Hugetlb cgroup config");
+        tracing::debug!("Apply Hugetlb cgroup config");
 
         if let Some(hugepage_limits) = Self::needs_to_handle(controller_opt) {
             for hugetlb in hugepage_limits {

--- a/crates/libcgroups/src/v1/manager.rs
+++ b/crates/libcgroups/src/v1/manager.rs
@@ -87,7 +87,7 @@ impl Manager {
             if let Ok(subsystem_path) = Self::get_subsystem_path(&cgroup_path, subsystem) {
                 subsystems.insert(*subsystem, subsystem_path);
             } else {
-                log::warn!("cgroup {} not supported on this system", subsystem);
+                tracing::warn!("cgroup {} not supported on this system", subsystem);
             }
         }
 
@@ -98,7 +98,7 @@ impl Manager {
         cgroup_path: &Path,
         subsystem: &CtrlType,
     ) -> Result<PathBuf, V1ManagerError> {
-        log::debug!("Get path for subsystem: {}", subsystem);
+        tracing::debug!("Get path for subsystem: {}", subsystem);
         let mount_point = util::get_subsystem_mount_point(subsystem)?;
 
         let cgroup = Process::myself()?
@@ -218,7 +218,7 @@ impl CgroupManager for Manager {
     fn remove(&self) -> Result<(), Self::Error> {
         for cgroup_path in &self.subsystems {
             if cgroup_path.1.exists() {
-                log::debug!("remove cgroup {:?}", cgroup_path.1);
+                tracing::debug!("remove cgroup {:?}", cgroup_path.1);
                 let procs_path = cgroup_path.1.join(CGROUP_PROCS);
                 let procs = fs::read_to_string(&procs_path).wrap_read(&procs_path)?;
 

--- a/crates/libcgroups/src/v1/memory.rs
+++ b/crates/libcgroups/src/v1/memory.rs
@@ -98,7 +98,7 @@ impl Controller for Memory {
         controller_opt: &ControllerOpt,
         cgroup_root: &Path,
     ) -> Result<(), V1MemoryControllerError> {
-        log::debug!("Apply Memory cgroup config");
+        tracing::debug!("Apply Memory cgroup config");
 
         if let Some(memory) = &controller_opt.resources.memory() {
             let reservation = memory.reservation().unwrap_or(0);

--- a/crates/libcgroups/src/v1/network_classifier.rs
+++ b/crates/libcgroups/src/v1/network_classifier.rs
@@ -12,7 +12,7 @@ impl Controller for NetworkClassifier {
     type Resource = LinuxNetwork;
 
     fn apply(controller_opt: &ControllerOpt, cgroup_root: &Path) -> Result<(), Self::Error> {
-        log::debug!("Apply NetworkClassifier cgroup config");
+        tracing::debug!("Apply NetworkClassifier cgroup config");
 
         if let Some(network) = Self::needs_to_handle(controller_opt) {
             Self::apply(cgroup_root, network)?;

--- a/crates/libcgroups/src/v1/network_priority.rs
+++ b/crates/libcgroups/src/v1/network_priority.rs
@@ -12,7 +12,7 @@ impl Controller for NetworkPriority {
     type Resource = LinuxNetwork;
 
     fn apply(controller_opt: &ControllerOpt, cgroup_root: &Path) -> Result<(), Self::Error> {
-        log::debug!("Apply NetworkPriority cgroup config");
+        tracing::debug!("Apply NetworkPriority cgroup config");
 
         if let Some(network) = Self::needs_to_handle(controller_opt) {
             Self::apply(cgroup_root, network)?;

--- a/crates/libcgroups/src/v1/pids.rs
+++ b/crates/libcgroups/src/v1/pids.rs
@@ -18,7 +18,7 @@ impl Controller for Pids {
     type Resource = LinuxPids;
 
     fn apply(controller_opt: &ControllerOpt, cgroup_root: &Path) -> Result<(), Self::Error> {
-        log::debug!("Apply pids cgroup config");
+        tracing::debug!("Apply pids cgroup config");
 
         if let Some(pids) = &controller_opt.resources.pids() {
             Self::apply(cgroup_root, pids)?;

--- a/crates/libcgroups/src/v2/devices/bpf.rs
+++ b/crates/libcgroups/src/v2/devices/bpf.rs
@@ -106,7 +106,7 @@ pub mod prog {
             #[allow(unused_unsafe)]
             let prog_fd = unsafe { bpf_prog_get_fd_by_id(*prog_id) };
             if prog_fd < 0 {
-                log::debug!("bpf_prog_get_fd_by_id failed: {}", errno::errno());
+                tracing::debug!("bpf_prog_get_fd_by_id failed: {}", errno::errno());
                 continue;
             }
             prog_fds.push(ProgramInfo {

--- a/crates/libcgroups/src/v2/devices/controller.rs
+++ b/crates/libcgroups/src/v2/devices/controller.rs
@@ -51,7 +51,7 @@ impl Devices {
         cgroup_root: &Path,
         linux_devices: &Option<Vec<LinuxDeviceCgroup>>,
     ) -> Result<(), DevicesControllerError> {
-        log::debug!("Apply Devices cgroup config");
+        tracing::debug!("Apply Devices cgroup config");
 
         // FIXME: should we start as "deny all"?
         let mut emulator = emulator::Emulator::with_default_allow(false);
@@ -59,7 +59,7 @@ impl Devices {
         // FIXME: apply user-defined and default rules in which order?
         if let Some(devices) = linux_devices {
             for d in devices {
-                log::debug!("apply user defined rule: {:?}", d);
+                tracing::debug!("apply user defined rule: {:?}", d);
                 emulator.add_rule(d);
             }
         }
@@ -70,7 +70,7 @@ impl Devices {
         ]
         .concat()
         {
-            log::debug!("apply default rule: {:?}", d);
+            tracing::debug!("apply default rule: {:?}", d);
             emulator.add_rule(&d);
         }
 

--- a/crates/libcgroups/src/v2/freezer.rs
+++ b/crates/libcgroups/src/v2/freezer.rs
@@ -131,7 +131,7 @@ impl Freezer {
             if line.starts_with("frozen ") {
                 if line.starts_with("frozen 1") {
                     if iter > 1 {
-                        log::debug!("frozen after {} retries", iter)
+                        tracing::debug!("frozen after {} retries", iter)
                     }
                     return Ok(FreezerState::Frozen);
                 }

--- a/crates/libcgroups/src/v2/hugetlb.rs
+++ b/crates/libcgroups/src/v2/hugetlb.rs
@@ -35,7 +35,7 @@ impl Controller for HugeTlb {
         controller_opt: &ControllerOpt,
         cgroup_root: &std::path::Path,
     ) -> Result<(), Self::Error> {
-        log::debug!("Apply hugetlb cgroup v2 config");
+        tracing::debug!("Apply hugetlb cgroup v2 config");
         if let Some(hugepage_limits) = controller_opt.resources.hugepage_limits() {
             for hugetlb in hugepage_limits {
                 Self::apply(cgroup_root, hugetlb)?

--- a/crates/libcgroups/src/v2/io.rs
+++ b/crates/libcgroups/src/v2/io.rs
@@ -33,7 +33,7 @@ impl Controller for Io {
     type Error = V2IoControllerError;
 
     fn apply(controller_opt: &ControllerOpt, cgroup_root: &Path) -> Result<(), Self::Error> {
-        log::debug!("Apply io cgroup v2 config");
+        tracing::debug!("Apply io cgroup v2 config");
         if let Some(io) = &controller_opt.resources.block_io() {
             Self::apply(cgroup_root, io)?;
         }

--- a/crates/libcgroups/src/v2/manager.rs
+++ b/crates/libcgroups/src/v2/manager.rs
@@ -180,7 +180,7 @@ impl CgroupManager for Manager {
 
     fn remove(&self) -> Result<(), Self::Error> {
         if self.full_path.exists() {
-            log::debug!("remove cgroup {:?}", self.full_path);
+            tracing::debug!("remove cgroup {:?}", self.full_path);
             let kill_file = self.full_path.join(CGROUP_KILL);
             if kill_file.exists() {
                 fs::write(&kill_file, "1").wrap_write(&kill_file, "1")?;

--- a/crates/libcgroups/src/v2/pids.rs
+++ b/crates/libcgroups/src/v2/pids.rs
@@ -17,7 +17,7 @@ impl Controller for Pids {
         controller_opt: &ControllerOpt,
         cgroup_root: &std::path::Path,
     ) -> Result<(), Self::Error> {
-        log::debug!("Apply pids cgroup v2 config");
+        tracing::debug!("Apply pids cgroup v2 config");
         if let Some(pids) = &controller_opt.resources.pids() {
             Self::apply(cgroup_root, pids)?;
         }

--- a/crates/libcgroups/src/v2/unified.rs
+++ b/crates/libcgroups/src/v2/unified.rs
@@ -34,7 +34,7 @@ impl Unified {
         cgroup_path: &Path,
         controllers: &[ControllerType],
     ) -> Result<(), V2UnifiedError> {
-        log::debug!("Apply unified cgroup config");
+        tracing::debug!("Apply unified cgroup config");
         for (cgroup_file, value) in unified {
             if let Err(err) = common::write_cgroup_file_str(cgroup_path.join(cgroup_file), value) {
                 let (subsystem, _) = cgroup_file.split_once('.').unwrap_or((cgroup_file, ""));

--- a/crates/libcgroups/src/v2/util.rs
+++ b/crates/libcgroups/src/v2/util.rs
@@ -48,7 +48,7 @@ pub fn get_available_controllers<P: AsRef<Path>>(
             "io" => controllers.push(ControllerType::Io),
             "memory" => controllers.push(ControllerType::Memory),
             "pids" => controllers.push(ControllerType::Pids),
-            tpe => log::warn!("Controller {} is not yet implemented.", tpe),
+            tpe => tracing::warn!("Controller {} is not yet implemented.", tpe),
         }
     }
 

--- a/crates/libcontainer/Cargo.toml
+++ b/crates/libcontainer/Cargo.toml
@@ -28,7 +28,6 @@ crossbeam-channel = "0.5"
 fastrand = "^1.7.0"
 futures = { version = "0.3", features = ["thread-pool"] }
 libc = "0.2.144"
-log = "0.4"
 mio = { version = "0.8.6", features = ["os-ext", "os-poll"] }
 nix = "0.26.2"
 path-clean = "1.0.1"
@@ -45,6 +44,7 @@ rust-criu = "0.4.0"
 clone3 = "0.2.3"
 regex = "1.7.3"
 thiserror = "1.0.24"
+tracing = { version = "0.1.37", features = ["attributes"]}
 
 [dev-dependencies]
 oci-spec = { version = "^0.6.0", features = ["proptests", "runtime"] }

--- a/crates/libcontainer/src/capabilities.rs
+++ b/crates/libcontainer/src/capabilities.rs
@@ -124,7 +124,7 @@ impl CapabilityExt for SpecCapability {
 /// effective capability set is set of capabilities used by kernel to perform checks
 /// see <https://man7.org/linux/man-pages/man7/capabilities.7.html> for more information
 pub fn reset_effective<S: Syscall + ?Sized>(syscall: &S) -> Result<(), SyscallError> {
-    log::debug!("reset all caps");
+    tracing::debug!("reset all caps");
     syscall.set_capability(CapSet::Effective, &caps::all())?;
     Ok(())
 }
@@ -134,7 +134,7 @@ pub fn drop_privileges<S: Syscall + ?Sized>(
     cs: &LinuxCapabilities,
     syscall: &S,
 ) -> Result<(), SyscallError> {
-    log::debug!("dropping bounding capabilities to {:?}", cs.bounding());
+    tracing::debug!("dropping bounding capabilities to {:?}", cs.bounding());
     if let Some(bounding) = cs.bounding() {
         syscall.set_capability(CapSet::Bounding, &to_set(bounding))?;
     }
@@ -154,7 +154,7 @@ pub fn drop_privileges<S: Syscall + ?Sized>(
     if let Some(ambient) = cs.ambient() {
         // check specifically for ambient, as those might not always be available
         if let Err(e) = syscall.set_capability(CapSet::Ambient, &to_set(ambient)) {
-            log::error!("failed to set ambient capabilities: {}", e);
+            tracing::error!("failed to set ambient capabilities: {}", e);
         }
     }
 

--- a/crates/libcontainer/src/container/builder_impl.rs
+++ b/crates/libcontainer/src/container/builder_impl.rs
@@ -104,7 +104,7 @@ impl<'a> ContainerBuilderImpl<'a> {
         // set). All children inherit their parent's oom_score_adj value on
         // fork(2) so this will always be propagated properly.
         if let Some(oom_score_adj) = process.oom_score_adj() {
-            log::debug!("Set OOM score to {}", oom_score_adj);
+            tracing::debug!("Set OOM score to {}", oom_score_adj);
             let mut f = fs::File::create("/proc/self/oom_score_adj")?;
             f.write_all(oom_score_adj.to_string().as_bytes())?;
         }

--- a/crates/libcontainer/src/container/container.rs
+++ b/crates/libcontainer/src/container/container.rs
@@ -198,7 +198,7 @@ impl Container {
     }
 
     pub fn save(&self) -> Result<()> {
-        log::debug!("Save container status: {:?} in {:?}", self, self.root);
+        tracing::debug!("Save container status: {:?} in {:?}", self, self.root);
         self.state.save(&self.root)
     }
 

--- a/crates/libcontainer/src/container/container_checkpoint.rs
+++ b/crates/libcontainer/src/container/container_checkpoint.rs
@@ -140,7 +140,7 @@ impl Container {
             self.set_status(ContainerStatus::Stopped).save()?;
         }
 
-        log::debug!("container {} checkpointed", self.id());
+        tracing::debug!("container {} checkpointed", self.id());
         Ok(())
     }
 }

--- a/crates/libcontainer/src/container/container_delete.rs
+++ b/crates/libcontainer/src/container/container_delete.rs
@@ -33,7 +33,7 @@ impl Container {
         self.refresh_status()
             .context("failed to refresh container status")?;
 
-        log::debug!("container status: {:?}", self.status());
+        tracing::debug!("container status: {:?}", self.status());
 
         // Check if container is allowed to be deleted based on container status.
         match self.status() {
@@ -69,7 +69,7 @@ impl Container {
 
         if let Some(true) = &self.clean_up_intel_rdt_subdirectory() {
             if let Err(err) = delete_resctrl_subdirectory(self.id()) {
-                log::warn!(
+                tracing::warn!(
                     "failed to delete resctrl subdirectory due to: {err:?}, continue to delete"
                 );
             }
@@ -78,7 +78,7 @@ impl Container {
         if self.root.exists() {
             match YoukiConfig::load(&self.root) {
                 Ok(config) => {
-                    log::debug!("config: {:?}", config);
+                    tracing::debug!("config: {:?}", config);
 
                     // remove the cgroup created for the container
                     // check https://man7.org/linux/man-pages/man7/cgroups.7.html
@@ -106,12 +106,14 @@ impl Container {
                     // created, but the container config is not yet generated
                     // from the OCI spec. In this case, we assume as if we
                     // successfully deleted the config and moving on.
-                    log::warn!("skipping loading youki config due to: {err:?}, continue to delete");
+                    tracing::warn!(
+                        "skipping loading youki config due to: {err:?}, continue to delete"
+                    );
                 }
             }
 
             // remove the directory storing container state
-            log::debug!("remove dir {:?}", self.root);
+            tracing::debug!("remove dir {:?}", self.root);
             fs::remove_dir_all(&self.root).with_context(|| {
                 format!("failed to remove container dir {}", self.root.display())
             })?;

--- a/crates/libcontainer/src/container/container_kill.rs
+++ b/crates/libcontainer/src/container/container_kill.rs
@@ -60,7 +60,7 @@ impl Container {
         let signal = signal.into().into_raw();
         let pid = self.pid().unwrap();
 
-        log::debug!("kill signal {} to {}", signal, pid);
+        tracing::debug!("kill signal {} to {}", signal, pid);
         let res = signal::kill(pid, signal);
 
         match res {
@@ -98,7 +98,7 @@ impl Container {
         let cmanger = create_cgroup_manager(cgroups_path, use_systemd, self.id())?;
         let ret = cmanger.freeze(libcgroups::common::FreezerState::Frozen);
         if ret.is_err() {
-            log::warn!(
+            tracing::warn!(
                 "failed to freeze container {}, error: {}",
                 self.id(),
                 ret.unwrap_err()
@@ -106,7 +106,7 @@ impl Container {
         }
         let pids = cmanger.get_all_pids()?;
         pids.iter().try_for_each(|&pid| {
-            log::debug!("kill signal {} to {}", signal, pid);
+            tracing::debug!("kill signal {} to {}", signal, pid);
             let res = signal::kill(pid, signal);
             match res {
                 Err(nix::errno::Errno::ESRCH) => {
@@ -118,7 +118,7 @@ impl Container {
         })?;
         let ret = cmanger.freeze(libcgroups::common::FreezerState::Thawed);
         if ret.is_err() {
-            log::warn!(
+            tracing::warn!(
                 "failed to thaw container {}, error: {}",
                 self.id(),
                 ret.unwrap_err()

--- a/crates/libcontainer/src/container/container_pause.rs
+++ b/crates/libcontainer/src/container/container_pause.rs
@@ -44,10 +44,10 @@ impl Container {
             libcgroups::common::create_cgroup_manager(cgroups_path, use_systemd, self.id())?;
         cmanager.freeze(FreezerState::Frozen)?;
 
-        log::debug!("saving paused status");
+        tracing::debug!("saving paused status");
         self.set_status(ContainerStatus::Paused).save()?;
 
-        log::debug!("container {} paused", self.id());
+        tracing::debug!("container {} paused", self.id());
         Ok(())
     }
 }

--- a/crates/libcontainer/src/container/container_resume.rs
+++ b/crates/libcontainer/src/container/container_resume.rs
@@ -47,10 +47,10 @@ impl Container {
         // resume the frozen container
         cmanager.freeze(FreezerState::Thawed)?;
 
-        log::debug!("saving running status");
+        tracing::debug!("saving running status");
         self.set_status(ContainerStatus::Running).save()?;
 
-        log::debug!("container {} resumed", self.id());
+        tracing::debug!("container {} resumed", self.id());
         Ok(())
     }
 }

--- a/crates/libcontainer/src/container/container_start.rs
+++ b/crates/libcontainer/src/container/container_start.rs
@@ -40,7 +40,7 @@ impl Container {
                 self.id(),
                 self.status()
             );
-            log::error!("{}", err_msg);
+            tracing::error!("{}", err_msg);
             bail!(err_msg);
         }
 

--- a/crates/libcontainer/src/container/init_builder.rs
+++ b/crates/libcontainer/src/container/init_builder.rs
@@ -110,7 +110,7 @@ impl<'a> InitContainerBuilder<'a> {
 
     fn create_container_dir(&self) -> Result<PathBuf> {
         let container_dir = self.base.root_path.join(&self.base.container_id);
-        log::debug!("container directory will be {:?}", container_dir);
+        tracing::debug!("container directory will be {:?}", container_dir);
 
         if container_dir.exists() {
             bail!("container {} already exists", self.base.container_id);

--- a/crates/libcontainer/src/container/tenant_builder.rs
+++ b/crates/libcontainer/src/container/tenant_builder.rs
@@ -112,7 +112,7 @@ impl<'a> TenantContainerBuilder<'a> {
         self.adapt_spec_for_tenant(&mut spec, &container)
             .context("failed to adapt spec for tenant")?;
 
-        log::debug!("{:#?}", spec);
+        tracing::debug!("{:#?}", spec);
 
         unistd::chdir(&container_dir)?;
         let notify_path = Self::setup_notify_listener(&container_dir)?;

--- a/crates/libcontainer/src/hooks.rs
+++ b/crates/libcontainer/src/hooks.rs
@@ -44,7 +44,7 @@ pub fn run_hooks(hooks: Option<&Vec<Hook>>, container: Option<&Container>) -> Re
             // doesn't include arg0. So we have to make the split arg0 from the
             // rest of args.
             if let Some((arg0, args)) = hook.args().as_ref().and_then(|a| a.split_first()) {
-                log::debug!("run_hooks arg0: {:?}, args: {:?}", arg0, args);
+                tracing::debug!("run_hooks arg0: {:?}, args: {:?}", arg0, args);
                 hook_command.arg0(arg0).args(args)
             } else {
                 hook_command.arg0(&hook.path().display().to_string())
@@ -55,7 +55,7 @@ pub fn run_hooks(hooks: Option<&Vec<Hook>>, container: Option<&Container>) -> Re
             } else {
                 HashMap::new()
             };
-            log::debug!("run_hooks envs: {:?}", envs);
+            tracing::debug!("run_hooks envs: {:?}", envs);
 
             let mut hook_process = hook_command
                 .env_clear()

--- a/crates/libcontainer/src/namespaces.rs
+++ b/crates/libcontainer/src/namespaces.rs
@@ -84,7 +84,7 @@ impl Namespaces {
     }
 
     pub fn unshare_or_setns(&self, namespace: &LinuxNamespace) -> Result<()> {
-        log::debug!("unshare or setns: {:?}", namespace);
+        tracing::debug!("unshare or setns: {:?}", namespace);
         match namespace.path() {
             Some(path) => {
                 let fd = fcntl::open(path, fcntl::OFlag::empty(), stat::Mode::empty()).map_err(

--- a/crates/libcontainer/src/notify_socket.rs
+++ b/crates/libcontainer/src/notify_socket.rs
@@ -79,7 +79,7 @@ impl NotifyListener {
                 socket
                     .read_to_string(&mut response)
                     .map_err(NotifyListenerError::Read)?;
-                log::debug!("received: {}", response);
+                tracing::debug!("received: {}", response);
             }
             Err(e) => Err(NotifyListenerError::Accept(e))?,
         }
@@ -105,7 +105,7 @@ impl NotifySocket {
     }
 
     pub fn notify_container_start(&mut self) -> Result<()> {
-        log::debug!("notify container start");
+        tracing::debug!("notify container start");
         let cwd = env::current_dir().map_err(NotifyListenerError::GetCwd)?;
         let workdir = self
             .path
@@ -127,7 +127,7 @@ impl NotifySocket {
         stream
             .write_all(b"start container")
             .map_err(NotifyListenerError::SendStartContainer)?;
-        log::debug!("notify finished");
+        tracing::debug!("notify finished");
         unistd::chdir(&cwd).map_err(|e| NotifyListenerError::Chdir {
             source: e,
             path: cwd,

--- a/crates/libcontainer/src/process/channel.rs
+++ b/crates/libcontainer/src/process/channel.rs
@@ -65,7 +65,7 @@ impl MainSender {
     // requests the Main to write the id mappings for the intermediate process
     // this needs to be done from the parent see https://man7.org/linux/man-pages/man7/user_namespaces.7.html
     pub fn identifier_mapping_request(&mut self) -> Result<(), ChannelError> {
-        log::debug!("send identifier mapping request");
+        tracing::debug!("send identifier mapping request");
         self.sender.send(Message::WriteMapping)?;
 
         Ok(())
@@ -80,7 +80,7 @@ impl MainSender {
 
     pub fn intermediate_ready(&mut self, pid: Pid) -> Result<(), ChannelError> {
         // Send over the IntermediateReady follow by the pid.
-        log::debug!("sending init pid ({:?})", pid);
+        tracing::debug!("sending init pid ({:?})", pid);
         self.sender.send(Message::IntermediateReady(pid.as_raw()))?;
 
         Ok(())
@@ -216,7 +216,7 @@ pub struct IntermediateSender {
 
 impl IntermediateSender {
     pub fn mapping_written(&mut self) -> Result<(), ChannelError> {
-        log::debug!("identifier mapping written");
+        tracing::debug!("identifier mapping written");
         self.sender.send(Message::MappingWritten)?;
 
         Ok(())
@@ -236,7 +236,7 @@ pub struct IntermediateReceiver {
 impl IntermediateReceiver {
     // wait until the parent process has finished writing the id mappings
     pub fn wait_for_mapping_ack(&mut self) -> Result<(), ChannelError> {
-        log::debug!("waiting for mapping ack");
+        tracing::debug!("waiting for mapping ack");
         let msg = self
             .receiver
             .recv()

--- a/crates/libcontainer/src/process/container_intermediate_process.rs
+++ b/crates/libcontainer/src/process/container_intermediate_process.rs
@@ -46,7 +46,7 @@ pub fn container_intermediate_process(
     if let Some(user_namespace) = namespaces.get(LinuxNamespaceType::User) {
         namespaces.unshare_or_setns(user_namespace)?;
         if user_namespace.path().is_none() {
-            log::debug!("creating new user namespace");
+            tracing::debug!("creating new user namespace");
             // child needs to be dumpable, otherwise the non root parent is not
             // allowed to write the uid/gid maps
             prctl::set_dumpable(true).unwrap();
@@ -119,7 +119,7 @@ pub fn container_intermediate_process(
                     write(exec_notify_fd, buf.as_bytes())?;
                     close(exec_notify_fd)?;
                 }
-                log::error!("failed to initialize container process: {e}");
+                tracing::error!("failed to initialize container process: {e}");
                 Err(ProcessError::InitProcessFailed { msg: e.to_string() })
             }
         }

--- a/crates/libcontainer/src/process/fork.rs
+++ b/crates/libcontainer/src/process/fork.rs
@@ -45,7 +45,7 @@ fn container_clone<F: FnOnce() -> Result<i32>>(
             // Inside the cloned process
             let ret = match cb() {
                 Err(error) => {
-                    log::debug!("failed to run child process in clone: {:?}", error);
+                    tracing::debug!("failed to run child process in clone: {:?}", error);
                     -1
                 }
                 Ok(exit_code) => exit_code,

--- a/crates/libcontainer/src/rootfs/rootfs.rs
+++ b/crates/libcontainer/src/rootfs/rootfs.rs
@@ -35,7 +35,7 @@ impl RootFS {
         bind_devices: bool,
         cgroup_ns: bool,
     ) -> Result<()> {
-        log::debug!("Prepare rootfs: {:?}", rootfs);
+        tracing::debug!("Prepare rootfs: {:?}", rootfs);
         let mut flags = MsFlags::MS_REC;
         let linux = spec.linux().as_ref().context("no linux in spec")?;
 
@@ -56,7 +56,7 @@ impl RootFS {
             .make_parent_mount_private(rootfs)
             .context("failed to change parent mount of rootfs private")?;
 
-        log::debug!("mount root fs {:?}", rootfs);
+        tracing::debug!("mount root fs {:?}", rootfs);
         self.syscall.mount(
             Some(rootfs),
             rootfs,
@@ -112,7 +112,7 @@ impl RootFS {
         };
 
         if let Some(flags) = flags {
-            log::debug!("make root mount {:?}", flags);
+            tracing::debug!("make root mount {:?}", flags);
             self.syscall
                 .mount(None, Path::new("/"), None, flags, None)?;
         }

--- a/crates/libcontainer/src/rootless.rs
+++ b/crates/libcontainer/src/rootless.rs
@@ -92,7 +92,7 @@ impl<'a> Rootless<'a> {
         }
 
         if user_namespace.is_some() && user_namespace.unwrap().path().is_none() {
-            log::debug!("rootless container should be created");
+            tracing::debug!("rootless container should be created");
 
             validate_spec_for_rootless(spec)
                 .context("The spec failed to comply to rootless requirement")?;
@@ -104,13 +104,13 @@ impl<'a> Rootless<'a> {
 
             Ok(Some(rootless))
         } else {
-            log::debug!("This is NOT a rootless container");
+            tracing::debug!("This is NOT a rootless container");
             Ok(None)
         }
     }
 
     pub fn write_uid_mapping(&self, target_pid: Pid) -> Result<()> {
-        log::debug!("Write UID mapping for {:?}", target_pid);
+        tracing::debug!("Write UID mapping for {:?}", target_pid);
         if let Some(uid_mappings) = self.uid_mappings {
             write_id_mapping(
                 target_pid,
@@ -124,7 +124,7 @@ impl<'a> Rootless<'a> {
     }
 
     pub fn write_gid_mapping(&self, target_pid: Pid) -> Result<()> {
-        log::debug!("Write GID mapping for {:?}", target_pid);
+        tracing::debug!("Write GID mapping for {:?}", target_pid);
         if let Some(gid_mappings) = self.gid_mappings {
             return write_id_mapping(
                 target_pid,
@@ -305,7 +305,7 @@ fn write_id_mapping(
     mappings: &[LinuxIdMapping],
     map_binary: Option<&Path>,
 ) -> Result<()> {
-    log::debug!("Write ID mapping: {:?}", mappings);
+    tracing::debug!("Write ID mapping: {:?}", mappings);
 
     match mappings.len() {
         0 => bail!("at least one id mapping needs to be defined"),

--- a/crates/libcontainer/src/seccomp/mod.rs
+++ b/crates/libcontainer/src/seccomp/mod.rs
@@ -186,7 +186,7 @@ pub fn initialize_seccomp(seccomp: &LinuxSeccomp) -> Result<Option<io::RawFd>> {
             if action == default_action {
                 // When the action is the same as the default action, the rule is redundant. We can
                 // skip this here to avoid failing when we add the rules.
-                log::warn!(
+                tracing::warn!(
                     "detect a seccomp action that is the same as the default action: {:?}",
                     syscall
                 );
@@ -199,7 +199,7 @@ pub fn initialize_seccomp(seccomp: &LinuxSeccomp) -> Result<Option<io::RawFd>> {
                     Err(_) => {
                         // If we failed to resolve the syscall by name, likely the kernel
                         // doeesn't support this syscall. So it is safe to skip...
-                        log::warn!(
+                        tracing::warn!(
                             "failed to resolve syscall, likely kernel doesn't support this. {:?}",
                             name
                         );
@@ -228,7 +228,7 @@ pub fn initialize_seccomp(seccomp: &LinuxSeccomp) -> Result<Option<io::RawFd>> {
                             );
                             ctx.add_rule_conditional(action, sc, &[cmp])
                                 .map_err(|err| {
-                                    log::error!(
+                                    tracing::error!(
                                         "failed to add seccomp action: {:?}. Cmp: {:?} Syscall: {name}", &action, cmp,
                                     );
                                     SeccompError::AddRule {
@@ -239,7 +239,10 @@ pub fn initialize_seccomp(seccomp: &LinuxSeccomp) -> Result<Option<io::RawFd>> {
                     }
                     None => {
                         ctx.add_rule(action, sc).map_err(|err| {
-                            log::error!("failed to add seccomp rule: {:?}. Syscall: {name}", &sc);
+                            tracing::error!(
+                                "failed to add seccomp rule: {:?}. Syscall: {name}",
+                                &sc
+                            );
                             SeccompError::AddRule { source: err }
                         })?;
                     }

--- a/crates/libcontainer/src/syscall/linux.rs
+++ b/crates/libcontainer/src/syscall/linux.rs
@@ -250,7 +250,7 @@ impl Syscall for LinuxSyscall {
         // open the path as directory and read only
         let newroot =
             open(path, OFlag::O_DIRECTORY | OFlag::O_RDONLY, Mode::empty()).map_err(|errno| {
-                log::error!("failed to open {:?}", path);
+                tracing::error!("failed to open {:?}", path);
                 SyscallError::PivotRoot { source: errno }
             })?;
 
@@ -263,7 +263,7 @@ impl Syscall for LinuxSyscall {
         // so we can move the original root there, and then unmount that. This way saves the creation of the temporary
         // directory to put original root directory.
         pivot_root(path, path).map_err(|errno| {
-            log::error!("failed to pivot root to {:?}", path);
+            tracing::error!("failed to pivot root to {:?}", path);
             SyscallError::PivotRoot { source: errno }
         })?;
 
@@ -277,7 +277,7 @@ impl Syscall for LinuxSyscall {
             None::<&str>,
         )
         .map_err(|errno| {
-            log::error!("failed to make original root directory rslave");
+            tracing::error!("failed to make original root directory rslave");
             SyscallError::PivotRoot { source: errno }
         })?;
 
@@ -286,12 +286,12 @@ impl Syscall for LinuxSyscall {
         // to be free of activity to actually unmount
         // see https://man7.org/linux/man-pages/man2/umount2.2.html for more information
         umount2("/", MntFlags::MNT_DETACH).map_err(|errno| {
-            log::error!("failed to unmount old root directory");
+            tracing::error!("failed to unmount old root directory");
             SyscallError::PivotRoot { source: errno }
         })?;
         // Change directory to the new root
         fchdir(newroot).map_err(|errno| {
-            log::error!("failed to change directory to new root");
+            tracing::error!("failed to change directory to new root");
             SyscallError::PivotRoot { source: errno }
         })?;
 
@@ -466,14 +466,14 @@ impl Syscall for LinuxSyscall {
 
     fn symlink(&self, original: &Path, link: &Path) -> Result<()> {
         symlink(original, link).map_err(|err| {
-            log::error!("failed to create symlink from {original:?} to {link:?}: {err}");
+            tracing::error!("failed to create symlink from {original:?} to {link:?}: {err}");
             SyscallError::Symlink { source: err }
         })
     }
 
     fn mknod(&self, path: &Path, kind: SFlag, perm: Mode, dev: u64) -> Result<()> {
         mknod(path, kind, perm, dev).map_err(|errno| {
-            log::error!(
+            tracing::error!(
                 "failed to mknod {path:?}, kind {kind:?}, perm {perm:?}, dev {dev:?}: {errno}"
             );
             SyscallError::Mknod { source: errno }
@@ -482,7 +482,7 @@ impl Syscall for LinuxSyscall {
 
     fn chown(&self, path: &Path, owner: Option<Uid>, group: Option<Gid>) -> Result<()> {
         chown(path, owner, group).map_err(|errno| {
-            log::error!("failed to chown {path:?} to {owner:?}:{group:?}: {errno}");
+            tracing::error!("failed to chown {path:?} to {owner:?}:{group:?}: {errno}");
             SyscallError::Chown { source: errno }
         })
     }

--- a/crates/libcontainer/src/tty.rs
+++ b/crates/libcontainer/src/tty.rs
@@ -127,7 +127,7 @@ pub fn setup_console(console_fd: &RawFd) -> Result<()> {
     .map_err(|err| TTYError::SendPtyMaster { source: err })?;
 
     if unsafe { libc::ioctl(openpty_result.slave, libc::TIOCSCTTY) } < 0 {
-        log::warn!("could not TIOCSCTTY");
+        tracing::warn!("could not TIOCSCTTY");
     };
     let slave = openpty_result.slave;
     connect_stdio(&slave, &slave, &slave)?;

--- a/crates/libcontainer/src/workload/default.rs
+++ b/crates/libcontainer/src/workload/default.rs
@@ -13,7 +13,7 @@ pub struct DefaultExecutor {}
 
 impl Executor for DefaultExecutor {
     fn exec(&self, spec: &Spec) -> Result<()> {
-        log::debug!("Executing workload with default handler");
+        tracing::debug!("Executing workload with default handler");
         let args = spec
             .process()
             .as_ref()

--- a/crates/youki/Cargo.toml
+++ b/crates/youki/Cargo.toml
@@ -31,7 +31,6 @@ chrono = { version = "0.4", features = ["serde"] }
 libcgroups = { version = "0.0.5", path = "../libcgroups", default-features = false }
 libcontainer = { version = "0.0.5", path = "../libcontainer", default-features = false }
 liboci-cli = { version = "0.0.5", path = "../liboci-cli" }
-log = { version = "0.4", features = ["std"] }
 nix = "0.26.2"
 oci-spec = { version = "^0.6.0", features = ["runtime"] }
 once_cell = "1.17.1"
@@ -44,10 +43,11 @@ clap_complete = "4.1.3"
 caps = "0.5.5"
 wasmer = { version = "3.2.0", optional = true }
 wasmer-wasix = { version = "0.4.0", optional = true }
-
 wasmedge-sdk = { version = "0.7.1", optional = true }
 wasmtime = {version = "8.0.1", optional = true }
 wasmtime-wasi = {version = "8.0.1", optional = true }
+tracing = { version = "0.1.37", features = ["attributes"]}
+tracing-subscriber = { version = "0.3.16", features = ["json", "env-filter"] }
 
 [dev-dependencies]
 serial_test = "2.0.0"

--- a/crates/youki/src/commands/checkpoint.rs
+++ b/crates/youki/src/commands/checkpoint.rs
@@ -7,7 +7,7 @@ use anyhow::{Context, Result};
 use liboci_cli::Checkpoint;
 
 pub fn checkpoint(args: Checkpoint, root_path: PathBuf) -> Result<()> {
-    log::debug!("start checkpointing container {}", args.container_id);
+    tracing::debug!("start checkpointing container {}", args.container_id);
     let mut container = load_container(root_path, &args.container_id)?;
     let opts = libcontainer::container::CheckpointOptions {
         ext_unix_sk: args.ext_unix_sk,

--- a/crates/youki/src/commands/delete.rs
+++ b/crates/youki/src/commands/delete.rs
@@ -5,7 +5,7 @@ use std::path::PathBuf;
 use liboci_cli::Delete;
 
 pub fn delete(args: Delete, root_path: PathBuf) -> Result<()> {
-    log::debug!("start deleting {}", args.container_id);
+    tracing::debug!("start deleting {}", args.container_id);
     if !container_exists(&root_path, &args.container_id)? && args.force {
         return Ok(());
     }

--- a/crates/youki/src/commands/pause.rs
+++ b/crates/youki/src/commands/pause.rs
@@ -12,7 +12,7 @@ use liboci_cli::Pause;
 // https://man7.org/linux/man-pages/man7/cgroups.7.html
 // https://www.kernel.org/doc/Documentation/cgroup-v1/freezer-subsystem.txt
 pub fn pause(args: Pause, root_path: PathBuf) -> Result<()> {
-    log::debug!("start pausing container {}", args.container_id);
+    tracing::debug!("start pausing container {}", args.container_id);
     let mut container = load_container(root_path, &args.container_id)?;
     container
         .pause()

--- a/crates/youki/src/commands/resume.rs
+++ b/crates/youki/src/commands/resume.rs
@@ -13,7 +13,7 @@ use liboci_cli::Resume;
 // https://man7.org/linux/man-pages/man7/cgroups.7.html
 // https://www.kernel.org/doc/Documentation/cgroup-v1/freezer-subsystem.txt
 pub fn resume(args: Resume, root_path: PathBuf) -> Result<()> {
-    log::debug!("start resuming container {}", args.container_id);
+    tracing::debug!("start resuming container {}", args.container_id);
     let mut container = load_container(root_path, &args.container_id)?;
     container
         .resume()

--- a/crates/youki/src/logger.rs
+++ b/crates/youki/src/logger.rs
@@ -55,16 +55,20 @@ pub fn init(
     // crate makes it hard to build a single layer with different conditions.
     match (log_file, log_format) {
         (None, LogFormat::Text) => {
-            // Text to stdout
-            tracing_subscriber::fmt().with_max_level(level).init();
+            // Text to stderr
+            tracing_subscriber::fmt()
+                .with_max_level(level)
+                .with_writer(std::io::stderr)
+                .init();
         }
         (None, LogFormat::Json) => {
-            // JSON to stdout
+            // JSON to stderr
             tracing_subscriber::fmt()
                 .json()
                 .flatten_event(true)
                 .with_span_list(false)
                 .with_max_level(level)
+                .with_writer(std::io::stderr)
                 .init();
         }
         (Some(path), LogFormat::Text) => {

--- a/crates/youki/src/logger.rs
+++ b/crates/youki/src/logger.rs
@@ -58,6 +58,7 @@ pub fn init(
             // Text to stderr
             tracing_subscriber::fmt()
                 .with_max_level(level)
+                .without_time()
                 .with_writer(std::io::stderr)
                 .init();
         }

--- a/crates/youki/src/logger.rs
+++ b/crates/youki/src/logger.rs
@@ -1,15 +1,12 @@
 //! Default Youki Logger
 
 use anyhow::{bail, Context, Result};
-use log::{LevelFilter, Log, Metadata, Record};
-use once_cell::sync::OnceCell;
 use std::borrow::Cow;
-use std::fs::{File, OpenOptions};
-use std::io::{stderr, Write};
+use std::fs::OpenOptions;
 use std::path::PathBuf;
 use std::str::FromStr;
+use tracing::metadata::LevelFilter;
 
-pub static LOG_FILE: OnceCell<Option<File>> = OnceCell::new();
 const LOG_LEVEL_ENV_NAME: &str = "YOUKI_LOG_LEVEL";
 const LOG_FORMAT_TEXT: &str = "text";
 const LOG_FORMAT_JSON: &str = "json";
@@ -25,35 +22,6 @@ const DEFAULT_LOG_LEVEL: &str = "debug";
 /// If not in debug mode, default level is warn to get important logs
 #[cfg(not(debug_assertions))]
 const DEFAULT_LOG_LEVEL: &str = "warn";
-
-/// Initialize the logger, must be called before accessing the logger
-/// Multiple parts might call this at once, but the actual initialization
-/// is done only once due to use of OnceCell
-pub fn init(
-    log_debug_flag: bool,
-    log_file: Option<PathBuf>,
-    log_format: Option<String>,
-) -> Result<()> {
-    let level = detect_log_level(log_debug_flag).context("failed to parse log level")?;
-    let format = detect_log_format(log_format).context("failed to detect log format")?;
-    let _ = LOG_FILE.get_or_init(|| -> Option<File> {
-        log_file.map(|path| {
-            OpenOptions::new()
-                .create(true)
-                .write(true)
-                .truncate(false)
-                .open(path)
-                .expect("failed opening log file")
-        })
-    });
-
-    let logger = YoukiLogger::new(level.to_level(), format);
-    log::set_boxed_logger(Box::new(logger))
-        .map(|()| log::set_max_level(level))
-        .expect("set logger failed");
-
-    Ok(())
-}
 
 fn detect_log_format(log_format: Option<String>) -> Result<LogFormat> {
     match log_format.as_deref() {
@@ -74,91 +42,69 @@ fn detect_log_level(is_debug: bool) -> Result<LevelFilter> {
     Ok(LevelFilter::from_str(filter.as_ref())?)
 }
 
-struct YoukiLogger {
-    /// Indicates level up to which logs are to be printed
-    level: Option<log::Level>,
-    format: LogFormat,
-}
+pub fn init(
+    log_debug_flag: bool,
+    log_file: Option<PathBuf>,
+    log_format: Option<String>,
+) -> Result<()> {
+    let level = detect_log_level(log_debug_flag).context("failed to parse log level")?;
+    let log_format = detect_log_format(log_format).context("failed to detect log format")?;
 
-impl YoukiLogger {
-    /// Create new logger
-    pub fn new(level: Option<log::Level>, format: LogFormat) -> Self {
-        Self { level, format }
-    }
-}
-
-/// Implements Log interface given by log crate, so we can use its functionality
-impl Log for YoukiLogger {
-    /// Check if level of given log is enabled or not
-    fn enabled(&self, metadata: &Metadata) -> bool {
-        if let Some(level) = self.level {
-            metadata.level() <= level
-        } else {
-            false
+    // I really dislike how we have to specify individual branch for each
+    // combination, but I can't find any better way to do this. The tracing
+    // crate makes it hard to build a single layer with different conditions.
+    match (log_file, log_format) {
+        (None, LogFormat::Text) => {
+            // Text to stdout
+            tracing_subscriber::fmt().with_max_level(level).init();
+        }
+        (None, LogFormat::Json) => {
+            // JSON to stdout
+            tracing_subscriber::fmt()
+                .json()
+                .flatten_event(true)
+                .with_span_list(false)
+                .with_max_level(level)
+                .init();
+        }
+        (Some(path), LogFormat::Text) => {
+            // Log file with text format
+            let file = OpenOptions::new()
+                .create(true)
+                .write(true)
+                .truncate(false)
+                .open(path)
+                .with_context(|| "failed to open log file")?;
+            tracing_subscriber::fmt()
+                .with_writer(file)
+                .with_max_level(level)
+                .init();
+        }
+        (Some(path), LogFormat::Json) => {
+            // Log file with JSON format
+            let file = OpenOptions::new()
+                .create(true)
+                .write(true)
+                .truncate(false)
+                .open(path)
+                .with_context(|| "failed to open log file")?;
+            tracing_subscriber::fmt()
+                .json()
+                .flatten_event(true)
+                .with_span_list(false)
+                .with_writer(file)
+                .with_max_level(level)
+                .init();
         }
     }
 
-    /// Function to carry out logging
-    fn log(&self, record: &Record) {
-        if self.enabled(record.metadata()) {
-            let log_msg = match self.format {
-                LogFormat::Text => text_format(record),
-                LogFormat::Json => json_format(record),
-            };
-            // if log file is set, write to it, else write to stderr
-            if let Some(mut log_file) = LOG_FILE.get().unwrap().as_ref() {
-                let _ = writeln!(log_file, "{log_msg}");
-            } else {
-                let _ = writeln!(stderr(), "{log_msg}");
-            }
-        }
-    }
-
-    /// Flush logs to file
-    fn flush(&self) {
-        if let Some(mut log_file) = LOG_FILE.get().unwrap().as_ref() {
-            log_file.flush().expect("failed to flush");
-        } else {
-            stderr().flush().expect("failed to flush");
-        }
-    }
-}
-
-fn json_format(record: &log::Record) -> String {
-    serde_json::to_string(&serde_json::json!({
-        "level": record.level().to_string(),
-        "time": chrono::Local::now().to_rfc3339(),
-        "message": record.args(),
-    }))
-    .expect("serde::to_string with string keys will not fail")
-}
-
-fn text_format(record: &log::Record) -> String {
-    let log_msg = match (record.file(), record.line()) {
-        (Some(file), Some(line)) => format!(
-            "[{} {}:{}] {} {}\r",
-            record.level(),
-            file,
-            line,
-            chrono::Local::now().to_rfc3339(),
-            record.args()
-        ),
-        (_, _) => format!(
-            "[{}] {} {}\r",
-            record.level(),
-            chrono::Local::now().to_rfc3339(),
-            record.args()
-        ),
-    };
-
-    log_msg
+    Ok(())
 }
 
 #[cfg(test)]
 mod tests {
-    use serial_test::serial;
-
     use super::*;
+    use serial_test::serial;
     use std::{env, path::Path};
 
     struct LogLevelGuard {
@@ -186,7 +132,7 @@ mod tests {
     #[test]
     fn test_detect_log_level_is_debug() {
         let _guard = LogLevelGuard::new("error").unwrap();
-        assert_eq!(detect_log_level(true).unwrap(), LevelFilter::Debug)
+        assert_eq!(detect_log_level(true).unwrap(), LevelFilter::DEBUG)
     }
 
     #[test]
@@ -195,9 +141,9 @@ mod tests {
         let _guard = LogLevelGuard::new("error").unwrap();
         env::remove_var(LOG_LEVEL_ENV_NAME);
         if cfg!(debug_assertions) {
-            assert_eq!(detect_log_level(false).unwrap(), LevelFilter::Debug)
+            assert_eq!(detect_log_level(false).unwrap(), LevelFilter::DEBUG)
         } else {
-            assert_eq!(detect_log_level(false).unwrap(), LevelFilter::Warn)
+            assert_eq!(detect_log_level(false).unwrap(), LevelFilter::WARN)
         }
     }
 
@@ -205,15 +151,22 @@ mod tests {
     #[serial]
     fn test_detect_log_level_from_env() {
         let _guard = LogLevelGuard::new("error").unwrap();
-        assert_eq!(detect_log_level(false).unwrap(), LevelFilter::Error)
+        assert_eq!(detect_log_level(false).unwrap(), LevelFilter::ERROR)
     }
 
     #[test]
-    fn test_logfile() {
-        let temp_dir = tempfile::tempdir().expect("failed to create tempdir for logfile");
+    fn test_json_logfile() -> Result<()> {
+        let temp_dir = tempfile::tempdir()?;
         let log_file = Path::join(temp_dir.path(), "test.log");
-
-        init(true, Some(log_file.to_owned()), None).expect("failed to initialize logger");
+        let _guard = LogLevelGuard::new("error").unwrap();
+        // Note, we can only init the tracing once, so we have to test in a
+        // single unit test. The orders are important here.
+        init(
+            false,
+            Some(log_file.to_owned()),
+            Some(LOG_FORMAT_JSON.to_owned()),
+        )
+        .context("failed to initialize logger")?;
         assert!(
             log_file
                 .as_path()
@@ -223,17 +176,26 @@ mod tests {
                 == 0,
             "a new logfile should be empty"
         );
-
-        log::info!("testing this");
-
-        assert!(
-            log_file
-                .as_path()
-                .metadata()
-                .expect("failed to get logfile metadata")
-                .len()
-                > 0,
-            "some log should be written into the logfile"
-        );
+        // Test that info level is not logged into the logfile because we set the log level to error.
+        tracing::info!("testing this");
+        if log_file
+            .as_path()
+            .metadata()
+            .expect("failed to get logfile metadata")
+            .len()
+            != 0
+        {
+            let data = std::fs::read_to_string(&log_file).context("failed to read logfile")?;
+            bail!("info level should not be logged into the logfile, but got: {data}")
+        }
+        // Test that the message logged is actually JSON format.
+        tracing::error!("testing json log");
+        let data = std::fs::read_to_string(&log_file).context("failed to read logfile")?;
+        if data.is_empty() {
+            bail!("logfile should not be empty")
+        }
+        serde_json::from_str::<serde_json::Value>(&data)
+            .context(format!("failed to parse log file content: {data}"))?;
+        Ok(())
     }
 }

--- a/crates/youki/src/main.rs
+++ b/crates/youki/src/main.rs
@@ -83,7 +83,7 @@ fn main() -> Result<()> {
         eprintln!("log init failed: {e:?}");
     }
 
-    log::debug!(
+    tracing::debug!(
         "started by user {} with {:?}",
         nix::unistd::geteuid(),
         std::env::args_os()
@@ -135,7 +135,7 @@ fn main() -> Result<()> {
     };
 
     if let Err(ref e) = cmd_result {
-        log::error!("error in executing command: {:?}", e);
+        tracing::error!("error in executing command: {:?}", e);
     }
     cmd_result
 }

--- a/crates/youki/src/workload/wasmer.rs
+++ b/crates/youki/src/workload/wasmer.rs
@@ -12,7 +12,7 @@ pub struct WasmerExecutor {}
 
 impl Executor for WasmerExecutor {
     fn exec(&self, spec: &Spec) -> Result<()> {
-        log::debug!("Executing workload with wasmer handler");
+        tracing::debug!("Executing workload with wasmer handler");
         let process = spec.process().as_ref();
 
         let args = process.and_then(|p| p.args().as_ref()).unwrap_or(&EMPTY);

--- a/crates/youki/src/workload/wasmtime.rs
+++ b/crates/youki/src/workload/wasmtime.rs
@@ -12,7 +12,7 @@ pub struct WasmtimeExecutor {}
 
 impl Executor for WasmtimeExecutor {
     fn exec(&self, spec: &Spec) -> Result<()> {
-        log::info!("Executing workload with wasmtime handler");
+        tracing::info!("Executing workload with wasmtime handler");
         let process = spec.process().as_ref();
 
         let args = spec

--- a/tests/rust-integration-tests/integration_test/Cargo.toml
+++ b/tests/rust-integration-tests/integration_test/Cargo.toml
@@ -9,7 +9,6 @@ chrono = { version="0.4" }
 flate2 = "1.0"
 libcgroups = { path = "../../../crates/libcgroups" }
 libcontainer = { path = "../../../crates/libcontainer" }
-log = { version = "0.4", features = ["std"] }
 nix = "0.26.2"
 num_cpus = "1.15"
 oci-spec = "0.6.0"
@@ -25,6 +24,8 @@ uuid = "1.3"
 which = "4.4.0"
 tempfile = "3"
 scopeguard = "1.1.0"
+tracing = { version = "0.1.37", features = ["attributes"]}
+tracing-subscriber = { version = "0.3.16", features = ["json", "env-filter"] }
 
 [dependencies.clap]
 version = "4.1.6"

--- a/tests/rust-integration-tests/integration_test/src/logger.rs
+++ b/tests/rust-integration-tests/integration_test/src/logger.rs
@@ -1,8 +1,7 @@
 use anyhow::{Context, Result};
-use log::{LevelFilter, Log, Metadata, Record};
 use std::borrow::Cow;
-use std::io::{stderr, Write};
 use std::str::FromStr;
+use tracing::metadata::LevelFilter;
 
 const LOG_LEVEL_ENV_NAME: &str = "YOUKI_INTEGRATION_LOG_LEVEL";
 
@@ -11,10 +10,7 @@ const LOG_LEVEL_ENV_NAME: &str = "YOUKI_INTEGRATION_LOG_LEVEL";
 /// is done only once due to use of OnceCell
 pub fn init(debug: bool) -> Result<()> {
     let level = detect_log_level(debug).context("failed to parse log level")?;
-    let logger = IntegrationLogger::new(level.to_level());
-    log::set_boxed_logger(Box::new(logger))
-        .map(|()| log::set_max_level(level))
-        .expect("set logger failed");
+    tracing_subscriber::fmt().with_max_level(level).init();
 
     Ok(())
 }
@@ -29,63 +25,4 @@ fn detect_log_level(is_debug: bool) -> Result<LevelFilter> {
     };
 
     Ok(LevelFilter::from_str(filter.as_ref())?)
-}
-
-struct IntegrationLogger {
-    /// Indicates level up to which logs are to be printed
-    level: Option<log::Level>,
-}
-
-impl IntegrationLogger {
-    /// Create new logger
-    pub fn new(level: Option<log::Level>) -> Self {
-        Self { level }
-    }
-}
-
-/// Implements Log interface given by log crate, so we can use its functionality
-impl Log for IntegrationLogger {
-    /// Check if level of given log is enabled or not
-    fn enabled(&self, metadata: &Metadata) -> bool {
-        if let Some(level) = self.level {
-            metadata.level() <= level
-        } else {
-            false
-        }
-    }
-
-    /// Function to carry out logging
-    fn log(&self, record: &Record) {
-        if self.enabled(record.metadata()) {
-            let log_msg = text_format(record);
-            // if log file is set, write to it, else write to stderr
-            let _ = writeln!(stderr(), "{log_msg}");
-        }
-    }
-
-    /// Flush logs to file
-    fn flush(&self) {
-        stderr().flush().expect("failed to flush");
-    }
-}
-
-fn text_format(record: &log::Record) -> String {
-    let log_msg = match (record.file(), record.line()) {
-        (Some(file), Some(line)) => format!(
-            "[{} {}:{}] {} {}\r",
-            record.level(),
-            file,
-            line,
-            chrono::Local::now().to_rfc3339(),
-            record.args()
-        ),
-        (_, _) => format!(
-            "[{}] {} {}\r",
-            record.level(),
-            chrono::Local::now().to_rfc3339(),
-            record.args()
-        ),
-    };
-
-    log_msg
 }

--- a/tests/rust-integration-tests/integration_test/src/tests/cgroups/cpu/v2.rs
+++ b/tests/rust-integration-tests/integration_test/src/tests/cgroups/cpu/v2.rs
@@ -16,9 +16,9 @@ use libcgroups::{
     v2::controller_type::ControllerType,
 };
 use libcontainer::utils::PathBufExt;
-use log::debug;
 use oci_spec::runtime::{LinuxCpuBuilder, Spec};
 use test_framework::{assert_result_eq, test_result, ConditionalTest, TestGroup, TestResult};
+use tracing::debug;
 
 use super::create_spec;
 
@@ -317,7 +317,7 @@ fn read_cgroup_data(cgroup_name: &str, cgroup_file: &str) -> Result<String> {
         .join(cgroup_name)
         .join(cgroup_file);
 
-    log::debug!("reading value from {:?}", cgroup_path);
+    debug!("reading value from {:?}", cgroup_path);
     let content = fs::read_to_string(&cgroup_path)
         .with_context(|| format!("failed to read {cgroup_path:?}"))?;
     let trimmed = content.trim();


### PR DESCRIPTION
This PR converts youki to use `tracing` crate for logging. I did the minimal to make the transition, but `tracing` crate allows for much richer logging and instrumentation. This is related to #1348 in that this would be a pre-requirement to implement open-telemetry.

In addition, the reason I decide to do this now because error handling can be difficult without tracing/logging support. In general with error handling, the audience are either the user/operator (human) or for code to handle. It is important to log as much as possible of the context of an error. There are usually 2 choices. Either we store the context of the error into the error itself, or we log the context and keep the error size small. There is no right answer and usually we need a combination of both. `tracing` crate allows us to minimize the context we have to store inside the error itself, and instead opting for rich logging.

Note, I tried to keep the change minimal, but switching logging infrastructure does have a wide impact. Hopefully this is not too disruptive to people. 