### PR TITLE
deps: do not use chrono default-features.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -392,12 +392,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4e3c5919066adf22df73762e50cffcde3a758f2a848b113b586d1f86728b673b"
 dependencies = [
  "iana-time-zone",
- "js-sys",
  "num-integer",
  "num-traits",
  "serde",
- "time 0.1.45",
- "wasm-bindgen",
  "winapi",
 ]
 

--- a/crates/libcontainer/Cargo.toml
+++ b/crates/libcontainer/Cargo.toml
@@ -23,7 +23,7 @@ cgroupsv2_devices = ["libcgroups/cgroupsv2_devices"]
 anyhow = "1.0"
 bitflags = "2.2.1"
 caps = "0.5.5"
-chrono = { version = "0.4", features = ["serde"] }
+chrono = { version = "0.4", default-features = false, features = ["clock", "serde"] }
 crossbeam-channel = "0.5"
 fastrand = "^1.7.0"
 futures = { version = "0.3", features = ["thread-pool"] }

--- a/crates/youki/Cargo.toml
+++ b/crates/youki/Cargo.toml
@@ -27,7 +27,7 @@ features = ["std", "suggestions", "derive", "cargo", "help", "usage", "error-con
 
 [dependencies]
 anyhow = "1.0.71"
-chrono = { version = "0.4", features = ["serde"] }
+chrono = { version = "0.4", default-features = false, features = ["clock", "serde"] }
 libcgroups = { version = "0.0.5", path = "../libcgroups", default-features = false }
 libcontainer = { version = "0.0.5", path = "../libcontainer", default-features = false }
 liboci-cli = { version = "0.0.5", path = "../liboci-cli" }

--- a/tests/rust-integration-tests/integration_test/Cargo.toml
+++ b/tests/rust-integration-tests/integration_test/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0"
-chrono = { version="0.4" }
+chrono = { version = "0.4", default-features = false, features = ["clock"] }
 flate2 = "1.0"
 libcgroups = { path = "../../../crates/libcgroups" }
 libcontainer = { path = "../../../crates/libcontainer" }


### PR DESCRIPTION
Make `chrono` dependency not use default features. This is because that's the recommended workaround for a `time` crate [vulnerability](https://rustsec.org/advisories/RUSTSEC-2020-0071).