### PR TITLE
[Trivial] fix dependency for fedora

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ $ sudo dnf install   \
       dbus-devel     \
       elfutils-libelf-devel \
       libseccomp-devel \
-      libclang-dev
+      clang-devel
 ```
 
 ## Build

--- a/docs/src/user/basic_setup.md
+++ b/docs/src/user/basic_setup.md
@@ -36,7 +36,7 @@ $ sudo dnf install   \
       dbus-devel     \
       elfutils-libelf-devel \
       libseccomp-devel \
-      libclang-dev
+      clang-devel
 ```
 
 ---


### PR DESCRIPTION
Not sure if this is a typo or package name is changed, but `libclang-dev` does not exist on dns packages. Change to the correct name and verified on Fedora 38.