### PR TITLE
Use safe_path crate instead of our original secure_join

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1968,6 +1968,7 @@ dependencies = [
  "rand",
  "regex",
  "rust-criu",
+ "safe-path",
  "serde",
  "serde_json",
  "serial_test",
@@ -3144,6 +3145,15 @@ name = "ryu"
 version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
+
+[[package]]
+name = "safe-path"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "980abdd3220aa19b67ca3ea07b173ca36383f18ae48cde696d90c8af39447ffb"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "same-file"

--- a/crates/libcontainer/Cargo.toml
+++ b/crates/libcontainer/Cargo.toml
@@ -45,6 +45,7 @@ clone3 = "0.2.3"
 regex = "1.7.3"
 thiserror = "1.0.24"
 tracing = { version = "0.1.37", features = ["attributes"]}
+safe-path = "0.1.0"
 
 [dev-dependencies]
 oci-spec = { version = "^0.6.0", features = ["proptests", "runtime"] }

--- a/crates/libcontainer/src/rootfs/device.rs
+++ b/crates/libcontainer/src/rootfs/device.rs
@@ -1,6 +1,6 @@
 use super::utils::to_sflag;
 use crate::syscall::{syscall::create_syscall, Syscall};
-use crate::utils::{self, PathBufExt};
+use crate::utils::PathBufExt;
 use anyhow::{bail, Context, Result};
 use nix::{
     fcntl::{open, OFlag},
@@ -109,7 +109,7 @@ fn create_container_dev_path(rootfs: &Path, dev: &LinuxDevice) -> Result<PathBuf
         .path()
         .as_relative()
         .with_context(|| format!("could not convert {:?} to relative path", dev.path()))?;
-    let full_container_path = utils::secure_join(rootfs, relative_dev_path)
+    let full_container_path = safe_path::scoped_join(rootfs, relative_dev_path)
         .with_context(|| format!("could not join {:?} with {:?}", rootfs, dev.path()))?;
 
     crate::utils::create_dir_all(

--- a/crates/libcontainer/src/rootfs/mount.rs
+++ b/crates/libcontainer/src/rootfs/mount.rs
@@ -3,7 +3,6 @@ use super::symlink::Symlink;
 use super::utils::{find_parent_mount, parse_mount, MountOptionConfig};
 use crate::{
     syscall::{linux, syscall::create_syscall, Syscall, SyscallError},
-    utils,
     utils::PathBufExt,
 };
 #[cfg(feature = "v2")]
@@ -15,6 +14,7 @@ use libcgroups::common::DEFAULT_CGROUP_ROOT;
 use nix::{dir::Dir, errno::Errno, fcntl::OFlag, mount::MsFlags, sys::stat::Mode};
 use oci_spec::runtime::{Mount as SpecMount, MountBuilder as SpecMountBuilder};
 use procfs::process::{MountInfo, MountOptFields, Process};
+use safe_path;
 use std::fs::{canonicalize, create_dir_all, OpenOptions};
 use std::mem;
 use std::os::unix::io::AsRawFd;
@@ -380,7 +380,7 @@ impl Mount {
             }
         }
 
-        let dest_for_host = utils::secure_join(rootfs, m.destination())
+        let dest_for_host = safe_path::scoped_join(rootfs, m.destination())
             .with_context(|| format!("failed to join {:?} with {:?}", rootfs, m.destination()))?;
 
         let dest = Path::new(&dest_for_host);

--- a/tests/k8s/deploy.yaml
+++ b/tests/k8s/deploy.yaml
@@ -24,4 +24,3 @@ spec:
         image: nginx:1.16.1
         ports:
         - containerPort: 80
-      automountServiceAccountToken: false


### PR DESCRIPTION
Our secure_join had a bug and did not work perfectly with K8s. It did not take into account the case where the symbolic destination is an absolute path. 
https://github.com/cyphar/filepath-securejoin/blob/64536a8a66ae59588c981e2199f1dcf410508e07/join.go#L97-L99

Thus there are many cases where secure_join should be considered; it would be more worthwhile to use safe_path, which kata-container makes, and mature this one.

Fix: https://github.com/containers/youki/issues/1890

https://docs.rs/safe-path/latest/safe_path/