### PR TITLE
Implemented `thiserror` for libcontainer - Part 4

### DIFF
--- a/crates/libcontainer/src/container/container.rs
+++ b/crates/libcontainer/src/container/container.rs
@@ -199,7 +199,9 @@ impl Container {
 
     pub fn save(&self) -> Result<()> {
         tracing::debug!("Save container status: {:?} in {:?}", self, self.root);
-        self.state.save(&self.root)
+        self.state.save(&self.root)?;
+
+        Ok(())
     }
 
     pub fn spec(&self) -> Result<YoukiConfig> {

--- a/crates/libcontainer/src/error.rs
+++ b/crates/libcontainer/src/error.rs
@@ -10,3 +10,13 @@ pub enum UnifiedSyscallError {
     #[error(transparent)]
     Syscall(#[from] crate::syscall::SyscallError),
 }
+
+#[derive(Debug, thiserror::Error)]
+pub enum MissingSpecError {
+    #[error("missing process in spec")]
+    MissingProcess,
+    #[error("missing linux in spec")]
+    MissingLinux,
+    #[error("missing args in the process spec")]
+    MissingArgs,
+}

--- a/crates/libcontainer/src/process/container_init_process.rs
+++ b/crates/libcontainer/src/process/container_init_process.rs
@@ -1,11 +1,11 @@
 use super::args::{ContainerArgs, ContainerType};
-use crate::apparmor;
+use crate::namespaces::NamespaceError;
 use crate::syscall::{Syscall, SyscallError};
+use crate::{apparmor, notify_socket, rootfs, workload};
 use crate::{
     capabilities, hooks, namespaces::Namespaces, process::channel, rootfs::RootFS,
     rootless::Rootless, tty, utils,
 };
-use anyhow::{bail, Context, Ok, Result};
 use nix::mount::MsFlags;
 use nix::sched::CloneFlags;
 use nix::sys::stat::Mode;
@@ -22,8 +22,125 @@ use std::{
 #[cfg(feature = "libseccomp")]
 use crate::seccomp;
 
-#[cfg(not(feature = "libseccomp"))]
-use tracing::warn;
+#[derive(Debug, thiserror::Error)]
+pub enum InitProcessError {
+    #[error("failed to set sysctl")]
+    Sysctl(#[source] std::io::Error),
+    #[error("failed to mount path as readonly")]
+    MountPathReadonly(#[source] SyscallError),
+    #[error("failed to mount path as masked")]
+    MountPathMasked(#[source] SyscallError),
+    #[error(transparent)]
+    Namespaces(#[from] NamespaceError),
+    #[error("failed to set hostname")]
+    SetHostname(#[source] SyscallError),
+    #[error("failed to set domainname")]
+    SetDomainname(#[source] SyscallError),
+    #[error("failed to reopen /dev/null")]
+    ReopenDevNull(#[source] std::io::Error),
+    #[error("failed to unix syscall")]
+    NixOther(#[source] nix::Error),
+    #[error("no linux in spec")]
+    NoLinuxSpec,
+    #[error("no process in spec")]
+    NoProcessSpec,
+    #[error("failed to setup tty")]
+    Tty(#[source] tty::TTYError),
+    #[error("failed to run hooks")]
+    Hooks(#[from] hooks::HookError),
+    #[error("failed to prepare rootfs")]
+    RootFS(#[source] rootfs::RootfsError),
+    #[error("failed syscall")]
+    SyscallOther(#[source] SyscallError),
+    #[error("failed apparmor")]
+    AppArmor(#[source] apparmor::AppArmorError),
+    #[error("invalid umask")]
+    InvalidUmask(u32),
+    #[error(transparent)]
+    Seccomp(#[from] seccomp::SeccompError),
+    #[error("invalid executable: {0}")]
+    InvalidExecutable(String),
+    #[error("io error")]
+    Io(#[source] std::io::Error),
+    #[error("no args in spec")]
+    NoArgs,
+    #[error(transparent)]
+    Channel(#[from] channel::ChannelError),
+    #[error("setgroup is disabled")]
+    SetGroupDisabled,
+    #[error(transparent)]
+    NotifyListener(#[from] notify_socket::NotifyListenerError),
+    #[error(transparent)]
+    Workload(#[from] workload::ExecutorManagerError),
+}
+
+type Result<T> = std::result::Result<T, InitProcessError>;
+
+fn get_executable_path(name: &str, path_var: &str) -> Option<PathBuf> {
+    // if path has / in it, we have to assume absolute path, as per runc impl
+    if name.contains('/') && PathBuf::from(name).exists() {
+        return Some(PathBuf::from(name));
+    }
+    for path in path_var.split(':') {
+        let potential_path = PathBuf::from(path).join(name);
+        if potential_path.exists() {
+            return Some(potential_path);
+        }
+    }
+    None
+}
+
+fn is_executable(path: &Path) -> std::result::Result<bool, std::io::Error> {
+    use std::os::unix::fs::PermissionsExt;
+    let metadata = path.metadata()?;
+    let permissions = metadata.permissions();
+    // we have to check if the path is file and the execute bit
+    // is set. In case of directories, the execute bit is also set,
+    // so have to check if this is a file or not
+    Ok(metadata.is_file() && permissions.mode() & 0o001 != 0)
+}
+
+// this checks if the binary to run actually exists and if we have
+// permissions to run it.  Taken from
+// https://github.com/opencontainers/runc/blob/25c9e888686773e7e06429133578038a9abc091d/libcontainer/standard_init_linux.go#L195-L206
+fn verify_binary(args: &[String], envs: &[String]) -> Result<()> {
+    let path_vars: Vec<&String> = envs.iter().filter(|&e| e.starts_with("PATH=")).collect();
+    if path_vars.is_empty() {
+        tracing::error!("PATH environment variable is not set");
+        return Err(InitProcessError::InvalidExecutable(args[0].clone()));
+    }
+    let path_var = path_vars[0].trim_start_matches("PATH=");
+    match get_executable_path(&args[0], path_var) {
+        None => {
+            tracing::error!(
+                "executable {} for container process not found in PATH",
+                args[0]
+            );
+            return Err(InitProcessError::InvalidExecutable(args[0].clone()));
+        }
+        Some(path) => match is_executable(&path) {
+            Ok(true) => {
+                tracing::debug!("found executable {:?}", path);
+            }
+            Ok(false) => {
+                tracing::error!(
+                    "executable {:?} does not have the correct permission set",
+                    path
+                );
+                return Err(InitProcessError::InvalidExecutable(args[0].clone()));
+            }
+            Err(err) => {
+                tracing::error!(
+                    "failed to check permissions for executable {:?}: {}",
+                    path,
+                    err
+                );
+                return Err(InitProcessError::Io(err));
+            }
+        },
+    }
+    Ok(())
+}
 
 fn sysctl(kernel_params: &HashMap<String, String>) -> Result<()> {
     let sys = PathBuf::from("/proc/sys");
@@ -34,8 +151,10 @@ fn sysctl(kernel_params: &HashMap<String, String>) -> Result<()> {
             value,
             kernel_param
         );
-        fs::write(path, value.as_bytes())
-            .with_context(|| format!("failed to set sysctl {kernel_param}={value}"))?;
+        fs::write(path, value.as_bytes()).map_err(|err| {
+            tracing::error!("failed to set sysctl {kernel_param}={value}: {err}");
+            InitProcessError::Sysctl(err)
+        })?;
     }
 
     Ok(())
@@ -53,29 +172,34 @@ fn readonly_path(path: &Path, syscall: &dyn Syscall) -> Result<()> {
         MsFlags::MS_BIND | MsFlags::MS_REC,
         None,
     ) {
-        match err {
-            SyscallError::Mount { source: errno } => {
-                // ignore error if path is not exist.
-                if matches!(errno, nix::errno::Errno::ENOENT) {
-                    return Ok(());
-                }
+        if let SyscallError::Mount { source: errno } = err {
+            // ignore error if path is not exist.
+            if matches!(errno, nix::errno::Errno::ENOENT) {
+                return Ok(());
             }
-            _ => bail!(err),
         }
+
+        tracing::error!(?path, ?err, "failed to mount path as readonly");
+        return Err(InitProcessError::MountPathReadonly(err));
     }
 
-    syscall.mount(
-        Some(path),
-        path,
-        None,
-        MsFlags::MS_NOSUID
-            | MsFlags::MS_NODEV
-            | MsFlags::MS_NOEXEC
-            | MsFlags::MS_BIND
-            | MsFlags::MS_REMOUNT
-            | MsFlags::MS_RDONLY,
-        None,
-    )?;
+    syscall
+        .mount(
+            Some(path),
+            path,
+            None,
+            MsFlags::MS_NOSUID
+                | MsFlags::MS_NODEV
+                | MsFlags::MS_NOEXEC
+                | MsFlags::MS_BIND
+                | MsFlags::MS_REMOUNT
+                | MsFlags::MS_RDONLY,
+            None,
+        )
+        .map_err(|err| {
+            tracing::error!(?path, ?err, "failed to remount path as readonly");
+            InitProcessError::MountPathReadonly(err)
+        })?;
 
     tracing::debug!("readonly path {:?} mounted", path);
     Ok(())
@@ -92,28 +216,40 @@ fn masked_path(path: &Path, mount_label: &Option<String>, syscall: &dyn Syscall)
         None,
     ) {
         match err {
-            SyscallError::Mount { source: errno } => match errno {
-                nix::errno::Errno::ENOENT => {
-                    tracing::warn!("masked path {:?} not exist", path);
-                }
-                nix::errno::Errno::ENOTDIR => {
-                    let label = match mount_label {
-                        Some(l) => format!("context=\"{l}\""),
-                        None => "".to_string(),
-                    };
-                    syscall.mount(
+            SyscallError::Mount {
+                source: nix::errno::Errno::ENOENT,
+            } => {
+                // ignore error if path is not exist.
+                tracing::warn!("masked path {:?} not exist", path);
+            }
+            SyscallError::Mount {
+                source: nix::errno::Errno::ENOTDIR,
+            } => {
+                let label = match mount_label {
+                    Some(l) => format!("context=\"{l}\""),
+                    None => "".to_string(),
+                };
+                syscall
+                    .mount(
                         Some(Path::new("tmpfs")),
                         path,
                         Some("tmpfs"),
                         MsFlags::MS_RDONLY,
                         Some(label.as_str()),
-                    )?;
-                }
-                _ => {
-                    bail!(err)
-                }
-            },
-            _ => bail!(err),
+                    )
+                    .map_err(|err| {
+                        tracing::error!(?path, ?err, "failed to mount path as masked using tempfs");
+                        InitProcessError::MountPathMasked(err)
+                    })?;
+            }
+            _ => {
+                tracing::error!(
+                    ?path,
+                    ?err,
+                    "failed to mount path as masked using /dev/null"
+                );
+                return Err(InitProcessError::MountPathMasked(err));
+            }
         }
     }
 
@@ -133,17 +269,29 @@ fn apply_rest_namespaces(
         .apply_namespaces(|ns_type| -> bool {
             ns_type != CloneFlags::CLONE_NEWUSER && ns_type != CloneFlags::CLONE_NEWPID
         })
-        .with_context(|| "failed to apply namespaces")?;
+        .map_err(|err| {
+            tracing::error!(
+                ?err,
+                "failed to apply rest of the namespaces (exclude user and pid)"
+            );
+            InitProcessError::Namespaces(err)
+        })?;
 
     // Only set the host name if entering into a new uts namespace
     if let Some(uts_namespace) = namespaces.get(LinuxNamespaceType::Uts) {
         if uts_namespace.path().is_none() {
             if let Some(hostname) = spec.hostname() {
-                syscall.set_hostname(hostname)?;
+                syscall.set_hostname(hostname).map_err(|err| {
+                    tracing::error!(?err, ?hostname, "failed to set hostname");
+                    InitProcessError::SetHostname(err)
+                })?;
             }
 
             if let Some(domainname) = spec.domainname() {
-                syscall.set_domainname(domainname)?;
+                syscall.set_domainname(domainname).map_err(|err| {
+                    tracing::error!(?err, ?domainname, "failed to set domainname");
+                    InitProcessError::SetDomainname(err)
+                })?;
             }
         }
     }
@@ -155,23 +303,35 @@ fn reopen_dev_null() -> Result<()> {
     // we can re-open /dev/null if it is in use to the /dev/null
     // in the container.
 
-    let dev_null = fs::File::open("/dev/null")?;
-    let dev_null_fstat_info = nix::sys::stat::fstat(dev_null.as_raw_fd())?;
+    let dev_null = fs::File::open("/dev/null").map_err(|err| {
+        tracing::error!(?err, "failed to open /dev/null inside the container");
+        InitProcessError::ReopenDevNull(err)
+    })?;
+    let dev_null_fstat_info = nix::sys::stat::fstat(dev_null.as_raw_fd()).map_err(|err| {
+        tracing::error!(?err, "failed to fstat /dev/null inside the container");
+        InitProcessError::NixOther(err)
+    })?;
 
     // Check if stdin, stdout or stderr point to /dev/null
     for fd in 0..3 {
-        let fstat_info = nix::sys::stat::fstat(fd)?;
+        let fstat_info = nix::sys::stat::fstat(fd).map_err(|err| {
+            tracing::error!(?err, "failed to fstat stdio fd {}", fd);
+            InitProcessError::NixOther(err)
+        })?;
 
         if dev_null_fstat_info.st_rdev == fstat_info.st_rdev {
             // This FD points to /dev/null outside of the container.
             // Let's point to /dev/null inside of the container.
-            nix::unistd::dup2(dev_null.as_raw_fd(), fd)?;
+            nix::unistd::dup2(dev_null.as_raw_fd(), fd).map_err(|err| {
+                tracing::error!(?err, "failed to dup2 fd {} to /dev/null", fd);
+                InitProcessError::NixOther(err)
+            })?;
         }
     }
+
     Ok(())
 }
 
-#[allow(unused_variables)]
 pub fn container_init_process(
     args: &ContainerArgs,
     main_sender: &mut channel::MainSender,
@@ -179,18 +339,27 @@ pub fn container_init_process(
 ) -> Result<()> {
     let syscall = args.syscall;
     let spec = args.spec;
-    let linux = spec.linux().as_ref().context("no linux in spec")?;
-    let proc = spec.process().as_ref().context("no process in spec")?;
+    let linux = spec.linux().as_ref().ok_or(InitProcessError::NoLinuxSpec)?;
+    let proc = spec
+        .process()
+        .as_ref()
+        .ok_or(InitProcessError::NoProcessSpec)?;
     let mut envs: Vec<String> = proc.env().as_ref().unwrap_or(&vec![]).clone();
     let rootfs_path = args.rootfs;
     let hooks = spec.hooks().as_ref();
     let container = args.container.as_ref();
     let namespaces = Namespaces::from(linux.namespaces().as_ref());
 
-    setsid().context("failed to create session")?;
+    setsid().map_err(|err| {
+        tracing::error!(?err, "failed to setsid to create a session");
+        InitProcessError::NixOther(err)
+    })?;
     // set up tty if specified
     if let Some(csocketfd) = args.console_socket {
-        tty::setup_console(&csocketfd).with_context(|| "failed to set up tty")?;
+        tty::setup_console(&csocketfd).map_err(|err| {
+            tracing::error!(?err, "failed to set up tty");
+            InitProcessError::Tty(err)
+        })?;
     }
 
     apply_rest_namespaces(&namespaces, spec, syscall)?;
@@ -203,8 +372,10 @@ pub fn container_init_process(
         // create_container hook needs to be called after the namespace setup, but
         // before pivot_root is called. This runs in the container namespaces.
         if let Some(hooks) = hooks {
-            hooks::run_hooks(hooks.create_container().as_ref(), container)
-                .context("failed to run create container hooks")?;
+            hooks::run_hooks(hooks.create_container().as_ref(), container).map_err(|err| {
+                tracing::error!(?err, "failed to run create container hooks");
+                InitProcessError::Hooks(err)
+            })?;
         }
 
         let bind_service = namespaces.get(LinuxNamespaceType::User).is_some();
@@ -216,7 +387,10 @@ pub fn container_init_process(
                 bind_service,
                 namespaces.get(LinuxNamespaceType::Cgroup).is_some(),
             )
-            .with_context(|| "failed to prepare rootfs")?;
+            .map_err(|err| {
+                tracing::error!(?err, "failed to prepare rootfs");
+                InitProcessError::RootFS(err)
+            })?;
 
         // Entering into the rootfs jail. If mount namespace is specified, then
         // we use pivot_root, but if we are on the host mount namespace, we will
@@ -224,63 +398,82 @@ pub fn container_init_process(
         // in the host mount namespace...
         if namespaces.get(LinuxNamespaceType::Mount).is_some() {
             // change the root of filesystem of the process to the rootfs
-            syscall
-                .pivot_rootfs(rootfs_path)
-                .with_context(|| format!("failed to pivot root to {rootfs_path:?}"))?;
+            syscall.pivot_rootfs(rootfs_path).map_err(|err| {
+                tracing::error!(?err, ?rootfs_path, "failed to pivot root");
+                InitProcessError::SyscallOther(err)
+            })?;
         } else {
-            syscall
-                .chroot(rootfs_path)
-                .with_context(|| format!("failed to chroot to {rootfs_path:?}"))?;
+            syscall.chroot(rootfs_path).map_err(|err| {
+                tracing::error!(?err, ?rootfs_path, "failed to chroot");
+                InitProcessError::SyscallOther(err)
+            })?;
         }
 
-        rootfs
-            .adjust_root_mount_propagation(linux)
-            .context("failed to set propagation type of root mount")?;
+        rootfs.adjust_root_mount_propagation(linux).map_err(|err| {
+            tracing::error!(?err, "failed to adjust root mount propagation");
+            InitProcessError::RootFS(err)
+        })?;
 
-        reopen_dev_null()?;
+        reopen_dev_null().map_err(|err| {
+            tracing::error!(?err, "failed to reopen /dev/null");
+            err
+        })?;
 
         if let Some(kernel_params) = linux.sysctl() {
-            sysctl(kernel_params)
-                .with_context(|| format!("failed to sysctl: {kernel_params:?}"))?;
+            sysctl(kernel_params)?;
         }
     }
 
     if let Some(profile) = proc.apparmor_profile() {
-        apparmor::apply_profile(profile)
-            .with_context(|| format!("failed to apply apparmor profile {profile}"))?;
+        apparmor::apply_profile(profile).map_err(|err| {
+            tracing::error!(?err, "failed to apply apparmor profile");
+            InitProcessError::AppArmor(err)
+        })?;
     }
 
     if let Some(true) = spec.root().as_ref().map(|r| r.readonly().unwrap_or(false)) {
-        syscall.mount(
-            None,
-            Path::new("/"),
-            None,
-            MsFlags::MS_RDONLY | MsFlags::MS_REMOUNT | MsFlags::MS_BIND,
-            None,
-        )?
+        syscall
+            .mount(
+                None,
+                Path::new("/"),
+                None,
+                MsFlags::MS_RDONLY | MsFlags::MS_REMOUNT | MsFlags::MS_BIND,
+                None,
+            )
+            .map_err(|err| {
+                tracing::error!(?err, "failed to remount root `/` as readonly");
+                InitProcessError::SyscallOther(err)
+            })?;
     }
 
     if let Some(umask) = proc.user().umask() {
-        if let Some(mode) = Mode::from_bits(umask) {
-            nix::sys::stat::umask(mode);
-        } else {
-            bail!("invalid umask {}", umask);
+        match Mode::from_bits(umask) {
+            Some(mode) => {
+                nix::sys::stat::umask(mode);
+            }
+            None => {
+                return Err(InitProcessError::InvalidUmask(umask));
+            }
         }
     }
 
     if let Some(paths) = linux.readonly_paths() {
         // mount readonly path
         for path in paths {
-            readonly_path(Path::new(path), syscall)
-                .with_context(|| format!("failed to set read only path {path:?}"))?;
+            readonly_path(Path::new(path), syscall).map_err(|err| {
+                tracing::error!(?err, ?path, "failed to set readonly path");
+                err
+            })?;
         }
     }
 
     if let Some(paths) = linux.masked_paths() {
         // mount masked path
         for path in paths {
-            masked_path(Path::new(path), linux.mount_label(), syscall)
-                .with_context(|| format!("failed to set masked path {path:?}"))?;
+            masked_path(Path::new(path), linux.mount_label(), syscall).map_err(|err| {
+                tracing::error!(?err, ?path, "failed to set masked path");
+                err
+            })?;
         }
     }
 
@@ -294,19 +487,29 @@ pub fn container_init_process(
         match unistd::chdir(proc.cwd()) {
             std::result::Result::Ok(_) => false,
             Err(nix::Error::EPERM) => true,
-            Err(e) => bail!("failed to chdir: {}", e),
+            Err(e) => {
+                tracing::error!(?e, "failed to chdir");
+                return Err(InitProcessError::NixOther(e));
+            }
         }
     };
 
-    set_supplementary_gids(proc.user(), args.rootless, syscall)
-        .context("failed to set supplementary gids")?;
+    set_supplementary_gids(proc.user(), args.rootless, syscall).map_err(|err| {
+        tracing::error!(?err, "failed to set supplementary gids");
+        err
+    })?;
 
     syscall
         .set_id(
             Uid::from_raw(proc.user().uid()),
             Gid::from_raw(proc.user().gid()),
         )
-        .context("failed to configure uid and gid")?;
+        .map_err(|err| {
+            let uid = proc.user().uid();
+            let gid = proc.user().gid();
+            tracing::error!(?err, ?uid, ?gid, "failed to set uid and gid");
+            InitProcessError::SyscallOther(err)
+        })?;
 
     // Take care of LISTEN_FDS used for systemd-active-socket. If the value is
     // not 0, then we have to preserve those fds as well, and set up the correct
@@ -355,9 +558,10 @@ pub fn container_init_process(
     // will be closed after execve into the container payload. We can't close the
     // fds immediately since we at least still need it for the pipe used to wait on
     // starting the container.
-    syscall
-        .close_range(preserve_fds)
-        .with_context(|| "failed to clean up extra fds")?;
+    syscall.close_range(preserve_fds).map_err(|err| {
+        tracing::error!(?err, "failed to cleanup extra fds");
+        InitProcessError::SyscallOther(err)
+    })?;
 
     // Without no new privileges, seccomp is a privileged operation. We have to
     // do this before dropping capabilities. Otherwise, we should do it later,
@@ -365,25 +569,39 @@ pub fn container_init_process(
     #[cfg(feature = "libseccomp")]
     if let Some(seccomp) = linux.seccomp() {
         if proc.no_new_privileges().is_none() {
-            let notify_fd =
-                seccomp::initialize_seccomp(seccomp).context("failed to execute seccomp")?;
-            sync_seccomp(notify_fd, main_sender, init_receiver)
-                .context("failed to sync seccomp")?;
+            let notify_fd = seccomp::initialize_seccomp(seccomp).map_err(|err| {
+                tracing::error!(?err, "failed to initialize seccomp");
+                err
+            })?;
+            sync_seccomp(notify_fd, main_sender, init_receiver).map_err(|err| {
+                tracing::error!(?err, "failed to sync seccomp");
+                err
+            })?;
         }
     }
     #[cfg(not(feature = "libseccomp"))]
     if proc.no_new_privileges().is_none() {
-        warn!("seccomp not available, unable to enforce no_new_privileges!")
+        tracing::warn!("seccomp not available, unable to enforce no_new_privileges!")
     }
 
-    capabilities::reset_effective(syscall).context("failed to reset effective capabilities")?;
+    capabilities::reset_effective(syscall).map_err(|err| {
+        tracing::error!(?err, "failed to reset effective capabilities");
+        InitProcessError::SyscallOther(err)
+    })?;
     if let Some(caps) = proc.capabilities() {
-        capabilities::drop_privileges(caps, syscall).context("failed to drop capabilities")?;
+        capabilities::drop_privileges(caps, syscall).map_err(|err| {
+            tracing::error!(?err, "failed to drop capabilities");
+            InitProcessError::SyscallOther(err)
+        })?;
     }
 
     // Change directory to process.cwd if process.cwd is not empty
     if do_chdir {
-        unistd::chdir(proc.cwd()).with_context(|| format!("failed to chdir {:?}", proc.cwd()))?;
+        unistd::chdir(proc.cwd()).map_err(|err| {
+            let cwd = proc.cwd();
+            tracing::error!(?err, ?cwd, "failed to chdir to cwd");
+            InitProcessError::NixOther(err)
+        })?;
     }
 
     // add HOME into envs if not exists
@@ -406,69 +624,73 @@ pub fn container_init_process(
     #[cfg(feature = "libseccomp")]
     if let Some(seccomp) = linux.seccomp() {
         if proc.no_new_privileges().is_some() {
-            let notify_fd =
-                seccomp::initialize_seccomp(seccomp).context("failed to execute seccomp")?;
-            sync_seccomp(notify_fd, main_sender, init_receiver)
-                .context("failed to sync seccomp")?;
+            let notify_fd = seccomp::initialize_seccomp(seccomp).map_err(|err| {
+                tracing::error!(?err, "failed to initialize seccomp");
+                err
+            })?;
+            sync_seccomp(notify_fd, main_sender, init_receiver).map_err(|err| {
+                tracing::error!(?err, "failed to sync seccomp");
+                err
+            })?;
         }
     }
     #[cfg(not(feature = "libseccomp"))]
     if proc.no_new_privileges().is_some() {
-        warn!("seccomp not available, unable to set seccomp privileges!")
+        tracing::warn!("seccomp not available, unable to set seccomp privileges!")
     }
 
-    // this checks if the binary to run actually exists and if we have permissions to run it.
-    // Taken from https://github.com/opencontainers/runc/blob/25c9e888686773e7e06429133578038a9abc091d/libcontainer/standard_init_linux.go#L195-L206
     if let Some(args) = proc.args() {
-        let path_var = {
-            let mut ret: &str = "";
-            for var in &envs {
-                if var.starts_with("PATH=") {
-                    ret = var;
-                }
-            }
-            ret
-        };
-        let executable_path = utils::get_executable_path(&args[0], path_var);
-        match executable_path {
-            None => bail!(
-                "executable '{}' for container process does not exist",
-                args[0]
-            ),
-            Some(path) => {
-                if !utils::is_executable(&path)? {
-                    bail!("file {:?} does not have executable permission set", path);
-                }
-            }
-        }
+        verify_binary(args, &envs)?;
     }
 
     // Notify main process that the init process is ready to execute the
     // payload.  Note, because we are already inside the pid namespace, the pid
     // outside the pid namespace should be recorded by the intermediate process
     // already.
-    main_sender.init_ready()?;
-    main_sender
-        .close()
-        .context("failed to close down main sender in init process")?;
+    main_sender.init_ready().map_err(|err| {
+        tracing::error!(
+            ?err,
+            "failed to notify main process that init process is ready"
+        );
+        InitProcessError::Channel(err)
+    })?;
+    main_sender.close().map_err(|err| {
+        tracing::error!(?err, "failed to close down main sender in init process");
+        InitProcessError::Channel(err)
+    })?;
 
     // listing on the notify socket for container start command
-    args.notify_socket.wait_for_container_start()?;
-    args.notify_socket.close()?;
+    args.notify_socket
+        .wait_for_container_start()
+        .map_err(|err| {
+            tracing::error!(?err, "failed to wait for container start");
+            err
+        })?;
+    args.notify_socket.close().map_err(|err| {
+        tracing::error!(?err, "failed to close notify socket");
+        err
+    })?;
 
     // create_container hook needs to be called after the namespace setup, but
     // before pivot_root is called. This runs in the container namespaces.
     if matches!(args.container_type, ContainerType::InitContainer) {
         if let Some(hooks) = hooks {
-            hooks::run_hooks(hooks.start_container().as_ref(), container)?
+            hooks::run_hooks(hooks.start_container().as_ref(), container).map_err(|err| {
+                tracing::error!(?err, "failed to run start container hooks");
+                err
+            })?;
         }
     }
 
     if proc.args().is_some() {
-        args.executor_manager.exec(spec)?;
+        args.executor_manager.exec(spec).map_err(|err| {
+            tracing::error!(?err, "failed to execute payload");
+            err
+        })?;
         unreachable!("should not be back here");
     } else {
-        bail!("on non-Windows, at least one process arg entry is required")
+        tracing::error!("on non-Windows, at least one process arg entry is required");
+        Err(InitProcessError::NoArgs)
     }
 }
 
@@ -506,10 +728,13 @@ fn set_supplementary_gids(
             return Ok(());
         }
 
-        let setgroups =
-            fs::read_to_string("/proc/self/setgroups").context("failed to read setgroups")?;
+        let setgroups = fs::read_to_string("/proc/self/setgroups").map_err(|err| {
+            tracing::error!(?err, "failed to read setgroups");
+            InitProcessError::Io(err)
+        })?;
         if setgroups.trim() == "deny" {
-            bail!("cannot set supplementary gids, setgroup is disabled");
+            tracing::error!("cannot set supplementary gids, setgroup is disabled");
+            return Err(InitProcessError::SetGroupDisabled);
         }
 
         let gids: Vec<Gid> = additional_gids
@@ -519,13 +744,15 @@ fn set_supplementary_gids(
 
         match rootless {
             Some(r) if r.privileged => {
-                syscall.set_groups(&gids).with_context(|| {
-                    format!("failed to set privileged supplementary gids: {gids:?}")
+                syscall.set_groups(&gids).map_err(|err| {
+                    tracing::error!(?err, ?gids, "failed to set privileged supplementary gids");
+                    InitProcessError::SyscallOther(err)
                 })?;
             }
             None => {
-                syscall.set_groups(&gids).with_context(|| {
-                    format!("failed to set unprivileged supplementary gids: {gids:?}")
+                syscall.set_groups(&gids).map_err(|err| {
+                    tracing::error!(?err, ?gids, "failed to set unprivileged supplementary gids");
+                    InitProcessError::SyscallOther(err)
                 })?;
             }
             // this should have been detected during validation
@@ -546,8 +773,16 @@ fn sync_seccomp(
 ) -> Result<()> {
     if let Some(fd) = fd {
         tracing::debug!("init process sync seccomp, notify fd: {}", fd);
-        main_sender.seccomp_notify_request(fd)?;
-        init_receiver.wait_for_seccomp_request_done()?;
+        main_sender.seccomp_notify_request(fd).map_err(|err| {
+            tracing::error!(?err, "failed to send seccomp notify request");
+            InitProcessError::Channel(err)
+        })?;
+        init_receiver
+            .wait_for_seccomp_request_done()
+            .map_err(|err| {
+                tracing::error!(?err, "failed to wait for seccomp request done");
+                InitProcessError::Channel(err)
+            })?;
         // Once we are sure the seccomp notify fd is sent, we can safely close
         // it. The fd is now duplicated to the main process and sent to seccomp
         // listener.
@@ -564,6 +799,7 @@ mod tests {
         syscall::create_syscall,
         test::{ArgName, MountArgs, TestHelperSyscall},
     };
+    use anyhow::Result;
     #[cfg(feature = "libseccomp")]
     use nix::unistd;
     use oci_spec::runtime::{LinuxNamespaceBuilder, SpecBuilder, UserBuilder};
@@ -820,5 +1056,43 @@ mod tests {
         assert!(masked_path(Path::new("/proc/self"), &None, syscall.as_ref()).is_err());
         let got = mocks.get_mount_args();
         assert_eq!(0, got.len());
+    }
+
+    #[test]
+    fn test_get_executable_path() {
+        let non_existing_abs_path = "/some/non/existent/absolute/path";
+        let existing_abs_path = "/usr/bin/sh";
+        let existing_binary = "sh";
+        let non_existing_binary = "non-existent";
+        let path_value = "/usr/bin:/bin";
+
+        assert_eq!(
+            get_executable_path(existing_abs_path, path_value),
+            Some(PathBuf::from(existing_abs_path))
+        );
+        assert_eq!(get_executable_path(non_existing_abs_path, path_value), None);
+
+        assert_eq!(
+            get_executable_path(existing_binary, path_value),
+            Some(PathBuf::from("/usr/bin/sh"))
+        );
+
+        assert_eq!(get_executable_path(non_existing_binary, path_value), None);
+    }
+
+    #[test]
+    fn test_is_executable() {
+        let tmp = tempfile::tempdir().expect("create temp directory for test");
+        let executable_path = PathBuf::from("/bin/sh");
+        let directory_path = tmp.path();
+        let non_executable_path = directory_path.join("non_executable_file");
+        let non_existent_path = PathBuf::from("/some/non/existent/path");
+
+        std::fs::File::create(non_executable_path.as_path()).unwrap();
+
+        assert!(is_executable(&non_existent_path).is_err());
+        assert!(is_executable(&executable_path).unwrap());
+        assert!(!is_executable(&non_executable_path).unwrap());
+        assert!(!is_executable(directory_path).unwrap());
     }
 }

--- a/crates/libcontainer/src/process/container_intermediate_process.rs
+++ b/crates/libcontainer/src/process/container_intermediate_process.rs
@@ -1,4 +1,3 @@
-use crate::process::{ProcessError, Result};
 use crate::{namespaces::Namespaces, process::channel, process::fork};
 use libcgroups::common::CgroupManager;
 use nix::unistd::{close, write};
@@ -10,6 +9,30 @@ use std::convert::From;
 use super::args::{ContainerArgs, ContainerType};
 use super::container_init_process::container_init_process;
 
+#[derive(Debug, thiserror::Error)]
+pub enum IntermediateProcessError {
+    #[error("missing linux in spec")]
+    NoLinuxSpec,
+    #[error("missing process in spec")]
+    NoProcessSpec,
+    #[error(transparent)]
+    Channel(#[from] channel::ChannelError),
+    #[error(transparent)]
+    Namespace(#[from] crate::namespaces::NamespaceError),
+    #[error(transparent)]
+    Syscall(#[from] crate::syscall::SyscallError),
+    #[error("failed to launch init process")]
+    InitProcess(#[source] fork::CloneError),
+    #[error("cgroup error: {0}")]
+    Cgroup(String),
+    #[error(transparent)]
+    Procfs(#[from] procfs::ProcError),
+    #[error("exec notify failed")]
+    ExecNotify(#[source] nix::Error),
+}
+
+type Result<T> = std::result::Result<T, IntermediateProcessError>;
+
 pub fn container_intermediate_process(
     args: &ContainerArgs,
     intermediate_chan: &mut (channel::IntermediateSender, channel::IntermediateReceiver),
@@ -20,7 +43,10 @@ pub fn container_intermediate_process(
     let (init_sender, init_receiver) = init_chan;
     let command = &args.syscall;
     let spec = &args.spec;
-    let linux = spec.linux().as_ref().ok_or(ProcessError::NoLinuxSpec)?;
+    let linux = spec
+        .linux()
+        .as_ref()
+        .ok_or(IntermediateProcessError::NoLinuxSpec)?;
     let namespaces = Namespaces::from(linux.namespaces().as_ref());
 
     // this needs to be done before we create the init process, so that the init
@@ -50,18 +76,14 @@ pub fn container_intermediate_process(
             // child needs to be dumpable, otherwise the non root parent is not
             // allowed to write the uid/gid maps
             prctl::set_dumpable(true).unwrap();
-            main_sender
-                .identifier_mapping_request()
-                .map_err(|err| ProcessError::ChannelError {
-                    msg: "failed to send id mapping request".into(),
-                    source: err,
-                })?;
-            inter_receiver
-                .wait_for_mapping_ack()
-                .map_err(|err| ProcessError::ChannelError {
-                    msg: "failed to hear back mapping ack".into(),
-                    source: err,
-                })?;
+            main_sender.identifier_mapping_request().map_err(|err| {
+                tracing::error!("failed to send id mapping request: {}", err);
+                err
+            })?;
+            inter_receiver.wait_for_mapping_ack().map_err(|err| {
+                tracing::error!("failed to receive id mapping ack: {}", err);
+                err
+            })?;
             prctl::set_dumpable(false).unwrap();
         }
 
@@ -75,7 +97,10 @@ pub fn container_intermediate_process(
     }
 
     // set limits and namespaces to the process
-    let proc = spec.process().as_ref().ok_or(ProcessError::NoProcessSpec)?;
+    let proc = spec
+        .process()
+        .as_ref()
+        .ok_or(IntermediateProcessError::NoProcessSpec)?;
     if let Some(rlimits) = proc.rlimits() {
         for rlimit in rlimits {
             command.set_rlimit(rlimit)?;
@@ -99,63 +124,70 @@ pub fn container_intermediate_process(
         // We are inside the forked process here. The first thing we have to do
         // is to close any unused senders, since fork will make a dup for all
         // the socket.
-        init_sender
-            .close()
-            .map_err(|err| ProcessError::ChannelError {
-                msg: "failed to close receiver in init process".into(),
-                source: err,
-            })?;
-        inter_sender
-            .close()
-            .map_err(|err| ProcessError::ChannelError {
-                msg: "failed to close sender in the intermediate process".into(),
-                source: err,
-            })?;
+        init_sender.close().map_err(|err| {
+            tracing::error!("failed to close receiver in init process: {}", err);
+            IntermediateProcessError::Channel(err)
+        })?;
+        inter_sender.close().map_err(|err| {
+            tracing::error!(
+                "failed to close sender in the intermediate process: {}",
+                err
+            );
+            IntermediateProcessError::Channel(err)
+        })?;
         match container_init_process(args, main_sender, init_receiver) {
             Ok(_) => Ok(0),
             Err(e) => {
                 if let ContainerType::TenantContainer { exec_notify_fd } = args.container_type {
                     let buf = format!("{e}");
-                    write(exec_notify_fd, buf.as_bytes())?;
-                    close(exec_notify_fd)?;
+                    write(exec_notify_fd, buf.as_bytes()).map_err(|err| {
+                        tracing::error!("failed to write to exec notify fd: {}", err);
+                        IntermediateProcessError::ExecNotify(err)
+                    })?;
+                    close(exec_notify_fd).map_err(|err| {
+                        tracing::error!("failed to close exec notify fd: {}", err);
+                        IntermediateProcessError::ExecNotify(err)
+                    })?;
                 }
                 tracing::error!("failed to initialize container process: {e}");
-                Err(ProcessError::InitProcessFailed { msg: e.to_string() })
+                Err(e.into())
             }
         }
+    })
+    .map_err(|err| {
+        tracing::error!("failed to fork init process: {}", err);
+        IntermediateProcessError::InitProcess(err)
     })?;
 
     // Close the exec_notify_fd in this process
     if let ContainerType::TenantContainer { exec_notify_fd } = args.container_type {
-        close(exec_notify_fd)?;
+        close(exec_notify_fd).map_err(|err| {
+            tracing::error!("failed to close exec notify fd: {}", err);
+            IntermediateProcessError::ExecNotify(err)
+        })?;
     }
 
-    main_sender
-        .intermediate_ready(pid)
-        .map_err(|err| ProcessError::ChannelError {
-            msg: "failed to wait on intermediate channel".into(),
-            source: err,
-        })?;
+    main_sender.intermediate_ready(pid).map_err(|err| {
+        tracing::error!("failed to wait on intermediate process: {}", err);
+        err
+    })?;
 
     // Close unused senders here so we don't have lingering socket around.
-    main_sender
-        .close()
-        .map_err(|err| ProcessError::ChannelError {
-            msg: "failed to close unused main sender".into(),
-            source: err,
-        })?;
-    inter_sender
-        .close()
-        .map_err(|err| ProcessError::ChannelError {
-            msg: "failed to close sender in the intermediate process".into(),
-            source: err,
-        })?;
-    init_sender
-        .close()
-        .map_err(|err| ProcessError::ChannelError {
-            msg: "failed to close unused init sender".into(),
-            source: err,
-        })?;
+    main_sender.close().map_err(|err| {
+        tracing::error!("failed to close unused main sender: {}", err);
+        err
+    })?;
+    inter_sender.close().map_err(|err| {
+        tracing::error!(
+            "failed to close sender in the intermediate process: {}",
+            err
+        );
+        err
+    })?;
+    init_sender.close().map_err(|err| {
+        tracing::error!("failed to close unused init sender: {}", err);
+        err
+    })?;
     Ok(pid)
 }
 
@@ -168,12 +200,10 @@ fn apply_cgroups<
     init: bool,
 ) -> Result<()> {
     let pid = Pid::from_raw(Process::myself()?.pid());
-    cmanager
-        .add_task(pid)
-        .map_err(|err| ProcessError::CgroupAdd {
-            pid,
-            msg: err.to_string(),
-        })?;
+    cmanager.add_task(pid).map_err(|err| {
+        tracing::error!(?pid, ?err, ?init, "failed to add task to cgroup");
+        IntermediateProcessError::Cgroup(err.to_string())
+    })?;
 
     if let Some(resources) = resources {
         if init {
@@ -184,11 +214,10 @@ fn apply_cgroups<
                 disable_oom_killer: false,
             };
 
-            cmanager
-                .apply(&controller_opt)
-                .map_err(|err| ProcessError::CgroupApply {
-                    msg: err.to_string(),
-                })?;
+            cmanager.apply(&controller_opt).map_err(|err| {
+                tracing::error!(?pid, ?err, ?init, "failed to apply cgroup");
+                IntermediateProcessError::Cgroup(err.to_string())
+            })?;
         }
     }
 

--- a/crates/libcontainer/src/process/container_main_process.rs
+++ b/crates/libcontainer/src/process/container_main_process.rs
@@ -5,23 +5,31 @@ use crate::{
         intel_rdt::setup_intel_rdt,
     },
     rootless::Rootless,
-    utils,
 };
-use anyhow::{bail, Context, Result};
 use nix::sys::wait::{waitpid, WaitStatus};
 use nix::unistd::Pid;
 
-#[cfg(feature = "libseccomp")]
-use crate::seccomp;
-#[cfg(feature = "libseccomp")]
-use nix::{
-    sys::socket::{self, UnixAddr},
-    unistd,
-};
-#[cfg(feature = "libseccomp")]
-use oci_spec::runtime;
-#[cfg(feature = "libseccomp")]
-use std::{io::IoSlice, path::Path};
+#[derive(Debug, thiserror::Error)]
+pub enum ProcessError {
+    #[error(transparent)]
+    Channel(#[from] channel::ChannelError),
+    #[error("failed to write deny to setgroups")]
+    SetGroupsDeny(#[source] std::io::Error),
+    #[error(transparent)]
+    Rootless(#[from] crate::rootless::RootlessError),
+    #[error("failed seccomp listener")]
+    SeccompListener(#[from] crate::process::seccomp_listener::SeccompListenerError),
+    #[error("container state is required")]
+    ContainerStateRequired,
+    #[error("failed to wait for intermediate process")]
+    WaitIntermediateProcess(#[source] nix::Error),
+    #[error(transparent)]
+    IntelRdt(#[from] crate::process::intel_rdt::IntelRdtError),
+    #[error("failed to create intermediate process")]
+    IntermediateProcessFailed(#[source] fork::CloneError),
+}
+
+type Result<T> = std::result::Result<T, ProcessError>;
 
 pub fn container_main_process(container_args: &ContainerArgs) -> Result<(Pid, bool)> {
     // We use a set of channels to communicate between parent and child process.
@@ -42,13 +50,18 @@ pub fn container_main_process(container_args: &ContainerArgs) -> Result<(Pid, bo
         )?;
 
         Ok(0)
+    })
+    .map_err(|err| {
+        tracing::error!("failed to fork intermediate process: {}", err);
+        ProcessError::IntermediateProcessFailed(err)
     })?;
 
     // Close down unused fds. The corresponding fds are duplicated to the
     // child process during fork.
-    main_sender
-        .close()
-        .context("failed to close unused sender")?;
+    main_sender.close().map_err(|err| {
+        tracing::error!("failed to close unused sender: {}", err);
+        err
+    })?;
 
     let (inter_sender, _) = inter_chan;
     let (init_sender, _) = init_chan;
@@ -64,9 +77,10 @@ pub fn container_main_process(container_args: &ContainerArgs) -> Result<(Pid, bo
 
     // At this point, we don't need to send any message to intermediate process anymore,
     // so we want to close this sender at the earliest point.
-    inter_sender
-        .close()
-        .context("failed to close unused intermediate sender")?;
+    inter_sender.close().map_err(|err| {
+        tracing::error!("failed to close unused intermediate sender: {}", err);
+        err
+    })?;
 
     // The intermediate process will send the init pid once it forks the init
     // process.  The intermediate process should exit after this point.
@@ -75,7 +89,6 @@ pub fn container_main_process(container_args: &ContainerArgs) -> Result<(Pid, bo
 
     if let Some(linux) = container_args.spec.linux() {
         if let Some(seccomp) = linux.seccomp() {
-            #[allow(unused_variables)]
             let state = ContainerProcessState {
                 oci_version: container_args.spec.version().to_string(),
                 // runc hardcode the `seccompFd` name for fds.
@@ -85,13 +98,17 @@ pub fn container_main_process(container_args: &ContainerArgs) -> Result<(Pid, bo
                 state: container_args
                     .container
                     .as_ref()
-                    .context("container state is required")?
+                    .ok_or(ProcessError::ContainerStateRequired)?
                     .state
                     .clone(),
             };
             #[cfg(feature = "libseccomp")]
-            sync_seccomp(seccomp, &state, init_sender, main_receiver)
-                .context("failed to sync seccomp with init")?;
+            crate::process::seccomp_listener::sync_seccomp(
+                seccomp,
+                &state,
+                init_sender,
+                main_receiver,
+            )?;
         }
         if let Some(intel_rdt) = linux.intel_rdt() {
             let container_id = container_args
@@ -105,13 +122,15 @@ pub fn container_main_process(container_args: &ContainerArgs) -> Result<(Pid, bo
 
     // We don't need to send anything to the init process after this point, so
     // close the sender.
-    init_sender
-        .close()
-        .context("failed to close unused init sender")?;
+    init_sender.close().map_err(|err| {
+        tracing::error!("failed to close unused init sender: {}", err);
+        err
+    })?;
 
-    main_receiver
-        .wait_for_init_ready()
-        .context("failed to wait for init ready")?;
+    main_receiver.wait_for_init_ready().map_err(|err| {
+        tracing::error!("failed to wait for init ready: {}", err);
+        err
+    })?;
 
     tracing::debug!("init pid is {:?}", init_pid);
 
@@ -133,69 +152,10 @@ pub fn container_main_process(container_args: &ContainerArgs) -> Result<(Pid, bo
             // finished by piping instead of exit code.
             tracing::warn!("intermediate process already reaped");
         }
-        Err(err) => bail!("failed to wait for intermediate process: {err}"),
+        Err(err) => return Err(ProcessError::WaitIntermediateProcess(err)),
     };
 
     Ok((init_pid, need_to_clean_up_intel_rdt_subdirectory))
-}
-
-#[cfg(feature = "libseccomp")]
-fn sync_seccomp(
-    seccomp: &runtime::LinuxSeccomp,
-    state: &ContainerProcessState,
-    init_sender: &mut channel::InitSender,
-    main_receiver: &mut channel::MainReceiver,
-) -> Result<()> {
-    if seccomp::is_notify(seccomp) {
-        tracing::debug!("main process waiting for sync seccomp");
-        let seccomp_fd = main_receiver.wait_for_seccomp_request()?;
-        let listener_path = seccomp
-            .listener_path()
-            .as_ref()
-            .context("notify will require seccomp listener path to be set")?;
-        let encoded_state =
-            serde_json::to_vec(state).context("failed to encode container process state")?;
-        sync_seccomp_send_msg(listener_path, &encoded_state, seccomp_fd)
-            .context("failed to send msg to seccomp listener")?;
-        init_sender.seccomp_notify_done()?;
-        // Once we sent the seccomp notify fd to the seccomp listener, we can
-        // safely close the fd. The SCM_RIGHTS msg will duplicate the fd to the
-        // process on the other end of the listener.
-        let _ = unistd::close(seccomp_fd);
-    }
-
-    Ok(())
-}
-
-#[cfg(feature = "libseccomp")]
-fn sync_seccomp_send_msg(listener_path: &Path, msg: &[u8], fd: i32) -> Result<()> {
-    // The seccomp listener has specific instructions on how to transmit the
-    // information through seccomp listener.  Therefore, we have to use
-    // libc/nix APIs instead of Rust std lib APIs to maintain flexibility.
-    let socket = socket::socket(
-        socket::AddressFamily::Unix,
-        socket::SockType::Stream,
-        socket::SockFlag::empty(),
-        None,
-    )
-    .context("failed to create unix domain socket for seccomp listener")?;
-    let unix_addr = socket::UnixAddr::new(listener_path).context("failed to create unix addr")?;
-    socket::connect(socket, &unix_addr).with_context(|| {
-        format!("failed to connect to seccomp notify listerner path: {listener_path:?}")
-    })?;
-    // We have to use sendmsg here because the spec requires us to send seccomp notify fds through
-    // SCM_RIGHTS message.
-    // Ref: https://man7.org/linux/man-pages/man3/sendmsg.3p.html
-    // Ref: https://man7.org/linux/man-pages/man3/cmsg.3.html
-    let iov = [IoSlice::new(msg)];
-    let fds = [fd];
-    let cmsgs = socket::ControlMessage::ScmRights(&fds);
-    socket::sendmsg::<UnixAddr>(socket, &iov, &[cmsgs], socket::MsgFlags::empty(), None)
-        .context("failed to write container state to seccomp listener")?;
-    // The spec requires the listener socket to be closed immediately after sending.
-    let _ = unistd::close(socket);
-
-    Ok(())
 }
 
 fn setup_mapping(rootless: &Rootless, pid: Pid) -> Result<()> {
@@ -203,15 +163,18 @@ fn setup_mapping(rootless: &Rootless, pid: Pid) -> Result<()> {
     if !rootless.privileged {
         // The main process is running as an unprivileged user and cannot write the mapping
         // until "deny" has been written to setgroups. See CVE-2014-8989.
-        utils::write_file(format!("/proc/{pid}/setgroups"), "deny")?;
+        std::fs::write(format!("/proc/{pid}/setgroups"), "deny")
+            .map_err(ProcessError::SetGroupsDeny)?;
     }
 
-    rootless
-        .write_uid_mapping(pid)
-        .context(format!("failed to map uid of pid {pid}"))?;
-    rootless
-        .write_gid_mapping(pid)
-        .context(format!("failed to map gid of pid {pid}"))?;
+    rootless.write_uid_mapping(pid).map_err(|err| {
+        tracing::error!("failed to write uid mapping for pid {:?}: {}", pid, err);
+        err
+    })?;
+    rootless.write_gid_mapping(pid).map_err(|err| {
+        tracing::error!("failed to write gid mapping for pid {:?}: {}", pid, err);
+        err
+    })?;
     Ok(())
 }
 
@@ -220,13 +183,12 @@ mod tests {
     use super::*;
     use crate::process::channel::{intermediate_channel, main_channel};
     use crate::rootless::RootlessIDMapper;
+    use anyhow::Result;
     use nix::{
         sched::{unshare, CloneFlags},
         unistd::{self, getgid, getuid},
     };
     use oci_spec::runtime::LinuxIdMappingBuilder;
-    #[cfg(feature = "libseccomp")]
-    use oci_spec::runtime::{LinuxSeccompAction, LinuxSeccompBuilder, LinuxSyscallBuilder};
     use serial_test::serial;
     use std::fs;
 
@@ -340,65 +302,6 @@ mod tests {
                 std::process::exit(0);
             }
         }
-        Ok(())
-    }
-
-    #[test]
-    #[serial]
-    #[cfg(feature = "libseccomp")]
-    fn test_sync_seccomp() -> Result<()> {
-        use std::io::Read;
-        use std::os::unix::io::IntoRawFd;
-        use std::os::unix::net::UnixListener;
-        use std::thread;
-
-        let tmp_dir = tempfile::tempdir()?;
-        let scmp_file = std::fs::OpenOptions::new()
-            .write(true)
-            .create(true)
-            .open(tmp_dir.path().join("scmp_file"))?;
-
-        std::fs::OpenOptions::new()
-            .write(true)
-            .create(true)
-            .open(tmp_dir.path().join("socket_file.sock"))?;
-
-        let (mut main_sender, mut main_receiver) = channel::main_channel()?;
-        let (mut init_sender, mut init_receiver) = channel::init_channel()?;
-        let socket_path = tmp_dir.path().join("socket_file.sock");
-        let socket_path_seccomp_th = socket_path.clone();
-
-        let state = ContainerProcessState::default();
-        let want = serde_json::to_string(&state)?;
-        let th = thread::spawn(move || {
-            sync_seccomp(
-                &LinuxSeccompBuilder::default()
-                    .listener_path(socket_path_seccomp_th)
-                    .syscalls(vec![LinuxSyscallBuilder::default()
-                        .action(LinuxSeccompAction::ScmpActNotify)
-                        .build()
-                        .unwrap()])
-                    .build()
-                    .unwrap(),
-                &state,
-                &mut init_sender,
-                &mut main_receiver,
-            )
-            .unwrap();
-        });
-
-        let fd = scmp_file.into_raw_fd();
-        assert!(main_sender.seccomp_notify_request(fd).is_ok());
-
-        fs::remove_file(socket_path.clone())?;
-        let lis = UnixListener::bind(socket_path)?;
-        let (mut socket, _) = lis.accept()?;
-        let mut got = String::new();
-        socket.read_to_string(&mut got)?;
-        assert!(init_receiver.wait_for_seccomp_request_done().is_ok());
-
-        assert_eq!(want, got);
-        assert!(th.join().is_ok());
         Ok(())
     }
 }

--- a/crates/libcontainer/src/process/mod.rs
+++ b/crates/libcontainer/src/process/mod.rs
@@ -1,51 +1,13 @@
 //! Provides a thin wrapper around fork syscall,
 //! with enums and functions specific to youki implemented
 
-use crate::syscall::SyscallError;
-
 pub mod args;
 pub mod channel;
 pub mod container_init_process;
 pub mod container_intermediate_process;
 pub mod container_main_process;
-pub mod fork;
+mod fork;
 pub mod intel_rdt;
-pub mod message;
-
-type Result<T> = std::result::Result<T, ProcessError>;
-
-#[derive(Debug, thiserror::Error)]
-pub enum ProcessError {
-    #[error("unknown fatal error")]
-    Unknown,
-    #[error("failed to clone process using clone3")]
-    CloneFailed {
-        errno: nix::errno::Errno,
-        child_name: String,
-    },
-    #[error("failed init process")]
-    InitProcessFailed { msg: String },
-    #[error("failed intermediate process")]
-    IntermediateProcessFailed,
-    #[error("io error: {0}")]
-    UnixIo(#[from] nix::errno::Errno),
-    #[error("failed to add task {pid} to cgroup manager")]
-    CgroupAdd { pid: nix::unistd::Pid, msg: String },
-    #[error("failed to apply resource limits to cgroup")]
-    CgroupApply { msg: String },
-    #[error("failed to get proc state")]
-    Procfs(#[from] procfs::ProcError),
-    #[error("missing linux in spec")]
-    NoLinuxSpec,
-    #[error("missing process in spec")]
-    NoProcessSpec,
-    #[error("channel error")]
-    ChannelError {
-        msg: String,
-        source: channel::ChannelError,
-    },
-    #[error("syscall failed")]
-    SyscallFailed(#[from] SyscallError),
-    #[error("failed to enter namespace")]
-    NamespaceError(#[from] crate::namespaces::NamespaceError),
-}
+mod message;
+#[cfg(feature = "libseccomp")]
+mod seccomp_listener;

--- a/crates/libcontainer/src/process/seccomp_listener.rs
+++ b/crates/libcontainer/src/process/seccomp_listener.rs
@@ -1,0 +1,172 @@
+use crate::container::ContainerProcessState;
+use crate::seccomp;
+use nix::{
+    sys::socket::{self, UnixAddr},
+    unistd,
+};
+use oci_spec::runtime;
+use std::{io::IoSlice, path::Path};
+
+use super::channel;
+
+#[derive(Debug, thiserror::Error)]
+pub enum SeccompListenerError {
+    #[error("notify will require seccomp listener path to be set")]
+    MissingListenerPath,
+    #[error("failed to encode container process state")]
+    EncodeState(#[source] serde_json::Error),
+    #[error(transparent)]
+    ChannelError(#[from] channel::ChannelError),
+    #[error("unix syscall fails")]
+    UnixOther(#[source] nix::Error),
+}
+
+type Result<T> = std::result::Result<T, SeccompListenerError>;
+
+pub fn sync_seccomp(
+    seccomp: &runtime::LinuxSeccomp,
+    state: &ContainerProcessState,
+    init_sender: &mut channel::InitSender,
+    main_receiver: &mut channel::MainReceiver,
+) -> Result<()> {
+    if seccomp::is_notify(seccomp) {
+        tracing::debug!("main process waiting for sync seccomp");
+        let seccomp_fd = main_receiver.wait_for_seccomp_request()?;
+        let listener_path = seccomp
+            .listener_path()
+            .as_ref()
+            .ok_or(SeccompListenerError::MissingListenerPath)?;
+        let encoded_state = serde_json::to_vec(state).map_err(SeccompListenerError::EncodeState)?;
+        sync_seccomp_send_msg(listener_path, &encoded_state, seccomp_fd).map_err(|err| {
+            tracing::error!("failed to send msg to seccomp listener: {}", err);
+            err
+        })?;
+        init_sender.seccomp_notify_done()?;
+        // Once we sent the seccomp notify fd to the seccomp listener, we can
+        // safely close the fd. The SCM_RIGHTS msg will duplicate the fd to the
+        // process on the other end of the listener.
+        let _ = unistd::close(seccomp_fd);
+    }
+
+    Ok(())
+}
+
+fn sync_seccomp_send_msg(listener_path: &Path, msg: &[u8], fd: i32) -> Result<()> {
+    // The seccomp listener has specific instructions on how to transmit the
+    // information through seccomp listener.  Therefore, we have to use
+    // libc/nix APIs instead of Rust std lib APIs to maintain flexibility.
+    let socket = socket::socket(
+        socket::AddressFamily::Unix,
+        socket::SockType::Stream,
+        socket::SockFlag::empty(),
+        None,
+    )
+    .map_err(|err| {
+        tracing::error!(
+            ?err,
+            "failed to create unix domain socket for seccomp listener"
+        );
+        SeccompListenerError::UnixOther(err)
+    })?;
+    let unix_addr = socket::UnixAddr::new(listener_path).map_err(|err| {
+        tracing::error!(
+            ?err,
+            ?listener_path,
+            "failed to create unix domain socket address"
+        );
+        SeccompListenerError::UnixOther(err)
+    })?;
+    socket::connect(socket, &unix_addr).map_err(|err| {
+        tracing::error!(
+            ?err,
+            ?listener_path,
+            "failed to connect to seccomp notify listerner path"
+        );
+        SeccompListenerError::UnixOther(err)
+    })?;
+    // We have to use sendmsg here because the spec requires us to send seccomp notify fds through
+    // SCM_RIGHTS message.
+    // Ref: https://man7.org/linux/man-pages/man3/sendmsg.3p.html
+    // Ref: https://man7.org/linux/man-pages/man3/cmsg.3.html
+    let iov = [IoSlice::new(msg)];
+    let fds = [fd];
+    let cmsgs = socket::ControlMessage::ScmRights(&fds);
+    socket::sendmsg::<UnixAddr>(socket, &iov, &[cmsgs], socket::MsgFlags::empty(), None).map_err(
+        |err| {
+            tracing::error!(?err, "failed to write container state to seccomp listener");
+            SeccompListenerError::UnixOther(err)
+        },
+    )?;
+    // The spec requires the listener socket to be closed immediately after sending.
+    let _ = unistd::close(socket);
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{container::ContainerProcessState, process::channel};
+
+    use super::*;
+    use anyhow::Result;
+    use oci_spec::runtime::{LinuxSeccompAction, LinuxSeccompBuilder, LinuxSyscallBuilder};
+    use serial_test::serial;
+
+    #[test]
+    #[serial]
+    fn test_sync_seccomp() -> Result<()> {
+        use std::io::Read;
+        use std::os::unix::io::IntoRawFd;
+        use std::os::unix::net::UnixListener;
+        use std::thread;
+
+        let tmp_dir = tempfile::tempdir()?;
+        let scmp_file = std::fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .open(tmp_dir.path().join("scmp_file"))?;
+
+        std::fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .open(tmp_dir.path().join("socket_file.sock"))?;
+
+        let (mut main_sender, mut main_receiver) = channel::main_channel()?;
+        let (mut init_sender, mut init_receiver) = channel::init_channel()?;
+        let socket_path = tmp_dir.path().join("socket_file.sock");
+        let socket_path_seccomp_th = socket_path.clone();
+
+        let state = ContainerProcessState::default();
+        let want = serde_json::to_string(&state)?;
+        let th = thread::spawn(move || {
+            sync_seccomp(
+                &LinuxSeccompBuilder::default()
+                    .listener_path(socket_path_seccomp_th)
+                    .syscalls(vec![LinuxSyscallBuilder::default()
+                        .action(LinuxSeccompAction::ScmpActNotify)
+                        .build()
+                        .unwrap()])
+                    .build()
+                    .unwrap(),
+                &state,
+                &mut init_sender,
+                &mut main_receiver,
+            )
+            .unwrap();
+        });
+
+        let fd = scmp_file.into_raw_fd();
+        assert!(main_sender.seccomp_notify_request(fd).is_ok());
+
+        std::fs::remove_file(socket_path.clone())?;
+        let lis = UnixListener::bind(socket_path)?;
+        let (mut socket, _) = lis.accept()?;
+        let mut got = String::new();
+        socket.read_to_string(&mut got)?;
+        assert!(init_receiver.wait_for_seccomp_request_done().is_ok());
+
+        assert_eq!(want, got);
+        assert!(th.join().is_ok());
+        Ok(())
+    }
+}

--- a/crates/libcontainer/src/rootfs/device.rs
+++ b/crates/libcontainer/src/rootfs/device.rs
@@ -1,7 +1,6 @@
 use super::utils::to_sflag;
 use crate::syscall::{syscall::create_syscall, Syscall};
 use crate::utils::PathBufExt;
-use anyhow::{bail, Context, Result};
 use nix::{
     fcntl::{open, OFlag},
     mount::MsFlags,
@@ -10,6 +9,24 @@ use nix::{
 };
 use oci_spec::runtime::LinuxDevice;
 use std::path::{Path, PathBuf};
+
+#[derive(Debug, thiserror::Error)]
+pub enum DeviceError {
+    #[error("{0:?} is not a valid device path")]
+    InvalidDevicePath(std::path::PathBuf),
+    #[error("failed to bind dev")]
+    BindDev {
+        source: crate::error::UnifiedSyscallError,
+    },
+    #[error("failed syscall to create device")]
+    Syscall(#[from] crate::syscall::SyscallError),
+    #[error(transparent)]
+    Other(Box<dyn std::error::Error + Send + Sync>),
+    #[error("{0}")]
+    Custom(String),
+}
+
+type Result<T> = std::result::Result<T, DeviceError>;
 
 pub struct Device {
     syscall: Box<dyn Syscall>,
@@ -41,7 +58,11 @@ impl Device {
             .into_iter()
             .map(|dev| {
                 if !dev.path().starts_with("/dev") {
-                    bail!("{} is not a valid device path", dev.path().display());
+                    tracing::error!(
+                        "{:?} is not a valid device path starting with /dev",
+                        dev.path()
+                    );
+                    return Err(DeviceError::InvalidDevicePath(dev.path().to_path_buf()));
                 }
 
                 if bind {
@@ -57,22 +78,38 @@ impl Device {
     }
 
     fn bind_dev(&self, rootfs: &Path, dev: &LinuxDevice) -> Result<()> {
-        let full_container_path = create_container_dev_path(rootfs, dev)
-            .with_context(|| format!("could not create container path for device {dev:?}"))?;
+        let full_container_path = create_container_dev_path(rootfs, dev)?;
+        tracing::debug!(
+            "bind_dev with full container path {:?}",
+            full_container_path
+        );
 
         let fd = open(
             &full_container_path,
             OFlag::O_RDWR | OFlag::O_CREAT,
             Mode::from_bits_truncate(0o644),
-        )?;
-        close(fd)?;
-        self.syscall.mount(
-            Some(dev.path()),
-            &full_container_path,
-            Some("bind"),
-            MsFlags::MS_BIND,
-            None,
-        )?;
+        )
+        .map_err(|err| {
+            tracing::error!("failed to open bind dev {:?}: {}", full_container_path, err);
+            DeviceError::BindDev { source: err.into() }
+        })?;
+        close(fd).map_err(|err| DeviceError::BindDev { source: err.into() })?;
+        self.syscall
+            .mount(
+                Some(dev.path()),
+                &full_container_path,
+                Some("bind"),
+                MsFlags::MS_BIND,
+                None,
+            )
+            .map_err(|err| {
+                tracing::error!(
+                    "failed to mount bind dev {:?}: {}",
+                    full_container_path,
+                    err
+                );
+                DeviceError::BindDev { source: err.into() }
+            })?;
 
         Ok(())
     }
@@ -85,8 +122,7 @@ impl Device {
                 | ((major & !0xfff) << 32)) as u64
         }
 
-        let full_container_path = create_container_dev_path(rootfs, dev)
-            .with_context(|| format!("could not create container path for device {dev:?}"))?;
+        let full_container_path = create_container_dev_path(rootfs, dev)?;
 
         self.syscall.mknod(
             &full_container_path,
@@ -105,18 +141,31 @@ impl Device {
 }
 
 fn create_container_dev_path(rootfs: &Path, dev: &LinuxDevice) -> Result<PathBuf> {
-    let relative_dev_path = dev
-        .path()
-        .as_relative()
-        .with_context(|| format!("could not convert {:?} to relative path", dev.path()))?;
-    let full_container_path = safe_path::scoped_join(rootfs, relative_dev_path)
-        .with_context(|| format!("could not join {:?} with {:?}", rootfs, dev.path()))?;
-
-    crate::utils::create_dir_all(
+    let relative_dev_path = dev.path().as_relative().map_err(|err| {
+        tracing::error!(
+            "failed to convert {:?} to relative path: {}",
+            dev.path(),
+            err
+        );
+        DeviceError::Other(err.into())
+    })?;
+    let full_container_path = safe_path::scoped_join(rootfs, relative_dev_path).map_err(|err| {
+        tracing::error!("failed to join {rootfs:?} with {:?}: {err}", dev.path());
+        DeviceError::Other(err.into())
+    })?;
+    std::fs::create_dir_all(
         full_container_path
             .parent()
             .unwrap_or_else(|| Path::new("")),
-    )?;
+    )
+    .map_err(|err| {
+        tracing::error!(
+            "failed to create parent dir of {:?}: {}",
+            full_container_path,
+            err
+        );
+        DeviceError::Other(err.into())
+    })?;
 
     Ok(full_container_path)
 }

--- a/crates/libcontainer/src/rootfs/mod.rs
+++ b/crates/libcontainer/src/rootfs/mod.rs
@@ -17,8 +17,8 @@ pub mod utils;
 pub enum RootfsError {
     #[error("failed syscall")]
     Syscall(#[from] crate::syscall::SyscallError),
-    #[error("no linux in spec")]
-    NoLinuxSpec,
+    #[error(transparent)]
+    MissingSpec(#[from] crate::error::MissingSpecError),
     #[error("unknown rootfs propagation")]
     UnknownRootfsPropagation(String),
     #[error(transparent)]

--- a/crates/libcontainer/src/rootfs/mod.rs
+++ b/crates/libcontainer/src/rootfs/mod.rs
@@ -1,5 +1,5 @@
-//! During kernel initialization, a minimal replica of the ramfs filesystem is loaded, called rootfs.
-//! Most systems mount another filesystem over it
+//! During kernel initialization, a minimal replica of the ramfs filesystem is
+//! loaded, called rootfs.  Most systems mount another filesystem over it
 
 #[allow(clippy::module_inception)]
 pub(crate) mod rootfs;
@@ -12,3 +12,21 @@ pub(super) mod mount;
 pub(super) mod symlink;
 
 pub mod utils;
+
+#[derive(Debug, thiserror::Error)]
+pub enum RootfsError {
+    #[error("failed syscall")]
+    Syscall(#[from] crate::syscall::SyscallError),
+    #[error("no linux in spec")]
+    NoLinuxSpec,
+    #[error("unknown rootfs propagation")]
+    UnknownRootfsPropagation(String),
+    #[error(transparent)]
+    Symlink(#[from] symlink::SymlinkError),
+    #[error(transparent)]
+    Mount(#[from] mount::MountError),
+    #[error(transparent)]
+    Device(#[from] device::DeviceError),
+}
+
+type Result<T> = std::result::Result<T, RootfsError>;

--- a/crates/libcontainer/src/rootfs/rootfs.rs
+++ b/crates/libcontainer/src/rootfs/rootfs.rs
@@ -3,9 +3,9 @@ use super::{
     mount::{Mount, MountOptions},
     symlink::Symlink,
     utils::default_devices,
+    Result, RootfsError,
 };
 use crate::syscall::{syscall::create_syscall, Syscall};
-use anyhow::{bail, Context, Result};
 use nix::mount::MsFlags;
 use oci_spec::runtime::{Linux, Spec};
 use std::path::Path;
@@ -37,24 +37,23 @@ impl RootFS {
     ) -> Result<()> {
         tracing::debug!("Prepare rootfs: {:?}", rootfs);
         let mut flags = MsFlags::MS_REC;
-        let linux = spec.linux().as_ref().context("no linux in spec")?;
+        let linux = spec.linux().as_ref().ok_or(RootfsError::NoLinuxSpec)?;
 
         match linux.rootfs_propagation().as_deref() {
             Some("shared") => flags |= MsFlags::MS_SHARED,
             Some("private") => flags |= MsFlags::MS_PRIVATE,
             Some("slave" | "unbindable") | None => flags |= MsFlags::MS_SLAVE,
-            Some(uknown) => bail!("unknown rootfs_propagation: {}", uknown),
+            Some(uknown) => {
+                return Err(RootfsError::UnknownRootfsPropagation(uknown.to_string()));
+            }
         }
 
         self.syscall
-            .mount(None, Path::new("/"), None, flags, None)
-            .context("failed to mount rootfs")?;
+            .mount(None, Path::new("/"), None, flags, None)?;
 
         let mounter = Mount::new();
 
-        mounter
-            .make_parent_mount_private(rootfs)
-            .context("failed to change parent mount of rootfs private")?;
+        mounter.make_parent_mount_private(rootfs)?;
 
         tracing::debug!("mount root fs {:?}", rootfs);
         self.syscall.mount(
@@ -73,19 +72,13 @@ impl RootFS {
 
         if let Some(mounts) = spec.mounts() {
             for mount in mounts {
-                mounter
-                    .setup_mount(mount, &global_options)
-                    .with_context(|| format!("failed to setup mount {mount:#?}"))?;
+                mounter.setup_mount(mount, &global_options)?;
             }
         }
 
         let symlinker = Symlink::new();
-        symlinker
-            .setup_kcore_symlink(rootfs)
-            .context("failed to  setup kcore symlink")?;
-        symlinker
-            .setup_default_symlinks(rootfs)
-            .context("failed to setup default symlinks")?;
+        symlinker.setup_kcore_symlink(rootfs)?;
+        symlinker.setup_default_symlinks(rootfs)?;
 
         let devicer = Device::new();
         if let Some(added_devices) = linux.devices() {

--- a/crates/libcontainer/src/rootfs/rootfs.rs
+++ b/crates/libcontainer/src/rootfs/rootfs.rs
@@ -5,7 +5,10 @@ use super::{
     utils::default_devices,
     Result, RootfsError,
 };
-use crate::syscall::{syscall::create_syscall, Syscall};
+use crate::{
+    error::MissingSpecError,
+    syscall::{syscall::create_syscall, Syscall},
+};
 use nix::mount::MsFlags;
 use oci_spec::runtime::{Linux, Spec};
 use std::path::Path;
@@ -37,7 +40,10 @@ impl RootFS {
     ) -> Result<()> {
         tracing::debug!("Prepare rootfs: {:?}", rootfs);
         let mut flags = MsFlags::MS_REC;
-        let linux = spec.linux().as_ref().ok_or(RootfsError::NoLinuxSpec)?;
+        let linux = spec
+            .linux()
+            .as_ref()
+            .ok_or(MissingSpecError::MissingLinux)?;
 
         match linux.rootfs_propagation().as_deref() {
             Some("shared") => flags |= MsFlags::MS_SHARED,

--- a/crates/libcontainer/src/rootless.rs
+++ b/crates/libcontainer/src/rootless.rs
@@ -1,5 +1,4 @@
-use crate::{namespaces::Namespaces, utils};
-use anyhow::{bail, Context, Result};
+use crate::namespaces::Namespaces;
 use nix::unistd::Pid;
 use oci_spec::runtime::{Linux, LinuxIdMapping, LinuxNamespace, LinuxNamespaceType, Mount, Spec};
 use std::fs;
@@ -41,14 +40,14 @@ impl RootlessIDMapper {
     }
 
     #[cfg(test)]
-    pub fn ensure_uid_path(&self, pid: &Pid) -> Result<()> {
+    pub fn ensure_uid_path(&self, pid: &Pid) -> std::result::Result<(), std::io::Error> {
         std::fs::create_dir_all(self.get_uid_path(pid).parent().unwrap())?;
 
         Ok(())
     }
 
     #[cfg(test)]
-    pub fn ensure_gid_path(&self, pid: &Pid) -> Result<()> {
+    pub fn ensure_gid_path(&self, pid: &Pid) -> std::result::Result<(), std::io::Error> {
         std::fs::create_dir_all(self.get_gid_path(pid).parent().unwrap())?;
 
         Ok(())
@@ -59,6 +58,64 @@ impl RootlessIDMapper {
     pub fn new_test(path: PathBuf) -> Self {
         Self { base_path: path }
     }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum RootlessError {
+    #[error("no linux in spec")]
+    NoLinuxSpec,
+    #[error("rootless container requires valid user namespace definition")]
+    NoUserNamespace,
+    #[error("invalid spec for rootless container")]
+    InvalidSpec(#[from] ValidateSpecError),
+    #[error("failed to read unprivileged userns clone")]
+    ReadUnprivilegedUsernsClone(#[source] std::io::Error),
+    #[error("failed to parse unprivileged userns clone")]
+    ParseUnprivilegedUsernsClone(#[source] std::num::ParseIntError),
+    #[error("unknown userns clone value")]
+    UnknownUnprivilegedUsernsClone(u8),
+    #[error(transparent)]
+    IDMapping(#[from] MappingError),
+}
+
+type Result<T> = std::result::Result<T, RootlessError>;
+
+#[derive(Debug, thiserror::Error)]
+pub enum ValidateSpecError {
+    #[error("no linux in spec")]
+    NoLinuxSpec,
+    #[error("rootless container requires valid user namespace definition")]
+    NoUserNamespace,
+    #[error("rootless container requires valid uid mappings")]
+    NoUIDMappings,
+    #[error("rootless container requires valid gid mappings")]
+    NoGIDMapping,
+    #[error("no mount in spec")]
+    NoMountSpec,
+    #[error("unprivileged user can't set supplementary groups")]
+    UnprivilegedUser,
+    #[error("supplementary group needs to be mapped in the gid mappings")]
+    GidNotMapped(u32),
+    #[error("failed to parse ID")]
+    ParseID(#[source] std::num::ParseIntError),
+    #[error("mount options require mapping uid inside the rootless container")]
+    MountGidMapping(u32),
+    #[error("mount options require mapping gid inside the rootless container")]
+    MountUidMapping(u32),
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum MappingError {
+    #[error("newuidmap/newgidmap binaries could not be found in path")]
+    BinaryNotFound,
+    #[error("could not find PATH")]
+    NoPathEnv,
+    #[error("failed to execute newuidmap/newgidmap")]
+    Execute(#[source] std::io::Error),
+    #[error("at least one id mapping needs to be defined")]
+    NoIDMapping,
+    #[error("failed to write id mapping")]
+    WriteIDMapping(#[source] std::io::Error),
 }
 
 #[derive(Debug, Clone, Default)]
@@ -81,21 +138,23 @@ pub struct Rootless<'a> {
 
 impl<'a> Rootless<'a> {
     pub fn new(spec: &'a Spec) -> Result<Option<Rootless<'a>>> {
-        let linux = spec.linux().as_ref().context("no linux in spec")?;
+        let linux = spec.linux().as_ref().ok_or(RootlessError::NoLinuxSpec)?;
         let namespaces = Namespaces::from(linux.namespaces().as_ref());
         let user_namespace = namespaces.get(LinuxNamespaceType::User);
 
         // If conditions requires us to use rootless, we must either create a new
         // user namespace or enter an existing.
         if rootless_required() && user_namespace.is_none() {
-            bail!("rootless container requires valid user namespace definition");
+            return Err(RootlessError::NoUserNamespace);
         }
 
         if user_namespace.is_some() && user_namespace.unwrap().path().is_none() {
             tracing::debug!("rootless container should be created");
 
-            validate_spec_for_rootless(spec)
-                .context("The spec failed to comply to rootless requirement")?;
+            validate_spec_for_rootless(spec).map_err(|err| {
+                tracing::error!("failed to validate spec for rootless container: {}", err);
+                err
+            })?;
             let mut rootless = Rootless::from(linux);
             if let Some((uid_binary, gid_binary)) = lookup_map_binaries(linux)? {
                 rootless.newuidmap = Some(uid_binary);
@@ -104,37 +163,35 @@ impl<'a> Rootless<'a> {
 
             Ok(Some(rootless))
         } else {
-            tracing::debug!("This is NOT a rootless container");
+            tracing::debug!("this is NOT a rootless container");
             Ok(None)
         }
     }
 
     pub fn write_uid_mapping(&self, target_pid: Pid) -> Result<()> {
-        tracing::debug!("Write UID mapping for {:?}", target_pid);
+        tracing::debug!("write UID mapping for {:?}", target_pid);
         if let Some(uid_mappings) = self.uid_mappings {
             write_id_mapping(
                 target_pid,
                 self.rootless_id_mapper.get_uid_path(&target_pid).as_path(),
                 uid_mappings,
                 self.newuidmap.as_deref(),
-            )
-        } else {
-            Ok(())
+            )?;
         }
+        Ok(())
     }
 
     pub fn write_gid_mapping(&self, target_pid: Pid) -> Result<()> {
-        tracing::debug!("Write GID mapping for {:?}", target_pid);
+        tracing::debug!("write GID mapping for {:?}", target_pid);
         if let Some(gid_mappings) = self.gid_mappings {
-            return write_id_mapping(
+            write_id_mapping(
                 target_pid,
                 self.rootless_id_mapper.get_gid_path(&target_pid).as_path(),
                 gid_mappings,
                 self.newgidmap.as_deref(),
-            );
-        } else {
-            Ok(())
+            )?;
         }
+        Ok(())
     }
 
     pub fn with_id_mapper(&mut self, mapper: RootlessIDMapper) {
@@ -174,42 +231,52 @@ pub fn unprivileged_user_ns_enabled() -> Result<bool> {
     }
 
     let content =
-        fs::read_to_string(user_ns_sysctl).context("failed to read unprivileged userns clone")?;
+        fs::read_to_string(user_ns_sysctl).map_err(RootlessError::ReadUnprivilegedUsernsClone)?;
 
-    match content.trim().parse::<u8>()? {
+    match content
+        .trim()
+        .parse::<u8>()
+        .map_err(RootlessError::ParseUnprivilegedUsernsClone)?
+    {
         0 => Ok(false),
         1 => Ok(true),
-        v => bail!("failed to parse unprivileged userns value: {}", v),
+        v => Err(RootlessError::UnknownUnprivilegedUsernsClone(v)),
     }
 }
 
 /// Validates that the spec contains the required information for
 /// running in rootless mode
-fn validate_spec_for_rootless(spec: &Spec) -> Result<()> {
-    let linux = spec.linux().as_ref().context("no linux in spec")?;
+fn validate_spec_for_rootless(spec: &Spec) -> std::result::Result<(), ValidateSpecError> {
+    tracing::debug!(?spec, "validating spec for rootless container");
+    let linux = spec
+        .linux()
+        .as_ref()
+        .ok_or(ValidateSpecError::NoLinuxSpec)?;
     let namespaces = Namespaces::from(linux.namespaces().as_ref());
     if namespaces.get(LinuxNamespaceType::User).is_none() {
-        bail!("rootless containers require the specification of a user namespace");
+        return Err(ValidateSpecError::NoUserNamespace);
     }
 
     let gid_mappings = linux
         .gid_mappings()
         .as_ref()
-        .context("rootless containers require gidMappings in spec")?;
+        .ok_or(ValidateSpecError::NoGIDMapping)?;
     let uid_mappings = linux
         .uid_mappings()
         .as_ref()
-        .context("rootless containers require uidMappings in spec")?;
+        .ok_or(ValidateSpecError::NoUIDMappings)?;
 
     if uid_mappings.is_empty() {
-        bail!("rootless containers require at least one uid mapping");
+        return Err(ValidateSpecError::NoUIDMappings);
     }
     if gid_mappings.is_empty() {
-        bail!("rootless containers require at least one gid mapping")
+        return Err(ValidateSpecError::NoGIDMapping);
     }
 
     validate_mounts_for_rootless(
-        spec.mounts().as_ref().context("no mounts in spec")?,
+        spec.mounts()
+            .as_ref()
+            .ok_or(ValidateSpecError::NoMountSpec)?,
         uid_mappings,
         gid_mappings,
     )?;
@@ -225,16 +292,18 @@ fn validate_spec_for_rootless(spec: &Spec) -> Result<()> {
             (true, false) => {
                 for gid in additional_gids {
                     if !is_id_mapped(*gid, gid_mappings) {
-                        bail!("gid {} is specified as supplementary group, but is not mapped in the user namespace", gid);
+                        tracing::error!(?gid,"gid is specified as supplementary group, but is not mapped in the user namespace");
+                        return Err(ValidateSpecError::GidNotMapped(*gid));
                     }
                 }
             }
             (false, false) => {
-                bail!(
-                    "user is {} (unprivileged). Supplementary groups cannot be set in \
+                tracing::error!(
+                    user = ?nix::unistd::geteuid(),
+                    "user is unprivileged. Supplementary groups cannot be set in \
                         a rootless container for this user due to CVE-2014-8989",
-                    nix::unistd::geteuid()
-                )
+                );
+                return Err(ValidateSpecError::UnprivilegedUser);
             }
             _ => {}
         }
@@ -247,16 +316,40 @@ fn validate_mounts_for_rootless(
     mounts: &[Mount],
     uid_mappings: &[LinuxIdMapping],
     gid_mappings: &[LinuxIdMapping],
-) -> Result<()> {
+) -> std::result::Result<(), ValidateSpecError> {
     for mount in mounts {
         if let Some(options) = mount.options() {
             for opt in options {
-                if opt.starts_with("uid=") && !is_id_mapped(opt[4..].parse()?, uid_mappings) {
-                    bail!("Mount {:?} specifies option {} which is not mapped inside the rootless container", mount, opt);
+                if opt.starts_with("uid=")
+                    && !is_id_mapped(
+                        opt[4..].parse().map_err(ValidateSpecError::ParseID)?,
+                        uid_mappings,
+                    )
+                {
+                    tracing::error!(
+                        ?mount,
+                        ?opt,
+                        "mount specifies option which is not mapped inside the rootless container"
+                    );
+                    return Err(ValidateSpecError::MountUidMapping(
+                        opt[4..].parse().map_err(ValidateSpecError::ParseID)?,
+                    ));
                 }
 
-                if opt.starts_with("gid=") && !is_id_mapped(opt[4..].parse()?, gid_mappings) {
-                    bail!("Mount {:?} specifies option {} which is not mapped inside the rootless container", mount, opt);
+                if opt.starts_with("gid=")
+                    && !is_id_mapped(
+                        opt[4..].parse().map_err(ValidateSpecError::ParseID)?,
+                        gid_mappings,
+                    )
+                {
+                    tracing::error!(
+                        ?mount,
+                        ?opt,
+                        "mount specifies option which is not mapped inside the rootless container"
+                    );
+                    return Err(ValidateSpecError::MountGidMapping(
+                        opt[4..].parse().map_err(ValidateSpecError::ParseID)?,
+                    ));
                 }
             }
         }
@@ -273,7 +366,9 @@ fn is_id_mapped(id: u32, mappings: &[LinuxIdMapping]) -> bool {
 
 /// Looks up the location of the newuidmap and newgidmap binaries which
 /// are required to write multiple user/group mappings
-pub fn lookup_map_binaries(spec: &Linux) -> Result<Option<(PathBuf, PathBuf)>> {
+pub fn lookup_map_binaries(
+    spec: &Linux,
+) -> std::result::Result<Option<(PathBuf, PathBuf)>, MappingError> {
     if let Some(uid_mappings) = spec.uid_mappings() {
         if uid_mappings.len() == 1 && uid_mappings.len() == 1 {
             return Ok(None);
@@ -284,15 +379,15 @@ pub fn lookup_map_binaries(spec: &Linux) -> Result<Option<(PathBuf, PathBuf)>> {
 
         match (uidmap, gidmap) {
             (Some(newuidmap), Some(newgidmap)) => Ok(Some((newuidmap, newgidmap))),
-            _ => bail!("newuidmap/newgidmap binaries could not be found in path. This is required if multiple id mappings are specified"),
+            _ => Err(MappingError::BinaryNotFound),
         }
     } else {
         Ok(None)
     }
 }
 
-fn lookup_map_binary(binary: &str) -> Result<Option<PathBuf>> {
-    let paths = env::var("PATH").context("could not find PATH")?;
+fn lookup_map_binary(binary: &str) -> std::result::Result<Option<PathBuf>, MappingError> {
+    let paths = env::var("PATH").map_err(|_| MappingError::NoPathEnv)?;
     Ok(paths
         .split_terminator(':')
         .map(|p| Path::new(p).join(binary))
@@ -304,17 +399,20 @@ fn write_id_mapping(
     map_file: &Path,
     mappings: &[LinuxIdMapping],
     map_binary: Option<&Path>,
-) -> Result<()> {
+) -> std::result::Result<(), MappingError> {
     tracing::debug!("Write ID mapping: {:?}", mappings);
 
     match mappings.len() {
-        0 => bail!("at least one id mapping needs to be defined"),
+        0 => return Err(MappingError::NoIDMapping),
         1 => {
             let mapping = mappings
                 .first()
                 .and_then(|m| format!("{} {} {}", m.container_id(), m.host_id(), m.size()).into())
                 .unwrap();
-            utils::write_file(map_file, mapping)?;
+            std::fs::write(map_file, &mapping).map_err(|err| {
+                tracing::error!(?err, ?map_file, ?mapping, "failed to write uid/gid mapping");
+                MappingError::WriteIDMapping(err)
+            })?;
         }
         _ => {
             let args: Vec<String> = mappings
@@ -332,7 +430,10 @@ fn write_id_mapping(
                 .arg(pid.to_string())
                 .args(args)
                 .output()
-                .with_context(|| format!("failed to execute {map_binary:?}"))?;
+                .map_err(|err| {
+                    tracing::error!(?err, ?map_binary, "failed to execute newuidmap/newgidmap");
+                    MappingError::Execute(err)
+                })?;
         }
     }
 
@@ -343,6 +444,7 @@ fn write_id_mapping(
 mod tests {
     use std::fs;
 
+    use anyhow::Result;
     use nix::unistd::getpid;
     use oci_spec::runtime::{
         LinuxBuilder, LinuxIdMappingBuilder, LinuxNamespaceBuilder, SpecBuilder,

--- a/crates/youki/src/workload/wasmedge.rs
+++ b/crates/youki/src/workload/wasmedge.rs
@@ -48,18 +48,18 @@ impl Executor for WasmEdgeExecutor {
         Ok(())
     }
 
-    fn can_handle(&self, spec: &Spec) -> Result<bool> {
+    fn can_handle(&self, spec: &Spec) -> bool {
         if let Some(annotations) = spec.annotations() {
             if let Some(handler) = annotations.get("run.oci.handler") {
-                return Ok(handler == "wasm");
+                return handler == "wasm";
             }
 
             if let Some(variant) = annotations.get("module.wasm.image/variant") {
-                return Ok(variant == "compat");
+                return variant == "compat";
             }
         }
 
-        Ok(false)
+        false
     }
 
     fn name(&self) -> &'static str {

--- a/crates/youki/src/workload/wasmer.rs
+++ b/crates/youki/src/workload/wasmer.rs
@@ -67,18 +67,18 @@ impl Executor for WasmerExecutor {
         Ok(())
     }
 
-    fn can_handle(&self, spec: &Spec) -> Result<bool> {
+    fn can_handle(&self, spec: &Spec) -> bool {
         if let Some(annotations) = spec.annotations() {
             if let Some(handler) = annotations.get("run.oci.handler") {
-                return Ok(handler == "wasm");
+                return handler == "wasm";
             }
 
             if let Some(variant) = annotations.get("module.wasm.image/variant") {
-                return Ok(variant == "compat");
+                return variant == "compat";
             }
         }
 
-        Ok(false)
+        false
     }
 
     fn name(&self) -> &'static str {
@@ -101,9 +101,7 @@ mod tests {
             .build()
             .context("build spec")?;
 
-        assert!(WasmerExecutor::default()
-            .can_handle(&spec)
-            .context("can handle")?);
+        assert!(WasmerExecutor::default().can_handle(&spec));
 
         Ok(())
     }
@@ -117,9 +115,7 @@ mod tests {
             .build()
             .context("build spec")?;
 
-        assert!(WasmerExecutor::default()
-            .can_handle(&spec)
-            .context("can handle")?);
+        assert!(WasmerExecutor::default().can_handle(&spec));
 
         Ok(())
     }
@@ -128,9 +124,7 @@ mod tests {
     fn test_can_handle_no_execute() -> Result<()> {
         let spec = SpecBuilder::default().build().context("build spec")?;
 
-        assert!(!WasmerExecutor::default()
-            .can_handle(&spec)
-            .context("can handle")?);
+        assert!(!WasmerExecutor::default().can_handle(&spec));
 
         Ok(())
     }

--- a/crates/youki/src/workload/wasmtime.rs
+++ b/crates/youki/src/workload/wasmtime.rs
@@ -77,18 +77,18 @@ impl Executor for WasmtimeExecutor {
             .context("wasm module was not executed successfully")
     }
 
-    fn can_handle(&self, spec: &Spec) -> Result<bool> {
+    fn can_handle(&self, spec: &Spec) -> bool {
         if let Some(annotations) = spec.annotations() {
             if let Some(handler) = annotations.get("run.oci.handler") {
-                return Ok(handler == "wasm");
+                return handler == "wasm";
             }
 
             if let Some(variant) = annotations.get("module.wasm.image/variant") {
-                return Ok(variant == "compat");
+                return variant == "compat";
             }
         }
 
-        Ok(false)
+        false
     }
 
     fn name(&self) -> &'static str {


### PR DESCRIPTION
This is the second to last PR. I converted most of the module in crate libcontainer to use `thiserror`. The missing 2 are `container` and `workload`. Both of these 2 requires a bit more thinking. The `workload` requires us to define the Executor type with an Error associated type. The container crate will be the main interface exposed by the `libcontainer` crate. It is easier to review these two changes in a different PR.