### PR TITLE
implemented thiserror for containers - Part 5

### DIFF
--- a/crates/libcontainer/src/apparmor.rs
+++ b/crates/libcontainer/src/apparmor.rs
@@ -12,11 +12,6 @@ pub enum AppArmorError {
         profile: String,
         source: std::io::Error,
     },
-    #[error("failed to read AppArmor profile: {source} {path}")]
-    ReadProfile {
-        path: String,
-        source: std::io::Error,
-    },
     #[error(transparent)]
     EnsureProcfs(#[from] utils::EnsureProcfsError),
 }
@@ -26,12 +21,8 @@ type Result<T> = std::result::Result<T, AppArmorError>;
 const ENABLED_PARAMETER_PATH: &str = "/sys/module/apparmor/parameters/enabled";
 
 /// Checks if AppArmor has been enabled on the system.
-pub fn is_enabled() -> Result<bool> {
-    let aa_enabled =
-        fs::read_to_string(ENABLED_PARAMETER_PATH).map_err(|e| AppArmorError::ReadProfile {
-            path: ENABLED_PARAMETER_PATH.to_string(),
-            source: e,
-        })?;
+pub fn is_enabled() -> std::result::Result<bool, std::io::Error> {
+    let aa_enabled = fs::read_to_string(ENABLED_PARAMETER_PATH)?;
     Ok(aa_enabled.starts_with('Y'))
 }
 

--- a/crates/libcontainer/src/container/container_events.rs
+++ b/crates/libcontainer/src/container/container_events.rs
@@ -34,9 +34,7 @@ impl Container {
         }
 
         let cgroups_path = self.spec()?.cgroup_path;
-        let use_systemd = self
-            .systemd()
-            .context("could not determine cgroup manager")?;
+        let use_systemd = self.systemd();
 
         let cgroup_manager =
             libcgroups::common::create_cgroup_manager(cgroups_path, use_systemd, self.id())?;

--- a/crates/libcontainer/src/container/container_kill.rs
+++ b/crates/libcontainer/src/container/container_kill.rs
@@ -1,6 +1,5 @@
 use super::{Container, ContainerStatus};
-use crate::signal::Signal;
-use anyhow::{bail, Context, Result};
+use crate::{error::LibcontainerError, signal::Signal};
 use libcgroups::common::{create_cgroup_manager, get_cgroup_setup, CgroupManager};
 use nix::sys::signal::{self};
 
@@ -27,28 +26,29 @@ impl Container {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn kill<S: Into<Signal>>(&mut self, signal: S, all: bool) -> Result<()> {
-        self.refresh_status()
-            .context("failed to refresh container status")?;
-        if self.can_kill() {
-            self.do_kill(signal, all)?;
-        } else {
-            // just like runc, allow kill --all even if the container is stopped
-            if all && self.status() == ContainerStatus::Stopped {
+    pub fn kill<S: Into<Signal>>(&mut self, signal: S, all: bool) -> Result<(), LibcontainerError> {
+        self.refresh_status()?;
+        match self.can_kill() {
+            true => {
                 self.do_kill(signal, all)?;
-            } else {
-                bail!(
-                    "{} could not be killed because it was {:?}",
-                    self.id(),
-                    self.status()
-                )
+            }
+            false if all && self.status() == ContainerStatus::Stopped => {
+                self.do_kill(signal, all)?;
+            }
+            false => {
+                tracing::error!(id = ?self.id(), status = ?self.status(), "cannot kill container due to incorrect state");
+                return Err(LibcontainerError::IncorrectContainerStatus);
             }
         }
         self.set_status(ContainerStatus::Stopped).save()?;
         Ok(())
     }
 
-    pub(crate) fn do_kill<S: Into<Signal>>(&self, signal: S, all: bool) -> Result<()> {
+    pub(crate) fn do_kill<S: Into<Signal>>(
+        &self,
+        signal: S,
+        all: bool,
+    ) -> Result<(), LibcontainerError> {
         if all {
             self.kill_all_processes(signal)
         } else {
@@ -56,32 +56,36 @@ impl Container {
         }
     }
 
-    fn kill_one_process<S: Into<Signal>>(&self, signal: S) -> Result<()> {
+    fn kill_one_process<S: Into<Signal>>(&self, signal: S) -> Result<(), LibcontainerError> {
         let signal = signal.into().into_raw();
         let pid = self.pid().unwrap();
 
         tracing::debug!("kill signal {} to {}", signal, pid);
-        let res = signal::kill(pid, signal);
 
-        match res {
+        match signal::kill(pid, signal) {
+            Ok(_) => {}
             Err(nix::errno::Errno::ESRCH) => {
-                /* the process does not exist, which is what we want */
+                // the process does not exist, which is what we want
             }
-            _ => res?,
+            Err(err) => {
+                tracing::error!(id = ?self.id(), err = ?err, ?pid, ?signal, "failed to kill process");
+                return Err(LibcontainerError::OtherSyscall(err));
+            }
         }
 
         // For cgroup V1, a frozon process cannot respond to signals,
         // so we need to thaw it. Only thaw the cgroup for SIGKILL.
         if self.status() == ContainerStatus::Paused && signal == signal::Signal::SIGKILL {
-            match get_cgroup_setup()? {
+            match get_cgroup_setup().map_err(|err| LibcontainerError::Cgroups(err.to_string()))? {
                 libcgroups::common::CgroupSetup::Legacy
                 | libcgroups::common::CgroupSetup::Hybrid => {
                     let cgroups_path = self.spec()?.cgroup_path;
-                    let use_systemd = self
-                        .systemd()
-                        .context("container state does not contain cgroup manager")?;
-                    let cmanger = create_cgroup_manager(cgroups_path, use_systemd, self.id())?;
-                    cmanger.freeze(libcgroups::common::FreezerState::Thawed)?;
+                    let use_systemd = self.systemd();
+                    let cmanger = create_cgroup_manager(cgroups_path, use_systemd, self.id())
+                        .map_err(|err| LibcontainerError::Cgroups(err.to_string()))?;
+                    cmanger
+                        .freeze(libcgroups::common::FreezerState::Thawed)
+                        .map_err(|err| LibcontainerError::Cgroups(err.to_string()))?;
                 }
                 libcgroups::common::CgroupSetup::Unified => {}
             }
@@ -89,41 +93,45 @@ impl Container {
         Ok(())
     }
 
-    fn kill_all_processes<S: Into<Signal>>(&self, signal: S) -> Result<()> {
+    fn kill_all_processes<S: Into<Signal>>(&self, signal: S) -> Result<(), LibcontainerError> {
         let signal = signal.into().into_raw();
         let cgroups_path = self.spec()?.cgroup_path;
-        let use_systemd = self
-            .systemd()
-            .context("container state does not contain cgroup manager")?;
-        let cmanger = create_cgroup_manager(cgroups_path, use_systemd, self.id())?;
-        let ret = cmanger.freeze(libcgroups::common::FreezerState::Frozen);
-        if ret.is_err() {
+        let use_systemd = self.systemd();
+        let cmanger = create_cgroup_manager(cgroups_path, use_systemd, self.id())
+            .map_err(|err| LibcontainerError::Cgroups(err.to_string()))?;
+
+        if let Err(e) = cmanger.freeze(libcgroups::common::FreezerState::Frozen) {
             tracing::warn!(
-                "failed to freeze container {}, error: {}",
-                self.id(),
-                ret.unwrap_err()
+                err = ?e,
+                id = ?self.id(),
+                "failed to freeze container",
             );
         }
-        let pids = cmanger.get_all_pids()?;
-        pids.iter().try_for_each(|&pid| {
-            tracing::debug!("kill signal {} to {}", signal, pid);
-            let res = signal::kill(pid, signal);
-            match res {
-                Err(nix::errno::Errno::ESRCH) => {
-                    /* the process does not exist, which is what we want */
-                    Ok(())
+
+        let pids = cmanger
+            .get_all_pids()
+            .map_err(|err| LibcontainerError::Cgroups(err.to_string()))?;
+        pids.iter()
+            .try_for_each(|&pid| {
+                tracing::debug!("kill signal {} to {}", signal, pid);
+                let res = signal::kill(pid, signal);
+                match res {
+                    Err(nix::errno::Errno::ESRCH) => {
+                        // the process does not exist, which is what we want
+                        Ok(())
+                    }
+                    _ => res,
                 }
-                _ => res,
-            }
-        })?;
-        let ret = cmanger.freeze(libcgroups::common::FreezerState::Thawed);
-        if ret.is_err() {
+            })
+            .map_err(LibcontainerError::OtherSyscall)?;
+        if let Err(err) = cmanger.freeze(libcgroups::common::FreezerState::Thawed) {
             tracing::warn!(
-                "failed to thaw container {}, error: {}",
-                self.id(),
-                ret.unwrap_err()
+                err = ?err,
+                id = ?self.id(),
+                "failed to thaw container",
             );
         }
+
         Ok(())
     }
 }

--- a/crates/libcontainer/src/container/container_pause.rs
+++ b/crates/libcontainer/src/container/container_pause.rs
@@ -37,9 +37,7 @@ impl Container {
         }
 
         let cgroups_path = self.spec()?.cgroup_path;
-        let use_systemd = self
-            .systemd()
-            .context("container state does not contain cgroup manager")?;
+        let use_systemd = self.systemd();
         let cmanager =
             libcgroups::common::create_cgroup_manager(cgroups_path, use_systemd, self.id())?;
         cmanager.freeze(FreezerState::Frozen)?;

--- a/crates/libcontainer/src/container/container_resume.rs
+++ b/crates/libcontainer/src/container/container_resume.rs
@@ -39,9 +39,7 @@ impl Container {
         }
 
         let cgroups_path = self.spec()?.cgroup_path;
-        let use_systemd = self
-            .systemd()
-            .context("container state does not contain cgroup manager")?;
+        let use_systemd = self.systemd();
         let cmanager =
             libcgroups::common::create_cgroup_manager(cgroups_path, use_systemd, self.id())?;
         // resume the frozen container

--- a/crates/libcontainer/src/container/state.rs
+++ b/crates/libcontainer/src/container/state.rs
@@ -118,7 +118,7 @@ pub struct State {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub creator: Option<u32>,
     // Specifies if systemd should be used to manage cgroups
-    pub use_systemd: Option<bool>,
+    pub use_systemd: bool,
     // Specifies if the Intel RDT subdirectory needs be cleaned up.
     pub clean_up_intel_rdt_subdirectory: Option<bool>,
 }
@@ -141,7 +141,7 @@ impl State {
             annotations: Some(HashMap::default()),
             created: None,
             creator: None,
-            use_systemd: None,
+            use_systemd: false,
             clean_up_intel_rdt_subdirectory: None,
         }
     }

--- a/crates/libcontainer/src/container/tenant_builder.rs
+++ b/crates/libcontainer/src/container/tenant_builder.rs
@@ -376,11 +376,7 @@ impl<'a> TenantContainerBuilder<'a> {
     }
 
     fn should_use_systemd(&self, container: &Container) -> bool {
-        if let Some(use_systemd) = container.systemd() {
-            return use_systemd;
-        }
-
-        false
+        container.systemd()
     }
 
     fn setup_notify_listener(container_dir: &Path) -> Result<PathBuf> {

--- a/crates/libcontainer/src/error.rs
+++ b/crates/libcontainer/src/error.rs
@@ -14,9 +14,79 @@ pub enum UnifiedSyscallError {
 #[derive(Debug, thiserror::Error)]
 pub enum MissingSpecError {
     #[error("missing process in spec")]
-    MissingProcess,
+    Process,
     #[error("missing linux in spec")]
-    MissingLinux,
+    Linux,
     #[error("missing args in the process spec")]
-    MissingArgs,
+    Args,
+    #[error("missing root in the spec")]
+    Root,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum LibcontainerError {
+    #[error("failed to perform operation due to incorrect container status")]
+    IncorrectContainerStatus,
+    #[error("container already exists")]
+    ContainerAlreadyExists,
+    #[error("invalid input")]
+    InvalidInput(String),
+    #[error("requires at least one executors")]
+    NoExecutors,
+
+    // Invalid inputs
+    #[error(transparent)]
+    InvalidID(#[from] ErrInvalidID),
+    #[error(transparent)]
+    MissingSpec(#[from] MissingSpecError),
+    #[error("invalid runtime spec")]
+    InvalidSpec(#[from] ErrInvalidSpec),
+
+    // Errors from submodules and other errors
+    #[error(transparent)]
+    Tty(#[from] crate::tty::TTYError),
+    #[error(transparent)]
+    Rootless(#[from] crate::rootless::RootlessError),
+    #[error(transparent)]
+    NotifyListener(#[from] crate::notify_socket::NotifyListenerError),
+    #[error(transparent)]
+    Config(#[from] crate::config::ConfigError),
+    #[error(transparent)]
+    Hook(#[from] crate::hooks::HookError),
+    #[error(transparent)]
+    State(#[from] crate::container::state::StateError),
+    #[error("oci spec error")]
+    Spec(#[from] oci_spec::OciSpecError),
+    #[error("cgroups error: {0}")]
+    Cgroups(String),
+    #[error(transparent)]
+    MainProcess(#[from] crate::process::container_main_process::ProcessError),
+    #[error(transparent)]
+    Procfs(#[from] procfs::ProcError),
+
+    // Catch all errors that are not covered by the above
+    #[error("syscall error")]
+    OtherSyscall(#[source] nix::Error),
+    #[error("IO error")]
+    OtherIO(#[source] std::io::Error),
+    #[error("{0}")]
+    Other(String),
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum ErrInvalidID {
+    #[error("container id can't be empty")]
+    Empty,
+    #[error("container id contains invalid characters: {0}")]
+    InvalidChars(char),
+    #[error("container id can't be used to represent a file name (such as . or ..)")]
+    FileName,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum ErrInvalidSpec {
+    #[error("runtime spec has incompatible version. Only 1.X.Y is supported")]
+    UnsupportedVersion,
+    #[error("apparmor is specified but not enabled on this system")]
+    AppArmorNotEnabled,
 }

--- a/crates/libcontainer/src/process/container_init_process.rs
+++ b/crates/libcontainer/src/process/container_init_process.rs
@@ -339,14 +339,8 @@ pub fn container_init_process(
 ) -> Result<()> {
     let syscall = args.syscall;
     let spec = args.spec;
-    let linux = spec
-        .linux()
-        .as_ref()
-        .ok_or(MissingSpecError::MissingLinux)?;
-    let proc = spec
-        .process()
-        .as_ref()
-        .ok_or(MissingSpecError::MissingProcess)?;
+    let linux = spec.linux().as_ref().ok_or(MissingSpecError::Linux)?;
+    let proc = spec.process().as_ref().ok_or(MissingSpecError::Process)?;
     let mut envs: Vec<String> = proc.env().as_ref().unwrap_or(&vec![]).clone();
     let rootfs_path = args.rootfs;
     let hooks = spec.hooks().as_ref();
@@ -693,7 +687,7 @@ pub fn container_init_process(
         unreachable!("should not be back here");
     } else {
         tracing::error!("on non-Windows, at least one process arg entry is required");
-        Err(MissingSpecError::MissingArgs)
+        Err(MissingSpecError::Args)
     }?
 }
 

--- a/crates/libcontainer/src/process/container_intermediate_process.rs
+++ b/crates/libcontainer/src/process/container_intermediate_process.rs
@@ -42,10 +42,7 @@ pub fn container_intermediate_process(
     let (init_sender, init_receiver) = init_chan;
     let command = &args.syscall;
     let spec = &args.spec;
-    let linux = spec
-        .linux()
-        .as_ref()
-        .ok_or(MissingSpecError::MissingLinux)?;
+    let linux = spec.linux().as_ref().ok_or(MissingSpecError::Linux)?;
     let namespaces = Namespaces::from(linux.namespaces().as_ref());
 
     // this needs to be done before we create the init process, so that the init
@@ -96,10 +93,7 @@ pub fn container_intermediate_process(
     }
 
     // set limits and namespaces to the process
-    let proc = spec
-        .process()
-        .as_ref()
-        .ok_or(MissingSpecError::MissingProcess)?;
+    let proc = spec.process().as_ref().ok_or(MissingSpecError::Process)?;
     if let Some(rlimits) = proc.rlimits() {
         for rlimit in rlimits {
             command.set_rlimit(rlimit)?;

--- a/crates/libcontainer/src/rootfs/rootfs.rs
+++ b/crates/libcontainer/src/rootfs/rootfs.rs
@@ -40,10 +40,7 @@ impl RootFS {
     ) -> Result<()> {
         tracing::debug!("Prepare rootfs: {:?}", rootfs);
         let mut flags = MsFlags::MS_REC;
-        let linux = spec
-            .linux()
-            .as_ref()
-            .ok_or(MissingSpecError::MissingLinux)?;
+        let linux = spec.linux().as_ref().ok_or(MissingSpecError::Linux)?;
 
         match linux.rootfs_propagation().as_deref() {
             Some("shared") => flags |= MsFlags::MS_SHARED,

--- a/crates/libcontainer/src/rootless.rs
+++ b/crates/libcontainer/src/rootless.rs
@@ -139,10 +139,7 @@ pub struct Rootless<'a> {
 
 impl<'a> Rootless<'a> {
     pub fn new(spec: &'a Spec) -> Result<Option<Rootless<'a>>> {
-        let linux = spec
-            .linux()
-            .as_ref()
-            .ok_or(MissingSpecError::MissingLinux)?;
+        let linux = spec.linux().as_ref().ok_or(MissingSpecError::Linux)?;
         let namespaces = Namespaces::from(linux.namespaces().as_ref());
         let user_namespace = namespaces.get(LinuxNamespaceType::User);
 
@@ -252,10 +249,7 @@ pub fn unprivileged_user_ns_enabled() -> Result<bool> {
 /// running in rootless mode
 fn validate_spec_for_rootless(spec: &Spec) -> std::result::Result<(), ValidateSpecError> {
     tracing::debug!(?spec, "validating spec for rootless container");
-    let linux = spec
-        .linux()
-        .as_ref()
-        .ok_or(MissingSpecError::MissingLinux)?;
+    let linux = spec.linux().as_ref().ok_or(MissingSpecError::Linux)?;
     let namespaces = Namespaces::from(linux.namespaces().as_ref());
     if namespaces.get(LinuxNamespaceType::User).is_none() {
         return Err(ValidateSpecError::NoUserNamespace);

--- a/crates/youki/src/commands/kill.rs
+++ b/crates/youki/src/commands/kill.rs
@@ -1,7 +1,7 @@
 //! Contains functionality of kill container command
 use std::{convert::TryInto, path::PathBuf};
 
-use anyhow::Result;
+use anyhow::{anyhow, Result};
 
 use crate::commands::load_container;
 use libcontainer::{container::ContainerStatus, signal::Signal};
@@ -15,9 +15,9 @@ pub fn kill(args: Kill, root_path: PathBuf) -> Result<()> {
         Err(e) => {
             // see https://github.com/containers/youki/issues/1314
             if container.status() == ContainerStatus::Stopped {
-                return Err(e.context("container not running"));
+                return Err(anyhow!(e).context("container not running"));
             }
-            Err(e)
+            Err(anyhow!(e).context("failed to kill container"))
         }
     }
 }

--- a/crates/youki/src/commands/mod.rs
+++ b/crates/youki/src/commands/mod.rs
@@ -59,9 +59,7 @@ fn create_cgroup_manager<P: AsRef<Path>>(
 ) -> Result<AnyCgroupManager> {
     let container = load_container(root_path, container_id)?;
     let cgroups_path = container.spec()?.cgroup_path;
-    let systemd_cgroup = container
-        .systemd()
-        .context("could not determine cgroup manager")?;
+    let systemd_cgroup = container.systemd();
 
     Ok(libcgroups::common::create_cgroup_manager(
         cgroups_path,


### PR DESCRIPTION
Implemented `thiserror` for container module. The only thing left now is `workload` which I will do together to remove anyhow from dependency (moving to dev-dependency). The workload code logic requires a little refactor, so for easy review, we will do it in another PR.