### PR TITLE
Simplified syscall error

### DIFF
--- a/crates/libcontainer/src/error.rs
+++ b/crates/libcontainer/src/error.rs
@@ -1,16 +1,3 @@
-/// UnifiedSyscallError aims to simplify error handling of syscalls in
-/// libcontainer. In many occasions, we mix nix::Error, std::io::Error and our
-/// own syscall wrappers, which makes error handling complicated.
-#[derive(Debug, thiserror::Error)]
-pub enum UnifiedSyscallError {
-    #[error(transparent)]
-    Io(#[from] std::io::Error),
-    #[error(transparent)]
-    Nix(#[from] nix::Error),
-    #[error(transparent)]
-    Syscall(#[from] crate::syscall::SyscallError),
-}
-
 #[derive(Debug, thiserror::Error)]
 pub enum MissingSpecError {
     #[error("missing process in spec")]

--- a/crates/libcontainer/src/rootfs/mount.rs
+++ b/crates/libcontainer/src/rootfs/mount.rs
@@ -522,7 +522,7 @@ impl Mount {
             self.syscall
                 .mount(Some(&*src), dest, typ, mount_option_config.flags, Some(&*d))
         {
-            if let SyscallError::Mount { source: errno, .. } = err {
+            if let SyscallError::Nix(errno) = err {
                 if !matches!(errno, Errno::EINVAL) {
                     tracing::error!("mount of {:?} failed. {}", m.destination(), errno);
                     return Err(err.into());

--- a/crates/libcontainer/src/syscall/mod.rs
+++ b/crates/libcontainer/src/syscall/mod.rs
@@ -12,76 +12,12 @@ pub use syscall::Syscall;
 pub enum SyscallError {
     #[error("unexpected mount attr option: {0}")]
     UnexpectedMountAttrOption(String),
-    #[error("set keep capabilities to {value}")]
-    PrctlSetKeepCapabilites {
-        #[source]
-        errno: nix::errno::Errno,
-        value: bool,
-    },
-    #[error("set hostname to {hostname}")]
-    SetHostname {
-        #[source]
-        errno: nix::errno::Errno,
-        hostname: String,
-    },
-    #[error("set domainname to {domainname}")]
-    SetDomainname {
-        #[source]
-        errno: nix::errno::Errno,
-        domainname: String,
-    },
-    #[error("{0} is not an actual procfs")]
-    NotProcfs(String),
-    #[error("failed to get open fds")]
-    GetOpenFds(#[source] std::io::Error),
-    #[error("failed to pivot root")]
-    PivotRoot { source: nix::errno::Errno },
-    #[error("failed to setns: {0}")]
-    SetNamespace(nix::errno::Errno),
-    #[error("failed to set real gid to {gid}")]
-    SetRealGid {
-        #[source]
-        errno: nix::errno::Errno,
-        gid: nix::unistd::Gid,
-    },
-    #[error("failed to set real uid to {uid}: {errno}")]
-    SetRealUid {
-        #[source]
-        errno: nix::errno::Errno,
-        uid: nix::unistd::Uid,
-    },
-    #[error("failed to unshare: {0}")]
-    Unshare(nix::errno::Errno),
+    #[error(transparent)]
+    Nix(#[from] nix::Error),
+    #[error(transparent)]
+    IO(#[from] std::io::Error),
     #[error("failed to set capabilities: {0}")]
     SetCaps(#[from] caps::errors::CapsError),
-    #[error("failed to set rlimit {rlimit:?}")]
-    SetRlimit {
-        #[source]
-        errno: nix::errno::Errno,
-        rlimit: oci_spec::runtime::LinuxRlimitType,
-    },
-    #[error("failed to chroot: {source}")]
-    Chroot { source: nix::errno::Errno },
-    #[error("mount failed")]
-    Mount { source: nix::errno::Errno },
-    #[error("symlink failed")]
-    Symlink { source: std::io::Error },
-    #[error("mknod failed")]
-    Mknod { source: nix::errno::Errno },
-    #[error("chown failed")]
-    Chown { source: nix::errno::Errno },
-    #[error("setgroups failed")]
-    SetGroups { source: nix::errno::Errno },
-    #[error("close range failed")]
-    CloseRange {
-        preserve_fds: i32,
-        #[source]
-        errno: syscalls::Errno,
-    },
-    #[error("invalid filename: {0:?}")]
-    InvalidFilename(std::path::PathBuf),
-    #[error("mount_setattr failed")]
-    MountSetattr { source: syscalls::Errno },
 }
 
 type Result<T> = std::result::Result<T, SyscallError>;

--- a/crates/libcontainer/src/syscall/syscall.rs
+++ b/crates/libcontainer/src/syscall/syscall.rs
@@ -1,7 +1,6 @@
 //! An interface trait so that rest of Youki can call
 //! necessary functions without having to worry about their
 //! implementation details
-use bitflags::bitflags;
 use caps::{CapSet, CapsHashSet};
 use libc;
 use nix::{
@@ -64,10 +63,3 @@ pub fn create_syscall() -> Box<dyn Syscall> {
         Box::new(LinuxSyscall)
     }
 }
-
-bitflags! {
-pub struct CloseRange : u32 {
-    const NONE = 0b00000000;
-    const UNSHARE = 0b00000010;
-    const CLOEXEC = 0b00000100;
-}}

--- a/crates/libcontainer/src/tty.rs
+++ b/crates/libcontainer/src/tty.rs
@@ -10,8 +10,6 @@ use std::os::unix::io::AsRawFd;
 use std::os::unix::prelude::RawFd;
 use std::path::{Path, PathBuf};
 
-use crate::error::UnifiedSyscallError;
-
 #[derive(Debug)]
 pub enum StdIO {
     Stdin = 0,
@@ -60,7 +58,7 @@ pub enum TTYError {
         source: nix::Error,
     },
     #[error("failed to create console socket fd")]
-    CreateConsoleSocketFd { source: UnifiedSyscallError },
+    CreateConsoleSocketFd { source: nix::Error },
     #[error("could not create pseudo terminal")]
     CreatePseudoTerminal { source: nix::Error },
     #[error("failed to send pty master")]
@@ -90,7 +88,7 @@ pub fn setup_console_socket(
         socket::SockFlag::empty(),
         None,
     )
-    .map_err(|err| TTYError::CreateConsoleSocketFd { source: err.into() })?;
+    .map_err(|err| TTYError::CreateConsoleSocketFd { source: err })?;
     csocketfd = match socket::connect(
         csocketfd,
         &socket::UnixAddr::new(socket_name).map_err(|err| TTYError::InvalidSocketName {


### PR DESCRIPTION
- Refactored the syscall errors. There is no need to create an error for each syscall. Only the errno is what is required. Other context can be logged at the site of the errors.
- Removed the `UnifiedSyscallError`. It was not well thought out at the moment.
- Refactored close_range and mount_set_attr to use `libc::syscall` directly.