### PR TITLE
Adjust capabilities and UID/GID setup to align with runc

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -57,21 +57,18 @@ jobs:
           runc --version
       - name: Integration Test
         run: sudo make TEST_RUNTIME=io.containerd.runc.v2 TESTFLAGS="-timeout 40m" integration
-  #
-  # k8s-tests:
-  #   runs-on: ubuntu-22.04
-  #   needs: [youki-build]
-  #   timeout-minutes: 40
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #     - name: Download youki binary
-  #       uses: actions/download-artifact@v3
-  #       with:
-  #         name: youki
-  #     - name: Add the permission to run
-  #       run: chmod +x ./youki
-  #     - name: test/k8s/deploy
-  #       run: make test/k8s/deploy
-  #     # - name: Debug
-  #     #   if: ${{ always() }}
-  #     #   uses: mxschmitt/action-tmate@v3
+
+  k8s-tests:
+    runs-on: ubuntu-22.04
+    needs: [youki-build]
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v3
+      - name: Download youki binary
+        uses: actions/download-artifact@v3
+        with:
+          name: youki
+      - name: Add the permission to run
+        run: chmod +x ./youki
+      - name: test/k8s/deploy
+        run: make test/k8s/deploy


### PR DESCRIPTION
Ref:
https://github.com/opencontainers/runc/blob/ba58ee9c3b9550c3e32b94802b0fb29761955290/libcontainer/init_linux.go#L259-L280
The timing of the capability reset is also organized so that the capability is applied correctly.