### PR TITLE
Update dependencies described in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,8 @@ $ sudo apt-get install   \
       build-essential    \
       libelf-dev \
       libseccomp-dev \
-      libclang-dev
+      libclang-dev \
+      libssl-devel
 ```
 
 ### Fedora, Centos, RHEL and related distributions
@@ -165,7 +166,8 @@ $ sudo dnf install   \
       dbus-devel     \
       elfutils-libelf-devel \
       libseccomp-devel \
-      clang-devel
+      clang-devel \
+      openssl-devel
 ```
 
 ## Build

--- a/README.md
+++ b/README.md
@@ -146,27 +146,27 @@ For other platforms, please use the [Vagrantfile](#setting-up-vagrant) that we h
 ### Debian, Ubuntu and related distributions
 
 ```console
-$ sudo apt-get install   \
-      pkg-config         \
-      libsystemd-dev     \
-      libdbus-glib-1-dev \
-      build-essential    \
-      libelf-dev \
-      libseccomp-dev \
-      libclang-dev \
-      libssl-devel
+$ sudo apt-get install    \
+      pkg-config          \
+      libsystemd-dev      \
+      libdbus-glib-1-dev  \
+      build-essential     \
+      libelf-dev          \
+      libseccomp-dev      \
+      libclang-dev        \
+      libssl-dev
 ```
 
-### Fedora, Centos, RHEL and related distributions
+### Fedora, CentOS, RHEL and related distributions
 
 ```console
-$ sudo dnf install   \
-      pkg-config     \
-      systemd-devel  \
-      dbus-devel     \
+$ sudo dnf install          \
+      pkg-config            \
+      systemd-devel         \
+      dbus-devel            \
       elfutils-libelf-devel \
-      libseccomp-devel \
-      clang-devel \
+      libseccomp-devel      \
+      clang-devel           \
       openssl-devel
 ```
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -12,7 +12,7 @@ Vagrant.configure("2") do |config|
     config.vm.provision "shell", inline: <<-SHELL
       set -e -u -o pipefail
       yum update -y
-      yum install -y git gcc docker systemd-devel dbus-devel libseccomp-devel wget openssl-devel
+      yum install -y git gcc docker wget pkg-config systemd-devel dbus-devel elfutils-libelf-devel libseccomp-devel clang-devel openssl-devel
       grubby --update-kernel=ALL --args="systemd.unified_cgroup_hierarchy=0"
       service docker start
     SHELL

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -12,7 +12,7 @@ Vagrant.configure("2") do |config|
     config.vm.provision "shell", inline: <<-SHELL
       set -e -u -o pipefail
       yum update -y
-      yum install -y git gcc docker systemd-devel dbus-devel libseccomp-devel
+      yum install -y git gcc docker systemd-devel dbus-devel libseccomp-devel wget openssl-devel
       grubby --update-kernel=ALL --args="systemd.unified_cgroup_hierarchy=0"
       service docker start
     SHELL

--- a/Vagrantfile.root
+++ b/Vagrantfile.root
@@ -14,7 +14,7 @@ Vagrant.configure("2") do |config|
     config.vm.provision "shell", inline: <<-SHELL
       set -e -u -o pipefail
       yum update -y
-      yum install -y git gcc docker systemd-devel dbus-devel libseccomp-devel
+      yum install -y git gcc docker systemd-devel dbus-devel libseccomp-devel wget openssl-devel
       grubby --update-kernel=ALL --args="systemd.unified_cgroup_hierarchy=0"
       service docker start
       curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
@@ -23,4 +23,3 @@ Vagrant.configure("2") do |config|
     config.ssh.username = 'root'
     config.ssh.insert_key = 'true'
   end
-

--- a/Vagrantfile.root
+++ b/Vagrantfile.root
@@ -14,7 +14,7 @@ Vagrant.configure("2") do |config|
     config.vm.provision "shell", inline: <<-SHELL
       set -e -u -o pipefail
       yum update -y
-      yum install -y git gcc docker systemd-devel dbus-devel libseccomp-devel wget openssl-devel
+      yum install -y git gcc docker wget pkg-config systemd-devel dbus-devel elfutils-libelf-devel libseccomp-devel clang-devel openssl-devel
       grubby --update-kernel=ALL --args="systemd.unified_cgroup_hierarchy=0"
       service docker start
       curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y

--- a/docs/src/user/basic_setup.md
+++ b/docs/src/user/basic_setup.md
@@ -17,26 +17,28 @@ To compile and run, Youki itself depends on some underlying libraries being inst
 #### Debian, Ubuntu and related distributions
 
 ```console
-$ sudo apt-get install   \
-      pkg-config         \
-      libsystemd-dev     \
-      libdbus-glib-1-dev \
-      build-essential    \
-      libelf-dev \
-      libseccomp-dev \
-      libclang-dev
+$ sudo apt-get install    \
+      pkg-config          \
+      libsystemd-dev      \
+      libdbus-glib-1-dev  \
+      build-essential     \
+      libelf-dev          \
+      libseccomp-dev      \
+      libclang-dev        \
+      libssl-dev
 ```
 
-#### Fedora, Centos, RHEL and related distributions
+#### Fedora, CentOS, RHEL and related distributions
 
 ```console
-$ sudo dnf install   \
-      pkg-config     \
-      systemd-devel  \
-      dbus-devel     \
+$ sudo dnf install          \
+      pkg-config            \
+      systemd-devel         \
+      dbus-devel            \
       elfutils-libelf-devel \
-      libseccomp-devel \
-      clang-devel
+      libseccomp-devel      \
+      clang-devel           \
+      openssl-devel
 ```
 
 ---


### PR DESCRIPTION
While setting up the environment, I encountered a few dependency issues that I hope to solve in this pull request.

1. Building `wasmedge-sys` requires `wget`, which is not found in the `fedora/33-cloud-base` VirtualBox image. See: https://github.com/WasmEdge/WasmEdge/blob/master/bindings/rust/wasmedge-sys/build.rs#L408
2. Building `openssl-sys` requires the host system to have the OpenSSL library, which is also not found in `fedora/33-cloud-base`.