### PR TITLE
Implemented sending logs to systemd-journald

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3926,6 +3926,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-journald"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba316a74e8fc3c3896a850dba2375928a9fa171b085ecddfc7c054d39970f3fd"
+dependencies = [
+ "libc",
+ "tracing-core",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "tracing-log"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5463,6 +5474,7 @@ dependencies = [
  "tabwriter",
  "tempfile",
  "tracing",
+ "tracing-journald",
  "tracing-subscriber",
  "vergen",
  "wasmedge-sdk",

--- a/crates/youki/Cargo.toml
+++ b/crates/youki/Cargo.toml
@@ -48,6 +48,7 @@ wasmtime = {version = "9.0.1", optional = true }
 wasmtime-wasi = {version = "9.0.1", optional = true }
 tracing = { version = "0.1.37", features = ["attributes"]}
 tracing-subscriber = { version = "0.3.16", features = ["json", "env-filter"] }
+tracing-journald = "0.3.0"
 
 [dev-dependencies]
 serial_test = "2.0.0"

--- a/crates/youki/src/logger.rs
+++ b/crates/youki/src/logger.rs
@@ -5,7 +5,9 @@ use std::borrow::Cow;
 use std::fs::OpenOptions;
 use std::path::PathBuf;
 use std::str::FromStr;
-use tracing::metadata::LevelFilter;
+use tracing::Level;
+use tracing_subscriber::prelude::__tracing_subscriber_SubscriberExt;
+use tracing_subscriber::util::SubscriberInitExt;
 
 const LOG_LEVEL_ENV_NAME: &str = "YOUKI_LOG_LEVEL";
 const LOG_FORMAT_TEXT: &str = "text";
@@ -23,15 +25,15 @@ const DEFAULT_LOG_LEVEL: &str = "debug";
 #[cfg(not(debug_assertions))]
 const DEFAULT_LOG_LEVEL: &str = "warn";
 
-fn detect_log_format(log_format: Option<String>) -> Result<LogFormat> {
-    match log_format.as_deref() {
+fn detect_log_format(log_format: Option<&str>) -> Result<LogFormat> {
+    match log_format {
         None | Some(LOG_FORMAT_TEXT) => Ok(LogFormat::Text),
         Some(LOG_FORMAT_JSON) => Ok(LogFormat::Json),
         Some(unknown) => bail!("unknown log format: {}", unknown),
     }
 }
 
-fn detect_log_level(is_debug: bool) -> Result<LevelFilter> {
+fn detect_log_level(is_debug: bool) -> Result<Level> {
     let filter: Cow<str> = if is_debug {
         "debug".into()
     } else if let Ok(level) = std::env::var(LOG_LEVEL_ENV_NAME) {
@@ -39,38 +41,63 @@ fn detect_log_level(is_debug: bool) -> Result<LevelFilter> {
     } else {
         DEFAULT_LOG_LEVEL.into()
     };
-    Ok(LevelFilter::from_str(filter.as_ref())?)
+    Ok(Level::from_str(filter.as_ref())?)
 }
 
-pub fn init(
-    log_debug_flag: bool,
-    log_file: Option<PathBuf>,
-    log_format: Option<String>,
-) -> Result<()> {
-    let level = detect_log_level(log_debug_flag).context("failed to parse log level")?;
-    let log_format = detect_log_format(log_format).context("failed to detect log format")?;
+pub struct ObservabilityConfig {
+    pub log_debug_flag: bool,
+    pub log_file: Option<PathBuf>,
+    pub log_format: Option<String>,
+}
+
+impl From<&crate::Opts> for ObservabilityConfig {
+    fn from(opts: &crate::Opts) -> Self {
+        Self {
+            log_debug_flag: opts.global.debug,
+            log_file: opts.global.log.to_owned(),
+            log_format: opts.global.log_format.to_owned(),
+        }
+    }
+}
+
+pub fn init_observability<T>(config: T) -> Result<()>
+where
+    T: Into<ObservabilityConfig>,
+{
+    let config = config.into();
+    let level =
+        detect_log_level(config.log_debug_flag).with_context(|| "failed to parse log level")?;
+    let log_level_filter = tracing_subscriber::filter::LevelFilter::from(level);
+    let log_format = detect_log_format(config.log_format.as_deref())
+        .with_context(|| "failed to detect log format")?;
+
+    let subscriber = tracing_subscriber::registry().with(log_level_filter);
 
     // I really dislike how we have to specify individual branch for each
     // combination, but I can't find any better way to do this. The tracing
     // crate makes it hard to build a single layer with different conditions.
-    match (log_file, log_format) {
+    match (config.log_file.as_ref(), log_format) {
         (None, LogFormat::Text) => {
             // Text to stderr
-            tracing_subscriber::fmt()
-                .with_max_level(level)
-                .without_time()
-                .with_writer(std::io::stderr)
+            subscriber
+                .with(
+                    tracing_subscriber::fmt::layer()
+                        .without_time()
+                        .with_writer(std::io::stderr),
+                )
                 .try_init()
                 .map_err(|e| anyhow::anyhow!("failed to init logger: {}", e))?;
         }
         (None, LogFormat::Json) => {
             // JSON to stderr
-            tracing_subscriber::fmt()
-                .json()
-                .flatten_event(true)
-                .with_span_list(false)
-                .with_max_level(level)
-                .with_writer(std::io::stderr)
+            subscriber
+                .with(
+                    tracing_subscriber::fmt::layer()
+                        .json()
+                        .flatten_event(true)
+                        .with_span_list(false)
+                        .with_writer(std::io::stderr),
+                )
                 .try_init()
                 .map_err(|e| anyhow::anyhow!("failed to init logger: {}", e))?;
         }
@@ -82,9 +109,8 @@ pub fn init(
                 .truncate(false)
                 .open(path)
                 .with_context(|| "failed to open log file")?;
-            tracing_subscriber::fmt()
-                .with_writer(file)
-                .with_max_level(level)
+            subscriber
+                .with(tracing_subscriber::fmt::layer().with_writer(file))
                 .try_init()
                 .map_err(|e| anyhow::anyhow!("failed to init logger: {}", e))?;
         }
@@ -96,12 +122,14 @@ pub fn init(
                 .truncate(false)
                 .open(path)
                 .with_context(|| "failed to open log file")?;
-            tracing_subscriber::fmt()
-                .json()
-                .flatten_event(true)
-                .with_span_list(false)
-                .with_writer(file)
-                .with_max_level(level)
+            subscriber
+                .with(
+                    tracing_subscriber::fmt::layer()
+                        .json()
+                        .flatten_event(true)
+                        .with_span_list(false)
+                        .with_writer(file),
+                )
                 .try_init()
                 .map_err(|e| anyhow::anyhow!("failed to init logger: {}", e))?;
         }
@@ -142,7 +170,7 @@ mod tests {
     #[test]
     fn test_detect_log_level_is_debug() {
         let _guard = LogLevelGuard::new("error").unwrap();
-        assert_eq!(detect_log_level(true).unwrap(), LevelFilter::DEBUG)
+        assert_eq!(detect_log_level(true).unwrap(), tracing::Level::DEBUG)
     }
 
     #[test]
@@ -151,9 +179,9 @@ mod tests {
         let _guard = LogLevelGuard::new("error").unwrap();
         env::remove_var(LOG_LEVEL_ENV_NAME);
         if cfg!(debug_assertions) {
-            assert_eq!(detect_log_level(false).unwrap(), LevelFilter::DEBUG)
+            assert_eq!(detect_log_level(false).unwrap(), tracing::Level::DEBUG)
         } else {
-            assert_eq!(detect_log_level(false).unwrap(), LevelFilter::WARN)
+            assert_eq!(detect_log_level(false).unwrap(), tracing::Level::WARN)
         }
     }
 
@@ -161,7 +189,7 @@ mod tests {
     #[serial]
     fn test_detect_log_level_from_env() {
         let _guard = LogLevelGuard::new("error").unwrap();
-        assert_eq!(detect_log_level(false).unwrap(), LevelFilter::ERROR)
+        assert_eq!(detect_log_level(false).unwrap(), tracing::Level::ERROR)
     }
 
     #[test]
@@ -170,8 +198,12 @@ mod tests {
             let temp_dir = tempfile::tempdir().expect("failed to create temp dir");
             let log_file = Path::join(temp_dir.path(), "test.log");
             let _guard = LogLevelGuard::new("error").unwrap();
-            init(false, Some(log_file), None)
-                .map_err(|err| TestCallbackError::Other(err.into()))?;
+            let config = ObservabilityConfig {
+                log_debug_flag: false,
+                log_file: Some(log_file),
+                log_format: None,
+            };
+            init_observability(config).map_err(|err| TestCallbackError::Other(err.into()))?;
             Ok(())
         };
         libcontainer::test_utils::test_in_child_process(cb)
@@ -189,8 +221,12 @@ mod tests {
             let _guard = LogLevelGuard::new("error").unwrap();
             // Note, we can only init the tracing once, so we have to test in a
             // single unit test. The orders are important here.
-            init(false, Some(log_file.to_owned()), None)
-                .map_err(|err| TestCallbackError::Other(err.into()))?;
+            let config = ObservabilityConfig {
+                log_debug_flag: false,
+                log_file: Some(log_file.clone()),
+                log_format: None,
+            };
+            init_observability(config).map_err(|err| TestCallbackError::Other(err.into()))?;
             assert!(
                 log_file
                     .as_path()
@@ -230,12 +266,12 @@ mod tests {
             let _guard = LogLevelGuard::new("error").unwrap();
             // Note, we can only init the tracing once, so we have to test in a
             // single unit test. The orders are important here.
-            init(
-                false,
-                Some(log_file.to_owned()),
-                Some(LOG_FORMAT_JSON.to_owned()),
-            )
-            .map_err(|err| TestCallbackError::Other(err.into()))?;
+            let config = ObservabilityConfig {
+                log_debug_flag: false,
+                log_file: Some(log_file.clone()),
+                log_format: Some(LOG_FORMAT_JSON.to_owned()),
+            };
+            init_observability(config).map_err(|err| TestCallbackError::Other(err.into()))?;
             assert!(
                 log_file
                     .as_path()

--- a/crates/youki/src/main.rs
+++ b/crates/youki/src/main.rs
@@ -2,7 +2,7 @@
 //! Container Runtime written in Rust, inspired by [railcar](https://github.com/oracle/railcar)
 //! This crate provides a container runtime which can be used by a high-level container runtime to run containers.
 mod commands;
-mod logger;
+mod observability;
 mod rootpath;
 mod workload;
 
@@ -78,7 +78,7 @@ fn main() -> Result<()> {
     let opts = Opts::parse();
     let mut app = Opts::command();
 
-    if let Err(e) = crate::logger::init_observability(&opts) {
+    if let Err(e) = crate::observability::init(&opts) {
         eprintln!("log init failed: {e:?}");
     }
 

--- a/crates/youki/src/main.rs
+++ b/crates/youki/src/main.rs
@@ -78,8 +78,7 @@ fn main() -> Result<()> {
     let opts = Opts::parse();
     let mut app = Opts::command();
 
-    if let Err(e) = crate::logger::init(opts.global.debug, opts.global.log, opts.global.log_format)
-    {
+    if let Err(e) = crate::logger::init_observability(&opts) {
         eprintln!("log init failed: {e:?}");
     }
 

--- a/crates/youki/src/observability.rs
+++ b/crates/youki/src/observability.rs
@@ -1,5 +1,3 @@
-//! Default Youki Logger
-
 use anyhow::{bail, Context, Result};
 use std::borrow::Cow;
 use std::fs::OpenOptions;
@@ -60,7 +58,7 @@ impl From<&crate::Opts> for ObservabilityConfig {
     }
 }
 
-pub fn init_observability<T>(config: T) -> Result<()>
+pub fn init<T>(config: T) -> Result<()>
 where
     T: Into<ObservabilityConfig>,
 {
@@ -203,7 +201,7 @@ mod tests {
                 log_file: Some(log_file),
                 log_format: None,
             };
-            init_observability(config).map_err(|err| TestCallbackError::Other(err.into()))?;
+            init(config).map_err(|err| TestCallbackError::Other(err.into()))?;
             Ok(())
         };
         libcontainer::test_utils::test_in_child_process(cb)
@@ -226,7 +224,7 @@ mod tests {
                 log_file: Some(log_file.clone()),
                 log_format: None,
             };
-            init_observability(config).map_err(|err| TestCallbackError::Other(err.into()))?;
+            init(config).map_err(|err| TestCallbackError::Other(err.into()))?;
             assert!(
                 log_file
                     .as_path()
@@ -271,7 +269,7 @@ mod tests {
                 log_file: Some(log_file.clone()),
                 log_format: Some(LOG_FORMAT_JSON.to_owned()),
             };
-            init_observability(config).map_err(|err| TestCallbackError::Other(err.into()))?;
+            init(config).map_err(|err| TestCallbackError::Other(err.into()))?;
             assert!(
                 log_file
                     .as_path()


### PR DESCRIPTION
@utam0k mentioned a usecase where when test `youki` inside k8s, it is hard to track logs of each `youki` implementation. A workaround was using `bpf` tracing the syscalls. However, it would be much better to see the actual `youki` logs. This is where `journald` comes in. It is one of the common ways for linux services and application to collect logs into a central place. In this PR, we implemented a different tracing layer that sends `youki` logs to `journald`. All logs are tagged as `youki` and we can obtain the logs with `journalctl -t youki`.

Note. I am not sure how best to enable this feature. I decided to implement this as a flag `--systemd-log` on the command line. However, this is not part of the OCI spec, so I added as a youki extension in the struct. However, this may not be the best way.

Another way to implement this is through `features`.

Tag along in this PR is a small refactor of the existing logging code. This refactors the logging into using different layers where we can get ready for the opentelelmetry work.