### PR TITLE
Rust 1.70

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
 profile="default"
-channel="1.69.0"
+channel="1.70.0"

--- a/tests/rust-integration-tests/integration_test/src/utils/test_utils.rs
+++ b/tests/rust-integration-tests/integration_test/src/utils/test_utils.rs
@@ -1,5 +1,5 @@
-///! Contains utility functions for testing
-///! Similar to https://github.com/opencontainers/runtime-tools/blob/master/validation/util/test.go
+//! Contains utility functions for testing
+//! Similar to https://github.com/opencontainers/runtime-tools/blob/master/validation/util/test.go
 use super::{generate_uuid, prepare_bundle, set_config};
 use super::{get_runtime_path, get_runtimetest_path};
 use anyhow::{anyhow, bail, Context, Result};

--- a/tests/rust-integration-tests/test_framework/src/conditional_test.rs
+++ b/tests/rust-integration-tests/test_framework/src/conditional_test.rs
@@ -1,4 +1,4 @@
-///! Contains definition for a tests which should be conditionally run
+//! Contains definition for a tests which should be conditionally run
 use crate::testable::{TestResult, Testable};
 
 // type aliases for test function signature

--- a/tests/rust-integration-tests/test_framework/src/test.rs
+++ b/tests/rust-integration-tests/test_framework/src/test.rs
@@ -1,4 +1,4 @@
-///! Contains definition for a simple and commonly usable test structure
+//! Contains definition for a simple and commonly usable test structure
 use crate::testable::{TestResult, Testable};
 
 // type alias for the test function

--- a/tests/rust-integration-tests/test_framework/src/test_group.rs
+++ b/tests/rust-integration-tests/test_framework/src/test_group.rs
@@ -1,4 +1,4 @@
-///! Contains structure for a test group
+//! Contains structure for a test group
 use crate::testable::{TestResult, Testable, TestableGroup};
 use crossbeam::thread;
 use std::collections::BTreeMap;

--- a/tests/rust-integration-tests/test_framework/src/test_manager.rs
+++ b/tests/rust-integration-tests/test_framework/src/test_manager.rs
@@ -1,4 +1,4 @@
-///! This exposes the main control wrapper to control the tests
+//! This exposes the main control wrapper to control the tests
 use crate::testable::{TestResult, TestableGroup};
 use anyhow::Result;
 use crossbeam::thread;

--- a/tests/rust-integration-tests/test_framework/src/testable.rs
+++ b/tests/rust-integration-tests/test_framework/src/testable.rs
@@ -1,6 +1,6 @@
+//! Contains Basic setup for testing, testable trait and its result type
 use std::fmt::Debug;
 
-///! Contains Basic setup for testing, testable trait and its result type
 use anyhow::{bail, Error, Result};
 
 #[derive(Debug)]


### PR DESCRIPTION
1.70 is released.

Note the fix to the new lint, `///!` is not a valid comment. `//!` is valid. Now clippy complains it. Reference: https://doc.rust-lang.org/reference/comments.html