### PR TITLE
Refactor CI

### DIFF
--- a/.github/scripts/dependency.sh
+++ b/.github/scripts/dependency.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-apt-get -y update
-apt-get install -y pkg-config libsystemd-dev libdbus-glib-1-dev libelf-dev libseccomp-dev

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -16,10 +16,10 @@ jobs:
       - uses: actions/checkout@v3
       - name: Setup Rust toolchain and cache
         uses: actions-rust-lang/setup-rust-toolchain@v1.3.7
-      - name: Install requirements
-        run: sudo ./.github/scripts/dependency.sh
       - name: Install just
         uses: taiki-e/install-action@just
+      - name: Install requirements
+        run: just ci-prepare
       - name: Build youki
         run: just youki-release
       - name: Upload youki binary
@@ -77,3 +77,54 @@ jobs:
   #     # - name: Debug
   #     #   if: ${{ always() }}
   #     #   uses: mxschmitt/action-tmate@v3
+
+  oci-validation-go:
+    runs-on: ubuntu-22.04
+    needs: [youki-build]
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: recursive
+      - name: Setup Rust toolchain and cache
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+      - name: Install just
+        uses: taiki-e/install-action@just
+      - uses: actions/setup-go@v3
+        with:
+          go-version: '1.19.9'
+          cache: true
+          cache-dependency-path: tests/oci-runtime-tests/src/github.com/opencontainers/runtime-tools/go.sum
+      - name: Download youki binary
+        uses: actions/download-artifact@v3
+        with:
+          name: youki
+      - name: Add the permission to run
+        run: chmod +x ./youki
+      - name: Run integration tests
+        run: just oci-tests
+
+  oci-validation-rust:
+    runs-on: ubuntu-22.04
+    needs: [youki-build]
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: recursive
+      - name: Setup Rust toolchain and cache
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+      - name: Install just
+        uses: taiki-e/install-action@just
+      - name: Install requirements
+        run: just ci-prepare
+      - name: Download youki binary
+        uses: actions/download-artifact@v3
+        with:
+          name: youki
+      - name: Add the permission to run
+        run: chmod +x ./youki
+      - name: Build
+        run: just runtimetest rust-oci-tests-bin
+      - name: Validate tests on youki
+        run: just rust-oci-tests

--- a/.github/workflows/integration_tests_validation.yaml
+++ b/.github/workflows/integration_tests_validation.yaml
@@ -9,39 +9,44 @@ on:
 
 jobs:
   changes:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 15
     outputs:
-      dirs: ${{ steps.filter.outputs.changes }}
+      any_modified: ${{ steps.filter.outputs.any_modified }}
     steps:
       - uses: actions/checkout@v3
-      - uses: dorny/paths-filter@v2
+      - uses: tj-actions/changed-files@v36
         id: filter
         with:
-          filters: |
-            ./integration_test: 
-              - './tests/rust-integration-tests/**'
+          files: |
+            .github/workflows/integration_tests_validation.yaml
+            integration_test/tests/rust-integration-tests/**
+          files_ignore: |
+            **.md
+      - name: List all changed files
+        run: |
+          for file in ${{ steps.filter.outputs.all_modified_files }}; do
+            echo "$file was changed"
+          done
   validate:
     needs: [changes]
-    if: ${{ !contains(needs.changes.outputs.dirs, '[]') }}
+    if: needs.changes.outputs.any_modified == 'true'
     runs-on: ubuntu-20.04
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v3
       - name: Setup Rust toolchain and cache
         uses: actions-rust-lang/setup-rust-toolchain@v1.3.7
-      - name: Install requirements
-        run: sudo ./.github/scripts/dependency.sh
       - name: Install just
         uses: taiki-e/install-action@just
+      - name: Install requirements
+        run: just ci-prepare
       - name: Install runc 1.1.0
         run: |
           wget -q https://github.com/opencontainers/runc/releases/download/v1.1.0/runc.amd64
           sudo mv runc.amd64 /usr/bin/runc
           sudo chmod 755 /usr/bin/runc
       - name: Build
-        run: just youki-release runtimetest rust-oci-tests-bin
+        run: just runtimetest rust-oci-tests-bin
       - name: Validate tests on runc
         run: just validate-rust-oci-runc
-      - name: Validate tests on youki
-        run: just rust-oci-tests

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,68 +9,62 @@ on:
 
 jobs:
   changes:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 15
     outputs:
-      dirs: ${{ steps.filter.outputs.changes }}
+      any_modified: ${{ steps.filter.outputs.any_modified }}
     steps:
       - uses: actions/checkout@v3
-      - uses: dorny/paths-filter@v2
+      - uses: tj-actions/changed-files@v36
         id: filter
         with:
-          filters: |
-            crates/youki: 
-              - 'crates/youki/**'
-            crates/libcontainer: 
-              - 'crates/libcontainer/**'
-            crates/libcgroups: 
-              - 'crates/libcgroups/**'
-            tests/rust-integration-tests/runtimetest: 
-              - './tests/rust-integration-tests/runtimetest/**'
-            tests/rust-integration-tests/integration_test: 
-              - './tests/rust-integration-tests/integration_test/**'
-            tests/rust-integration-tests/test_framework:
-              - './tests/rust-integration-tests/test_framework/**'
-
+          files_ignore: |
+            docs
+            LICENSE
+            **.md
+      - name: List all changed files
+        run: |
+          for file in ${{ steps.filter.outputs.all_modified_files }}; do
+            echo "$file was changed"
+          done
   check:
     needs: [changes]
-    if: ${{ !contains(needs.changes.outputs.dirs, '[]') }}
-    runs-on: ubuntu-20.04
+    if: needs.changes.outputs.any_modified == 'true'
+    runs-on: ubuntu-22.04
     timeout-minutes: 15
-    strategy:
-      matrix:
-        dirs: ${{ fromJSON(needs.changes.outputs.dirs) }}
     steps:
       - uses: actions/checkout@v3
       - name: Setup Rust toolchain and cache
-        uses: actions-rust-lang/setup-rust-toolchain@v1.3.7
-      - run: rustup component add rustfmt clippy
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          components: rustfmt, clippy
+      - uses: taiki-e/install-action@just
       - name: Install requirements
-        run: sudo ./.github/scripts/dependency.sh
-      - run: sudo apt-get install -y pkg-config libsystemd-dev libdbus-glib-1-dev libelf-dev libseccomp-dev
-      - name: Check formatting
-        run: cargo fmt --all -- --check
-        working-directory: ${{matrix.dirs}}
-      - name: Check clippy lints
-        working-directory: ${{matrix.dirs}}
-        run: cargo clippy --all-targets --all-features -- -D warnings
+        run: just ci-prepare
+      - name: Check formatting and lints
+        run: just lint
 
   tests:
-    runs-on: ubuntu-20.04
+    needs: [changes]
+    if: needs.changes.outputs.any_modified == 'true'
+    runs-on: ubuntu-22.04
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v3
-      - name: Install rus
-        run: rustup show
-      - run: sudo apt-get -y update
-      - run: sudo apt-get install -y pkg-config libsystemd-dev libdbus-glib-1-dev libelf-dev libseccomp-dev
+      - name: Setup Rust toolchain and cache
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+      - uses: taiki-e/install-action@just
+      - name: Install requirements
+        run: just ci-prepare
       - name: Run tests
         run: |
           export LD_LIBRARY_PATH=$HOME/.wasmedge/lib
           cd ./crates && cargo test --all --all-features --no-fail-fast
 
   coverage:
-    runs-on: ubuntu-20.04
+    needs: [changes]
+    if: needs.changes.outputs.any_modified == 'true'
+    runs-on: ubuntu-22.04
     timeout-minutes: 15
     name: Run test coverage
     steps:
@@ -83,37 +77,15 @@ jobs:
         uses: taiki-e/install-action@v1
         with:
           tool: cargo-llvm-cov@0.4.0
+      - uses: taiki-e/install-action@just
       - name: Install requirements
-        run: sudo ./.github/scripts/dependency.sh
+        run: just ci-prepare
       - name: Run Test Coverage for youki
         run: |
           cargo llvm-cov clean --workspace
           cargo llvm-cov --no-report
           cargo llvm-cov --no-run --lcov --ignore-filename-regex "libcgroups/src/systemd/dbus/systemd_api.rs" --output-path ./coverage.lcov
       - name: Upload Youki Code Coverage Results
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@v3
         with:
           file: ./coverage.lcov
-
-  integration_tests:
-    runs-on: ubuntu-20.04
-    timeout-minutes: 15
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          submodules: recursive
-      - name: Setup Rust toolchain and cache
-        uses: actions-rust-lang/setup-rust-toolchain@v1.3.7
-      - name: Install requirements
-        run: sudo ./.github/scripts/dependency.sh
-      - name: Install just
-        uses: taiki-e/install-action@just
-      - uses: actions/setup-go@v3
-        with:
-          go-version: "1.17.6"
-          cache: true
-          cache-dependency-path: tests/oci-runtime-tests/src/github.com/opencontainers/runtime-tools/go.sum
-      - name: Build
-        run: just youki-release
-      - name: Run integration tests
-        run: just oci-tests

--- a/README.md
+++ b/README.md
@@ -32,10 +32,13 @@ Here is why we are writing a new container runtime in Rust.
   <summary>Details about the benchmark</summary>
 
   - A command used for the benchmark
-    ```console
-    $ hyperfine --prepare 'sudo sync; echo 3 | sudo tee /proc/sys/vm/drop_caches' --warmup 10 --min-runs 100 'sudo ./youki create -b tutorial a && sudo ./youki start a && sudo ./youki delete -f a'
+
+    ```bash
+    hyperfine --prepare 'sudo sync; echo 3 | sudo tee /proc/sys/vm/drop_caches' --warmup 10 --min-runs 100 'sudo ./youki create -b tutorial a && sudo ./youki start a && sudo ./youki delete -f a'
     ```
+
   - Environment
+
     ```console
     $ ./youki info
     Version           0.0.1
@@ -91,6 +94,7 @@ Here is why we are writing a new container runtime in Rust.
     spec: 1.0.0
     +SYSTEMD +SELINUX +APPARMOR +CAP +SECCOMP +EBPF +CRIU +YAJL
     ```
+
   </details>
 
 - The development of [railcar](https://github.com/oracle/railcar) has been suspended. This project was very nice but is no longer being developed. This project is inspired by it.
@@ -143,6 +147,8 @@ For other platforms, please use the [Vagrantfile](#setting-up-vagrant) that we h
 
 ## Dependencies
 
+To install `just`, follow the instruction [here](https://github.com/casey/just#installation).
+
 ### Debian, Ubuntu and related distributions
 
 ```console
@@ -172,11 +178,11 @@ $ sudo dnf install          \
 
 ## Build
 
-```console
-$ git clone git@github.com:containers/youki.git
-$ cd youki
-$ make youki-dev # or youki-release
-$ ./youki -h # you can get information about youki command
+```bash
+git clone git@github.com:containers/youki.git
+cd youki
+just youki-dev # or youki-release
+./youki -h # you can get information about youki command
 ```
 
 ## Tutorial
@@ -189,21 +195,21 @@ $ ./youki -h # you can get information about youki command
 
 Let's try to run a container that executes `sleep 30` with youki. This tutorial may need root permission.
 
-```console
-$ git clone git@github.com:containers/youki.git
-$ cd youki
-$ make youki-dev # or youki-release
+```bash
+git clone git@github.com:containers/youki.git
+cd youki
+just youki-dev # or youki-release
 
-$ mkdir -p tutorial/rootfs
-$ cd tutorial
+mkdir -p tutorial/rootfs
+cd tutorial
 # use docker to export busybox into the rootfs directory
-$ docker export $(docker create busybox) | tar -C rootfs -xvf -
+docker export $(docker create busybox) | tar -C rootfs -xvf -
 ```
 
 Then, we need to prepare a configuration file. This file contains metadata and specs for a container, such as the process to run, environment variables to inject, sandboxing features to use, etc.
 
-```console
-$ ../youki spec  # will generate a spec file named config.json
+```bash
+../youki spec  # will generate a spec file named config.json
 ```
 
 We can edit the `config.json` to add customized behaviors for container. Here, we modify the `process` field to run `sleep 30`.
@@ -221,13 +227,13 @@ We can edit the `config.json` to add customized behaviors for container. Here, w
 
 Then we can explore the lifecycle of a container:
 
-```console
-$ cd ..                                                # go back to the repository root
-$ sudo ./youki create -b tutorial tutorial_container   # create a container with name `tutorial_container`
-$ sudo ./youki state tutorial_container                # you can see the state the container is `created`
-$ sudo ./youki start tutorial_container                # start the container
-$ sudo ./youki list                                    # will show the list of containers, the container is `running`
-$ sudo ./youki delete tutorial_container               # delete the container
+```bash
+cd ..                                                # go back to the repository root
+sudo ./youki create -b tutorial tutorial_container   # create a container with name `tutorial_container`
+sudo ./youki state tutorial_container                # you can see the state the container is `created`
+sudo ./youki start tutorial_container                # start the container
+sudo ./youki list                                    # will show the list of containers, the container is `running`
+sudo ./youki delete tutorial_container               # delete the container
 ```
 
 Change the command to be executed in `config.json` and try something other than `sleep 30`.
@@ -236,7 +242,7 @@ Change the command to be executed in `config.json` and try something other than 
 
 `youki` provides the ability to run containers as non-root user([rootless mode](https://docs.docker.com/engine/security/rootless/)). To run a container in rootless mode, we need to add some extra options in `config.json`, other steps are same with above:
 
-```console
+```bash
 $ mkdir -p tutorial/rootfs
 $ cd tutorial
 # use docker to export busybox into the rootfs directory
@@ -252,13 +258,13 @@ $ ../youki run rootless-container   # will create and run a container with rootl
 
 Start the docker daemon.
 
-```console
-$ dockerd --experimental --add-runtime="youki=$(pwd)/youki"
+```bash
+dockerd --experimental --add-runtime="youki=$(pwd)/youki"
 ```
 
 If you get an error like the below, that means your normal Docker daemon is running, and it needs to be stopped. Do that with your init system (i.e., with systemd, run `systemctl stop docker`, as root if necessary).
 
-```
+```console
 failed to start daemon: pid file found, ensure docker is not running or delete /var/run/docker.pid
 ```
 
@@ -266,44 +272,44 @@ Now repeat the command, which should start the docker daemon.
 
 You can use youki in a different terminal to start the container.
 
-```console
-$ docker run -it --rm --runtime youki busybox
+```bash
+docker run -it --rm --runtime youki busybox
 ```
 
 Afterwards, you can close the docker daemon process in other the other terminal. To restart normal docker daemon (if you had stopped it before), run:
 
-```console
-$ systemctl start docker # might need root permission
+```bash
+systemctl start docker # might need root permission
 ```
 
 ### Integration Tests
 
 Go and node-tap are required to run integration tests. See the [opencontainers/runtime-tools](https://github.com/opencontainers/runtime-tools) README for details.
 
-```console
-$ git submodule update --init --recursive
-$ make oci-tests
+```bash
+git submodule update --init --recursive
+just oci-tests
 ```
 
 ### Setting up Vagrant
 
 You can try youki on platforms other than Linux by using the Vagrantfile we have prepared. We have prepared two environments for vagrant, namely rootless mode and rootful mode
 
-```console
-$ git clone git@github.com:containers/youki.git
-$ cd youki
+```bash
+git clone git@github.com:containers/youki.git
+cd youki
 
 # If you want to develop in rootless mode, and this is the default mode
-$ vagrant up
-$ vagrant ssh
+vagrant up
+vagrant ssh
 
 # or if you want to develop in rootful mode
-$ VAGRANT_VAGRANTFILE=Vagrantfile.root vagrant up
-$ VAGRANT_VAGRANTFILE=Vagrantfile.root vagrant ssh
+VAGRANT_VAGRANTFILE=Vagrantfile.root vagrant up
+VAGRANT_VAGRANTFILE=Vagrantfile.root vagrant ssh
 
 # in virtual machine
-$ cd youki
-$ make youki-dev # or youki-release
+cd youki
+just youki-dev # or youki-release
 ```
 
 # Community

--- a/justfile
+++ b/justfile
@@ -78,7 +78,7 @@ format:
 clean:
     ./scripts/clean.sh {{ ROOT }}
 
-prepare-ci:
+ci-prepare:
     #!/usr/bin/env bash
     set -euo pipefail
 
@@ -102,21 +102,5 @@ prepare-ci:
         fi
     fi
 
-    # Check if system is Fedora
-    if [[ -f /etc/fedora-release ]]; then
-        echo "System is Fedora"
-        sudo dnf -y update
-        sudo dnf install -y \
-            pkg-config \
-            systemd-devel \
-            dbus-devel \
-            elfutils-libelf-devel \
-            libseccomp-devel \
-            clang-devel \
-            openssl-devel \
-            criu
-        exit 0
-    fi
-
-    echo "Unknown system for `prepare` automation. You will need to forge your own path. Good luck!"
+    echo "Unknown system. The CI is only configured for Ubuntu. You will need to forge your own path. Good luck!"
     exit 1

--- a/justfile
+++ b/justfile
@@ -3,7 +3,6 @@ alias youki := youki-dev
 
 ROOT := `git rev-parse --show-toplevel`
 
-
 # build
 
 # build all binaries
@@ -11,24 +10,22 @@ build-all: youki-release rust-oci-tests-bin runtimetest
 
 # build youki in dev mode
 youki-dev:
-    ./scripts/build.sh -o {{ROOT}} -c youki
+    ./scripts/build.sh -o {{ ROOT }} -c youki
 
 # build youki in release mode
 youki-release:
-    ./scripts/build.sh -o {{ROOT}} -r -c youki
+    ./scripts/build.sh -o {{ ROOT }} -r -c youki
 
 # build runtimetest binary
 runtimetest:
-    ./scripts/build.sh -o {{ROOT}} -r -c runtimetest
+    ./scripts/build.sh -o {{ ROOT }} -r -c runtimetest
 
 # build rust oci tests binary
 rust-oci-tests-bin:
-    ./scripts/build.sh -o {{ROOT}} -r -c integration-test
-
+    ./scripts/build.sh -o {{ ROOT }} -r -c integration-test
 
 
 # Tests
-
 
 # run oci tests
 test-oci: oci-tests rust-oci-tests
@@ -46,13 +43,12 @@ featuretest:
     ./scripts/features_test.sh
 
 # run oci integration tests
-oci-tests: youki-release
-    ./scripts/oci_integration_tests.sh {{ROOT}}
-
+oci-tests: 
+    ./scripts/oci_integration_tests.sh {{ ROOT }}
 
 # run rust oci integration tests
 rust-oci-tests: youki-release runtimetest rust-oci-tests-bin
-    ./scripts/rust_integration_tests.sh {{ROOT}}/youki
+    ./scripts/rust_integration_tests.sh {{ ROOT }}/youki
 
 # validate rust oci integration tests on runc
 validate-rust-oci-runc: runtimetest rust-oci-tests-bin
@@ -63,7 +59,7 @@ containerd-test: youki-dev
 	VAGRANT_VAGRANTFILE=Vagrantfile.containerd2youki vagrant up
 	VAGRANT_VAGRANTFILE=Vagrantfile.containerd2youki vagrant provision --provision-with test
 
-#misc
+# misc
 
 # run bpftrace hack
 hack-bpftrace:
@@ -72,8 +68,55 @@ hack-bpftrace:
 # run linting on project
 lint:
     cargo fmt --all -- --check
-    cargo clippy --all-targets --all-features -- -D warnings
+    cargo clippy --all --all-targets --all-features -- -D warnings
+
+# run format on project
+format:
+    cargo fmt --all
 
 # cleans up generated artifacts
 clean:
-    ./scripts/clean.sh {{ROOT}}
+    ./scripts/clean.sh {{ ROOT }}
+
+prepare-ci:
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    # Check if system is Ubuntu
+    if [[ -f /etc/lsb-release ]]; then
+        source /etc/lsb-release
+        if [[ $DISTRIB_ID == "Ubuntu" ]]; then
+            echo "System is Ubuntu"
+            sudo apt-get -y update
+            sudo apt-get install -y \
+                pkg-config \
+                libsystemd-dev \
+                libdbus-glib-1-dev \
+                build-essential \
+                libelf-dev \
+                libseccomp-dev \
+                libclang-dev \
+                libssl-dev \
+                criu
+            exit 0
+        fi
+    fi
+
+    # Check if system is Fedora
+    if [[ -f /etc/fedora-release ]]; then
+        echo "System is Fedora"
+        sudo dnf -y update
+        sudo dnf install -y \
+            pkg-config \
+            systemd-devel \
+            dbus-devel \
+            elfutils-libelf-devel \
+            libseccomp-devel \
+            clang-devel \
+            openssl-devel \
+            criu
+        exit 0
+    fi
+
+    echo "Unknown system for `prepare` automation. You will need to forge your own path. Good luck!"
+    exit 1


### PR DESCRIPTION
- attempt to standardized all CI to use Ubuntu 22 (the integration validation using `runc` is currently failing on Ubuntu 22, but others are successful)
- refactored the justfile to be more ergonomics
- moved the rust integration test to e2e
- moved the oci validation go version to e2e
- change the file filter action to `tj-actions/changed-files`
- refactored the dependencies installation to `just prepare` recipe
- update readme to replace `make` related calls.

Fix #1974 

CI should all pass. Note the `integration_test` is in a `Expected` state. This is due to branch protection rules and not directly related to this PR. In this PR, we renamed the integration_test to `oci-validation-go`. When moving to `e2e.yaml`, the name `integration_test` is way too ambiguous. We will fix the branch protection rule once the PR is merged into main or right after approve of this PR.