### PR TITLE
Bump the oci-spec-rs to 0.6.1 to resolve seccomp rule issue

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2335,9 +2335,9 @@ dependencies = [
 
 [[package]]
 name = "oci-spec"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "214b837f7dde5026f2028ead5ae720073277c19f82ff85623b142c39d4b843e7"
+checksum = "cf77d2eace1f4909b081d231d1ad3570ba3448ae95290ab701314faaee1b611a"
 dependencies = [
  "derive_builder",
  "getset",

--- a/crates/libcgroups/Cargo.toml
+++ b/crates/libcgroups/Cargo.toml
@@ -22,7 +22,7 @@ cgroupsv2_devices = ["rbpf", "libbpf-sys", "errno", "libc"]
 [dependencies]
 nix = "0.26.2"
 procfs = "0.15.1"
-oci-spec = { version = "^0.6.0", features = ["runtime"] }
+oci-spec = { version = "^0.6.1", features = ["runtime"] }
 dbus = { version = "0.9.7", optional = true }
 fixedbitset = "0.4.2"
 serde = { version = "1.0", features = ["derive"] }

--- a/crates/libcontainer/Cargo.toml
+++ b/crates/libcontainer/Cargo.toml
@@ -28,7 +28,7 @@ fastrand = "^1.7.0"
 futures = { version = "0.3", features = ["thread-pool"] }
 libc = "0.2.146"
 nix = "0.26.2"
-oci-spec = { version = "^0.6.0", features = ["runtime"] }
+oci-spec = { version = "^0.6.1", features = ["runtime"] }
 once_cell = "1.18.0"
 procfs = "0.15.1"
 prctl = "1.0.0"

--- a/crates/libcontainer/src/seccomp/mod.rs
+++ b/crates/libcontainer/src/seccomp/mod.rs
@@ -78,6 +78,7 @@ fn translate_arch(arch: Arch) -> ScmpArch {
 }
 
 fn translate_action(action: LinuxSeccompAction, errno: Option<u32>) -> Result<ScmpAction> {
+    tracing::trace!(?action, ?errno, "translating action");
     let errno = errno.map(|e| e as i32).unwrap_or(libc::EPERM);
     let action = match action {
         LinuxSeccompAction::ScmpActKill => ScmpAction::KillThread,
@@ -94,6 +95,7 @@ fn translate_action(action: LinuxSeccompAction, errno: Option<u32>) -> Result<Sc
         LinuxSeccompAction::ScmpActLog => ScmpAction::Log,
     };
 
+    tracing::trace!(?action, "translated action");
     Ok(action)
 }
 

--- a/crates/libcontainer/src/seccomp/mod.rs
+++ b/crates/libcontainer/src/seccomp/mod.rs
@@ -141,9 +141,11 @@ fn check_seccomp(seccomp: &LinuxSeccomp) -> Result<()> {
     Ok(())
 }
 
+#[tracing::instrument(level = "trace", skip(seccomp))]
 pub fn initialize_seccomp(seccomp: &LinuxSeccomp) -> Result<Option<io::RawFd>> {
     check_seccomp(seccomp)?;
 
+    tracing::trace!(default_action = ?seccomp.default_action(), errno = ?seccomp.default_errno_ret(), "initializing seccomp");
     let default_action = translate_action(seccomp.default_action(), seccomp.default_errno_ret())?;
     let mut ctx =
         ScmpFilterContext::new_filter(default_action).map_err(|err| SeccompError::NewFilter {
@@ -167,6 +169,7 @@ pub fn initialize_seccomp(seccomp: &LinuxSeccomp) -> Result<Option<io::RawFd>> {
 
     if let Some(architectures) = seccomp.architectures() {
         for &arch in architectures {
+            tracing::trace!(?arch, "adding architecture");
             ctx.add_arch(translate_arch(arch))
                 .map_err(|err| SeccompError::AddArch { source: err, arch })?;
         }
@@ -228,6 +231,7 @@ pub fn initialize_seccomp(seccomp: &LinuxSeccomp) -> Result<Option<io::RawFd>> {
                                 translate_op(arg.op(), arg.value_two()),
                                 arg.value(),
                             );
+                            tracing::trace!(?name, ?action, ?arg, "add seccomp conditional rule");
                             ctx.add_rule_conditional(action, sc, &[cmp])
                                 .map_err(|err| {
                                     tracing::error!(
@@ -240,6 +244,7 @@ pub fn initialize_seccomp(seccomp: &LinuxSeccomp) -> Result<Option<io::RawFd>> {
                         }
                     }
                     None => {
+                        tracing::trace!(?name, ?action, "add seccomp rule");
                         ctx.add_rule(action, sc).map_err(|err| {
                             tracing::error!(
                                 "failed to add seccomp rule: {:?}. Syscall: {name}",

--- a/crates/liboci-cli/src/lib.rs
+++ b/crates/liboci-cli/src/lib.rs
@@ -70,9 +70,10 @@ pub struct GlobalOpts {
     // Example in future : '--debug     change log level to debug. (default: "warn")'
     #[clap(long)]
     pub debug: bool,
-    // Set a consistent behavior like in runc and crun: set log to the last given value
+    /// set the log file to write youki logs to (default is '/dev/stderr')
     #[clap(short, long, overrides_with("log"))]
     pub log: Option<PathBuf>,
+    /// set the log format ('text' (default), or 'json') (default: "text")
     #[clap(long)]
     pub log_format: Option<String>,
     /// root directory to store container state

--- a/crates/youki/Cargo.toml
+++ b/crates/youki/Cargo.toml
@@ -32,7 +32,7 @@ libcgroups = { version = "0.0.5", path = "../libcgroups", default-features = fal
 libcontainer = { version = "0.0.5", path = "../libcontainer", default-features = false }
 liboci-cli = { version = "0.0.5", path = "../liboci-cli" }
 nix = "0.26.2"
-oci-spec = { version = "^0.6.0", features = ["runtime"] }
+oci-spec = { version = "^0.6.1", features = ["runtime"] }
 once_cell = "1.18.0"
 pentacle = "1.0.0"
 procfs = "0.15.1"

--- a/docs/src/user/basic_usage.md
+++ b/docs/src/user/basic_usage.md
@@ -34,7 +34,7 @@ This will start the daemon and hang up the console. You can either start this as
 
 In case you don't stop the original daemon, you can get an error message after previous command
 
-```
+```console
 failed to start daemon: pid file found, ensure docker is not running or delete /var/run/docker.pid
 ```
 
@@ -63,19 +63,29 @@ let docker know youki
 ([source](https://docs.docker.com/engine/reference/commandline/dockerd/#on-linux)).
 You may need to create this file, if it does not yet exist. A sample content of it:
 
-```
+```json
 {
   "default-runtime": "runc",
   "runtimes": {
     "youki": {
-      "path": "/path/to/youki/youki"
+      "path": "/path/to/youki/youki",
+      "runtimeArgs": [
+          "--debug",
+          "--systemd-log"
+      ]
     }
   }
 }
 ```
 
 After this (need to restart docker at the first time), you can use youki
-with docker: `docker run --runtime youki ...`.
+with docker: `docker run --runtime youki ...`. You can verify the runtime includes `youki`:
+
+```console
+$ docker info|grep -i runtime
+ Runtimes: youki runc
+ Default Runtime: runc
+```
 
 #### Using Youki Standalone
 

--- a/justfile
+++ b/justfile
@@ -24,7 +24,6 @@ runtimetest:
 rust-oci-tests-bin:
     ./scripts/build.sh -o {{ ROOT }} -r -c integration-test
 
-
 # Tests
 
 # run oci tests
@@ -86,6 +85,7 @@ clean:
 dev-prepare:
     cargo install typos-cli
 
+# setup dependencies in CI
 ci-prepare:
     #!/usr/bin/env bash
     set -euo pipefail

--- a/tests/rust-integration-tests/integration_test/Cargo.toml
+++ b/tests/rust-integration-tests/integration_test/Cargo.toml
@@ -11,7 +11,7 @@ libcgroups = { path = "../../../crates/libcgroups" }
 libcontainer = { path = "../../../crates/libcontainer" }
 nix = "0.26.2"
 num_cpus = "1.15"
-oci-spec = "0.6.0"
+oci-spec = { version = "0.6.1", features = ["runtime"] }
 once_cell = "1.18.0"
 pnet_datalink = "0.33.0"
 procfs = "0.15.1"

--- a/tests/rust-integration-tests/runtimetest/Cargo.toml
+++ b/tests/rust-integration-tests/runtimetest/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.1"
 edition = "2021"
 
 [dependencies]
-oci-spec = { version = "0.6.0", features = ["runtime"] }
+oci-spec = { version = "0.6.1", features = ["runtime"] }
 nix = "0.26.2"
 anyhow = "1.0"
 


### PR DESCRIPTION
Fix #2022 

The detail of the cause of the issue and why 0.6.1 fixes the issue are explained in #2022. 

However, the 0.6.1 introduced the `time` namespace into the runtime spec. For this PR, we set the `time` namespace to be unsupported. Both `libc` and `nix` crate have not provided the support. We should ideally wait for the support to land in either of this crate first before we support it. As a result, there are a number of functions needs to propagate errors now. This is a good add because in the future I imagine we will run into similar situations when new namespaces is introduced.