### PR TITLE
Don't create a file when it already exists when mounting with bind

### DIFF
--- a/crates/libcontainer/src/rootfs/mount.rs
+++ b/crates/libcontainer/src/rootfs/mount.rs
@@ -497,7 +497,7 @@ impl Mount {
                 err
             })?;
 
-            if src.is_file() {
+            if src.is_file() && !dest.exists() {
                 OpenOptions::new()
                     .create(true)
                     .write(true)

--- a/hack/debug.bt
+++ b/hack/debug.bt
@@ -78,8 +78,6 @@ tracepoint:syscalls:sys_enter_setresuid
     printf("ruid=%d, euid=%d, suid=%d\n", args->ruid, args->euid, args->suid);
 }
 
-
-
 END
 {
     clear(@filename);


### PR DESCRIPTION
For example, it is more likely that the /etc/hosts file already exists. In that case, it fails because it tries to open the file with write permission while it is RO.