### PR TITLE
Introduce a `log-level` flag.

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -7,7 +7,6 @@ on:
   pull_request:
     branches:
       - main
-  workflow_dispatch:
 
 jobs:
   youki-build:

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -7,6 +7,7 @@ on:
   pull_request:
     branches:
       - main
+  workflow_dispatch:
 
 jobs:
   youki-build:

--- a/.github/workflows/integration_tests_validation.yaml
+++ b/.github/workflows/integration_tests_validation.yaml
@@ -20,7 +20,7 @@ jobs:
         with:
           files: |
             .github/workflows/integration_tests_validation.yaml
-            integration_test/tests/rust-integration-tests/**
+            tests/rust-integration-tests/**
           files_ignore: |
             **.md
       - name: List all changed files

--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ $ sudo apt-get install    \
       libelf-dev          \
       libseccomp-dev      \
       libclang-dev        \
+      glibc-static        \
       libssl-dev
 ```
 

--- a/crates/liboci-cli/src/lib.rs
+++ b/crates/liboci-cli/src/lib.rs
@@ -72,9 +72,6 @@ pub struct GlobalOpts {
     /// change log level to debug, but the `log-level` flag takes precedence
     #[clap(long)]
     pub debug: bool,
-    /// set the log level (default is 'warn')
-    #[clap(long)]
-    pub log_level: Option<String>,
     /// set the log format ('text' (default), or 'json') (default: "text")
     #[clap(long)]
     pub log_format: Option<String>,

--- a/crates/liboci-cli/src/lib.rs
+++ b/crates/liboci-cli/src/lib.rs
@@ -66,13 +66,15 @@ pub enum CommonCmd {
 // flags, but these are commonly accepted by runtimes
 #[derive(Parser, Debug)]
 pub struct GlobalOpts {
-    /// change log level to debug.
-    // Example in future : '--debug     change log level to debug. (default: "warn")'
-    #[clap(long)]
-    pub debug: bool,
     /// set the log file to write youki logs to (default is '/dev/stderr')
     #[clap(short, long, overrides_with("log"))]
     pub log: Option<PathBuf>,
+    /// change log level to debug, but the `log-level` flag takes precedence
+    #[clap(long)]
+    pub debug: bool,
+    /// set the log level (default is 'warn')
+    #[clap(long)]
+    pub log_level: Option<String>,
     /// set the log format ('text' (default), or 'json') (default: "text")
     #[clap(long)]
     pub log_format: Option<String>,

--- a/crates/youki/src/main.rs
+++ b/crates/youki/src/main.rs
@@ -21,6 +21,9 @@ struct YoukiExtendOpts {
     /// Enable logging to systemd-journald
     #[clap(long)]
     pub systemd_log: bool,
+    /// set the log level (default is 'error')
+    #[clap(long)]
+    pub log_level: Option<String>,
 }
 
 // High-level commandline option definition

--- a/crates/youki/src/observability.rs
+++ b/crates/youki/src/observability.rs
@@ -55,7 +55,7 @@ impl From<&crate::Opts> for ObservabilityConfig {
     fn from(opts: &crate::Opts) -> Self {
         Self {
             log_debug_flag: opts.global.debug,
-            log_level: opts.global.log_level.to_owned(),
+            log_level: opts.youki_extend.log_level.to_owned(),
             log_file: opts.global.log.to_owned(),
             log_format: opts.global.log_format.to_owned(),
             systemd_log: opts.youki_extend.systemd_log,

--- a/docs/src/user/basic_usage.md
+++ b/docs/src/user/basic_usage.md
@@ -171,3 +171,13 @@ cd ..
 ./youki list
 ./youki delete rootless_container
 ```
+
+#### Log level
+
+`youki` defaults the log level to `error` in the release build. In the debug
+build, the log level defaults to `debug`. The `--log-level` flag can be used to
+set the log-level. For least amount of log, we recommend using the `error` log
+level. For the most spammy logging, we have a `trace` level.
+
+For compatibility with `runc` and `crun`, we have a `--debug` flag to set the
+log level to `debug`. This flag is ignored if `--log-level` is also set.

--- a/scripts/rust_integration_tests.sh
+++ b/scripts/rust_integration_tests.sh
@@ -24,7 +24,7 @@ if [ ! -f ${ROOT}/bundle.tar.gz ]; then
 fi
 touch ${LOGFILE}
 
-sudo YOUKI_LOG_LEVEL="error" ${ROOT}/integration_test run --runtime "$RUNTIME" --runtimetest ${ROOT}/runtimetest > $LOGFILE
+sudo ${ROOT}/integration_test run --runtime "$RUNTIME" --runtimetest ${ROOT}/runtimetest > $LOGFILE
 
 if [ 0 -ne $(grep "not ok" $LOGFILE | wc -l ) ]; then
     cat $LOGFILE

--- a/tests/rust-integration-tests/integration_test/src/utils/test_utils.rs
+++ b/tests/rust-integration-tests/integration_test/src/utils/test_utils.rs
@@ -48,9 +48,6 @@ pub fn create_container<P: AsRef<Path>>(id: &str, dir: P) -> Result<Child> {
         // in test_inside_container function
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
-        // set log level to error only, otherwise
-        // we get warnings in stderr
-        .env("YOUKI_LOG_LEVEL", "error")
         .arg("--root")
         .arg(dir.as_ref().join("runtime"))
         .arg("create")

--- a/tests/rust-integration-tests/runtimetest/src/utils.rs
+++ b/tests/rust-integration-tests/runtimetest/src/utils.rs
@@ -217,7 +217,7 @@ pub fn test_mount_releatime_option(path: &str) -> Result<(), std::io::Error> {
     println!(
         "{:?} file three metadata atime is {:?}",
         test_file_path,
-        two_metadata.atime()
+        three_metadata.atime()
     );
     if two_metadata.atime() != three_metadata.atime() {
         return Err(std::io::Error::new(
@@ -282,8 +282,8 @@ pub fn test_mount_noreleatime_option(path: &str) -> Result<(), std::io::Error> {
     println!(
         "{:?} file three atime is {:?},mtime is {:?},current time is {:?}",
         test_file_path,
-        two_metadata.atime(),
-        two_metadata.mtime(),
+        three_metadata.atime(),
+        three_metadata.mtime(),
         std::time::SystemTime::now()
     );
 


### PR DESCRIPTION
Fix #2028 

As proposed in #2028, we introduce a `--log-level` flag to allow us to easily set log level through runtimes. To avoid confusion, we also deprecated setting log level through `env` variable. The `--debug` flag is kept for compatibility reasons.

Note, the integration test was not changed in this PR. If this PR is accepted, we will make the changes to the rust integration test to keep things consistent.