### PR TITLE
Update podman test workflow for new justfile setup

### DIFF
--- a/.github/workflows/podman_tests.yaml
+++ b/.github/workflows/podman_tests.yaml
@@ -9,10 +9,10 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
-      - name: Install requirements
-        run: sudo ./.github/scripts/dependency.sh
       - name: Install just
         uses: taiki-e/install-action@just
+      - name: Install requirements
+        run: sudo env PATH=$PATH just ci-prepare
       - run: just youki-dev
       - run: sudo cp youki /usr/local/bin
       - name: Install requirements for Podman
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: containers/podman
-      - uses: actions/setup-go@v2
+      - uses: actions/setup-go@v4
         with:
           go-version: '1.18'
       - name: Build podman
@@ -32,4 +32,4 @@ jobs:
         run: sudo OCI_RUNTIME=/usr/local/bin/youki ./hack/bats 2>&1 | tee build.log 
       - name: Adding Summary
         run: |
-          echo "Total tests: 360 Failed tests: $(cat build.log | grep " ok " | wc -l)" >> $GITHUB_STEP_SUMMARY
+          echo "Total tests: 577 Failed tests: $(cat build.log | grep " ok " | wc -l)" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
This updates the podman tests CI to correctly use new justfile setup.
Also updates the total number of tests, and setup-go action version.

I validated this in https://github.com/YJDoc2/youki/actions/runs/5239903983