### PR TITLE
re-export oci-spec in libcontainer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5580,7 +5580,6 @@ dependencies = [
  "libcontainer",
  "liboci-cli",
  "nix",
- "oci-spec",
  "once_cell",
  "pentacle",
  "procfs",

--- a/crates/libcgroups/Cargo.toml
+++ b/crates/libcgroups/Cargo.toml
@@ -22,7 +22,7 @@ cgroupsv2_devices = ["rbpf", "libbpf-sys", "errno", "libc"]
 [dependencies]
 nix = "0.26.2"
 procfs = "0.15.1"
-oci-spec = { version = "^0.6.1", features = ["runtime"] }
+oci-spec = { version = "0.6.1", features = ["runtime"] }
 dbus = { version = "0.9.7", optional = true }
 fixedbitset = "0.4.2"
 serde = { version = "1.0", features = ["derive"] }
@@ -35,7 +35,7 @@ tracing = { version = "0.1.37", features = ["attributes"]}
 
 [dev-dependencies]
 anyhow = "1.0"
-oci-spec = { version = "^0.6.0", features = ["proptests", "runtime"] }
+oci-spec = { version = "0.6.1", features = ["proptests", "runtime"] }
 quickcheck = "1"
 mockall = { version = "0.11.4", features = [] }
 clap = "4.1.6"

--- a/crates/libcgroups/Cargo.toml
+++ b/crates/libcgroups/Cargo.toml
@@ -22,7 +22,7 @@ cgroupsv2_devices = ["rbpf", "libbpf-sys", "errno", "libc"]
 [dependencies]
 nix = "0.26.2"
 procfs = "0.15.1"
-oci-spec = { version = "0.6.1", features = ["runtime"] }
+oci-spec = { version = "~0.6.1", features = ["runtime"] }
 dbus = { version = "0.9.7", optional = true }
 fixedbitset = "0.4.2"
 serde = { version = "1.0", features = ["derive"] }
@@ -35,7 +35,7 @@ tracing = { version = "0.1.37", features = ["attributes"]}
 
 [dev-dependencies]
 anyhow = "1.0"
-oci-spec = { version = "0.6.1", features = ["proptests", "runtime"] }
+oci-spec = { version = "~0.6.1", features = ["proptests", "runtime"] }
 quickcheck = "1"
 mockall = { version = "0.11.4", features = [] }
 clap = "4.1.6"

--- a/crates/libcontainer/Cargo.toml
+++ b/crates/libcontainer/Cargo.toml
@@ -27,7 +27,7 @@ fastrand = "^2.0.0"
 futures = { version = "0.3", features = ["thread-pool"] }
 libc = "0.2.147"
 nix = "0.26.2"
-oci-spec = { version = "^0.6.1", features = ["runtime"] }
+oci-spec = { version = "~0.6.1", features = ["runtime"] }
 once_cell = "1.18.0"
 procfs = "0.15.1"
 prctl = "1.0.0"
@@ -43,7 +43,7 @@ tracing = { version = "0.1.37", features = ["attributes"]}
 safe-path = "0.1.0"
 
 [dev-dependencies]
-oci-spec = { version = "^0.6.0", features = ["proptests", "runtime"] }
+oci-spec = { version = "~0.6.1", features = ["proptests", "runtime"] }
 quickcheck = "1"
 serial_test = "2.0.0"
 tempfile = "3"

--- a/crates/libcontainer/src/lib.rs
+++ b/crates/libcontainer/src/lib.rs
@@ -21,4 +21,6 @@ pub mod workload;
 
 // Because the `libcontainer` api uses the oci_spec who resides in a different
 // crate, we re-export the version of oci_spec this crate uses.
+// Ref: https://github.com/containers/youki/issues/2066
+// Ref: https://github.com/rust-lang/api-guidelines/discussions/176
 pub use oci_spec;

--- a/crates/libcontainer/src/lib.rs
+++ b/crates/libcontainer/src/lib.rs
@@ -18,3 +18,7 @@ pub mod test_utils;
 pub mod tty;
 pub mod utils;
 pub mod workload;
+
+// Because the `libcontainer` api uses the oci_spec who resides in a different
+// crate, we re-export the version of oci_spec this crate uses.
+pub use oci_spec;

--- a/crates/youki/Cargo.toml
+++ b/crates/youki/Cargo.toml
@@ -32,7 +32,6 @@ libcgroups = { version = "0.1.0", path = "../libcgroups", default-features = fal
 libcontainer = { version = "0.1.0", path = "../libcontainer", default-features = false }
 liboci-cli = { version = "0.1.0", path = "../liboci-cli" }
 nix = "0.26.2"
-oci-spec = { version = "^0.6.1", features = ["runtime"] }
 once_cell = "1.18.0"
 pentacle = "1.0.0"
 procfs = "0.15.1"

--- a/crates/youki/src/commands/spec_json.rs
+++ b/crates/youki/src/commands/spec_json.rs
@@ -1,10 +1,10 @@
 use anyhow::Result;
-use nix;
-use oci_spec::runtime::Mount;
-use oci_spec::runtime::{
+use libcontainer::oci_spec::runtime::Mount;
+use libcontainer::oci_spec::runtime::{
     LinuxBuilder, LinuxIdMappingBuilder, LinuxNamespace, LinuxNamespaceBuilder, LinuxNamespaceType,
     Spec,
 };
+use nix;
 use serde_json::to_writer_pretty;
 use std::fs::File;
 use std::io::{BufWriter, Write};
@@ -17,12 +17,13 @@ pub fn get_default() -> Result<Spec> {
 
 pub fn get_rootless() -> Result<Spec> {
     // Remove network and user namespace from the default spec
-    let mut namespaces: Vec<LinuxNamespace> = oci_spec::runtime::get_default_namespaces()
-        .into_iter()
-        .filter(|ns| {
-            ns.typ() != LinuxNamespaceType::Network && ns.typ() != LinuxNamespaceType::User
-        })
-        .collect();
+    let mut namespaces: Vec<LinuxNamespace> =
+        libcontainer::oci_spec::runtime::get_default_namespaces()
+            .into_iter()
+            .filter(|ns| {
+                ns.typ() != LinuxNamespaceType::Network && ns.typ() != LinuxNamespaceType::User
+            })
+            .collect();
 
     // Add user namespace
     namespaces.push(
@@ -50,7 +51,7 @@ pub fn get_rootless() -> Result<Spec> {
 
     // Prepare the mounts
 
-    let mut mounts: Vec<Mount> = oci_spec::runtime::get_default_mounts();
+    let mut mounts: Vec<Mount> = libcontainer::oci_spec::runtime::get_default_mounts();
     for mount in &mut mounts {
         if mount.destination().eq(Path::new("/sys")) {
             mount

--- a/crates/youki/src/commands/update.rs
+++ b/crates/youki/src/commands/update.rs
@@ -6,8 +6,8 @@ use crate::commands::create_cgroup_manager;
 use anyhow::Result;
 use libcgroups::common::CgroupManager;
 use libcgroups::{self, common::ControllerOpt};
+use libcontainer::oci_spec::runtime::{LinuxPidsBuilder, LinuxResources, LinuxResourcesBuilder};
 use liboci_cli::Update;
-use oci_spec::runtime::{LinuxPidsBuilder, LinuxResources, LinuxResourcesBuilder};
 
 pub fn update(args: Update, root_path: PathBuf) -> Result<()> {
     let cmanager = create_cgroup_manager(root_path, &args.container_id)?;

--- a/crates/youki/src/workload/wasmedge.rs
+++ b/crates/youki/src/workload/wasmedge.rs
@@ -1,4 +1,4 @@
-use oci_spec::runtime::Spec;
+use libcontainer::oci_spec::runtime::Spec;
 use wasmedge_sdk::{
     config::{CommonConfigOptions, ConfigBuilder, HostRegistrationConfigOptions},
     params, VmBuilder,

--- a/crates/youki/src/workload/wasmer.rs
+++ b/crates/youki/src/workload/wasmer.rs
@@ -1,4 +1,4 @@
-use oci_spec::runtime::Spec;
+use libcontainer::oci_spec::runtime::Spec;
 use wasmer::{Instance, Module, Store};
 use wasmer_wasix::WasiEnv;
 
@@ -100,7 +100,7 @@ impl Executor for WasmerExecutor {
 mod tests {
     use super::*;
     use anyhow::{Context, Result};
-    use oci_spec::runtime::SpecBuilder;
+    use libcontainer::oci_spec::runtime::SpecBuilder;
     use std::collections::HashMap;
 
     #[test]

--- a/crates/youki/src/workload/wasmtime.rs
+++ b/crates/youki/src/workload/wasmtime.rs
@@ -1,4 +1,4 @@
-use oci_spec::runtime::Spec;
+use libcontainer::oci_spec::runtime::Spec;
 use wasmtime::*;
 use wasmtime_wasi::WasiCtxBuilder;
 


### PR DESCRIPTION
Fix #2066 

- re-export the oci-spec crate used by libcontainer as part of the libcontainer api
- fix the oci-spec version, because oci-spec can have breaking changes with version bump.
- remove oci-spec from `youki` crate dependency (this is the key here)