### PR TITLE
Implement `clone3` fallback to `clone` when ENOSYS returns

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,7 +34,7 @@ version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "once_cell",
  "version_check",
 ]
@@ -182,7 +182,7 @@ checksum = "233d376d6d185f2a3093e58f283f60f880315b6c60075b01f36b3b85154564ca"
 dependencies = [
  "addr2line",
  "cc",
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
  "miniz_oxide 0.6.2",
  "object",
@@ -399,12 +399,6 @@ dependencies = [
 
 [[package]]
 name = "cfg-if"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
-
-[[package]]
-name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
@@ -486,16 +480,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2da6da31387c7e4ef160ffab6d5e7f00c42626fe39aea70a7b0f1773f7dd6c1b"
 
 [[package]]
-name = "clone3"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ee4e061ea30800291ca09663878f3953840a69b08ce244b3e8b26e894d9f60f"
-dependencies = [
- "bitflags 1.3.2",
- "uapi",
-]
-
-[[package]]
 name = "cmake"
 version = "0.1.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -555,7 +539,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9847f90f32a50b0dcbd68bc23ff242798b13080b97b0569f6ed96a45ce4cf2cd"
 dependencies = [
  "autocfg",
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
  "scopeguard",
  "windows-sys 0.33.0",
@@ -567,7 +551,7 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eeaa953eaad386a53111e47172c2fedba671e5684c8dd601a5f474f4f118710f"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
 ]
 
 [[package]]
@@ -776,7 +760,7 @@ version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
 ]
 
 [[package]]
@@ -791,7 +775,7 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2801af0d36612ae591caa9568261fddce32ce6e08a7275ea334a06a4ad021a2c"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "crossbeam-channel",
  "crossbeam-deque",
  "crossbeam-epoch",
@@ -805,7 +789,7 @@ version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a33c2bf77f2df06183c3aa30d1e96c0695a313d4f9c453cc3762a6db39f99200"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "crossbeam-utils",
 ]
 
@@ -815,7 +799,7 @@ version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce6fd6f855243022dcecf8702fef0c297d4338e226845fe067f6341ad9fa0cef"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "crossbeam-epoch",
  "crossbeam-utils",
 ]
@@ -827,7 +811,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae211234986c545741a7dc064309f67ee1e5ad243d0e48335adc0484d960bcc7"
 dependencies = [
  "autocfg",
- "cfg-if 1.0.0",
+ "cfg-if",
  "crossbeam-utils",
  "memoffset 0.9.0",
  "scopeguard",
@@ -839,7 +823,7 @@ version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d1cfb3ea8a53f37c40dea2c7bedcbd88bdfae54f5e2175d6ecaff1c988353add"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "crossbeam-utils",
 ]
 
@@ -849,7 +833,7 @@ version = "0.8.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a22b2d63d4d1dc0b7f1b6b2747dd0088008a9be28b6ddf0b1e7d335e3037294"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
 ]
 
 [[package]]
@@ -937,7 +921,7 @@ version = "5.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "907076dfda823b0b36d2a1bb5f90c96660a5bbcd7729e10727f07858f22c4edc"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "hashbrown 0.12.3",
  "lock_api",
  "once_cell",
@@ -1028,7 +1012,7 @@ version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "339ee130d97a610ea5a5872d2bbb130fdf68884ff09d3028b81bec8a1ac23bbc"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "dirs-sys-next",
 ]
 
@@ -1087,7 +1071,7 @@ version = "0.8.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071a31f4ee85403370b58aca746f01041ede6f0da2730960ad001edc2b71b394"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
 ]
 
 [[package]]
@@ -1202,7 +1186,7 @@ version = "3.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39ae6b3d9530211fb3b12a95374b8b0823be812f53d09e18c5675c0146b09642"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "rustix 0.37.19",
  "windows-sys 0.48.0",
 ]
@@ -1223,7 +1207,7 @@ version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5cbc844cecaee9d4443931972e1289c8ff485cb4cc2767cb03ca139ed6885153"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
  "redox_syscall 0.2.16",
  "windows-sys 0.48.0",
@@ -1441,7 +1425,7 @@ version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "js-sys",
  "libc",
  "wasi",
@@ -1741,7 +1725,7 @@ version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
 ]
 
 [[package]]
@@ -1952,7 +1936,6 @@ dependencies = [
  "bitflags 2.3.2",
  "caps",
  "chrono",
- "clone3",
  "fastrand 2.0.0",
  "futures",
  "libc",
@@ -1991,7 +1974,7 @@ version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b67380fd3b2fbe7527a606e18729d21c6f3951633d0500574c4dc22d2d638b9f"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "winapi",
 ]
 
@@ -2194,7 +2177,7 @@ version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c84490118f2ee2d74570d114f3d0493cbf02790df303d2707606c3e14e07c96"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "downcast",
  "fragile",
  "lazy_static",
@@ -2209,7 +2192,7 @@ version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22ce75669015c4f47b289fd4d4f56e894e4c96003ffdf3ac51313126f94c6cbb"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -2246,7 +2229,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfdda3d196821d6af13126e40375cdf7da646a96114af134d5f417a9a1dc8e1a"
 dependencies = [
  "bitflags 1.3.2",
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
  "memoffset 0.7.1",
  "pin-utils",
@@ -2375,7 +2358,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "345df152bc43501c5eb9e4654ff05f794effb78d4efe3d53abc158baddc0703d"
 dependencies = [
  "bitflags 1.3.2",
- "cfg-if 1.0.0",
+ "cfg-if",
  "foreign-types",
  "libc",
  "once_cell",
@@ -2434,7 +2417,7 @@ version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93f00c865fe7cabf650081affecd3871070f26767e7b2070a3ffae14c654b447"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
  "redox_syscall 0.3.5",
  "smallvec",
@@ -3368,7 +3351,7 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479fb9d862239e610720565ca91403019f2f00410f1864c5aa7479b950a76ed8"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "cpufeatures",
  "digest",
 ]
@@ -3621,7 +3604,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31c0432476357e58790aaa47a8efb0c5138f137343f3b5f23bd36a27e3b0a6d6"
 dependencies = [
  "autocfg",
- "cfg-if 1.0.0",
+ "cfg-if",
  "fastrand 1.9.0",
  "redox_syscall 0.3.5",
  "rustix 0.37.19",
@@ -3696,7 +3679,7 @@ version = "1.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "once_cell",
 ]
 
@@ -3881,7 +3864,7 @@ version = "0.1.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "log",
  "pin-project-lite",
  "tracing-attributes",
@@ -3973,32 +3956,6 @@ name = "typenum"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
-
-[[package]]
-name = "uapi"
-version = "0.2.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "019450240401d342e2a5bc47f7fbaeb002a38fe18197b83788750d7ffb143274"
-dependencies = [
- "cc",
- "cfg-if 0.1.10",
- "libc",
- "uapi-proc",
-]
-
-[[package]]
-name = "uapi-proc"
-version = "0.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54de46f980cea7b2ae8d8f7f9f1c35cf7062c68343e99345ef73758f8e60975a"
-dependencies = [
- "lazy_static",
- "libc",
- "proc-macro2",
- "quote",
- "regex",
- "syn 1.0.109",
-]
 
 [[package]]
 name = "unicase"
@@ -4336,7 +4293,7 @@ version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7706a72ab36d8cb1f80ffbf0e071533974a60d0a308d01a5d0375bf60499a342"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "wasm-bindgen-macro",
 ]
 
@@ -4384,7 +4341,7 @@ version = "0.4.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c02dbc21516f9f1f04f187958890d7e6026df8d16540b7ad9492bc34a67cea03"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "js-sys",
  "wasm-bindgen",
  "web-sys",
@@ -4495,7 +4452,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78caedecd8cb71ed47ccca03b68d69414a3d278bb031e6f93f15759344efdd52"
 dependencies = [
  "bytes",
- "cfg-if 1.0.0",
+ "cfg-if",
  "derivative",
  "indexmap",
  "js-sys",
@@ -4523,7 +4480,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "726a8450541af4a57c34af7b6973fdbfc79f896cc7e733429577dfd1d1687180"
 dependencies = [
  "backtrace",
- "cfg-if 1.0.0",
+ "cfg-if",
  "enum-iterator",
  "enumset",
  "lazy_static",
@@ -4594,7 +4551,7 @@ checksum = "043118ec4f16d1714fed3aab758b502b864bd865e1d5188626c9ad290100563f"
 dependencies = [
  "backtrace",
  "cc",
- "cfg-if 1.0.0",
+ "cfg-if",
  "corosensei",
  "dashmap",
  "derivative",
@@ -4623,7 +4580,7 @@ dependencies = [
  "async-trait",
  "bincode",
  "bytes",
- "cfg-if 1.0.0",
+ "cfg-if",
  "cooked-waker",
  "derivative",
  "futures",
@@ -4672,7 +4629,7 @@ dependencies = [
  "anyhow",
  "bitflags 1.3.2",
  "byteorder",
- "cfg-if 1.0.0",
+ "cfg-if",
  "num_enum",
  "time 0.2.27",
  "wai-bindgen-gen-core",
@@ -4715,7 +4672,7 @@ dependencies = [
  "async-trait",
  "bincode",
  "bumpalo",
- "cfg-if 1.0.0",
+ "cfg-if",
  "fxprof-processed-profile",
  "indexmap",
  "libc",
@@ -4746,7 +4703,7 @@ version = "9.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d33c73c24ce79b0483a3b091a9acf88871f4490b88998e8974b22236264d304c"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
 ]
 
 [[package]]
@@ -4855,7 +4812,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23c5127908fdf720614891ec741c13dd70c844e102caa393e2faca1ee68e9bfb"
 dependencies = [
  "cc",
- "cfg-if 1.0.0",
+ "cfg-if",
  "rustix 0.37.19",
  "wasmtime-asm-macros",
  "windows-sys 0.48.0",
@@ -4870,7 +4827,7 @@ dependencies = [
  "addr2line",
  "anyhow",
  "bincode",
- "cfg-if 1.0.0",
+ "cfg-if",
  "cpp_demangle",
  "gimli 0.27.2",
  "ittapi",
@@ -4903,7 +4860,7 @@ version = "9.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d1364900b05f7d6008516121e8e62767ddb3e176bdf4c84dfa85da1734aeab79"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
  "windows-sys 0.48.0",
 ]
@@ -4916,7 +4873,7 @@ checksum = "4a16ffe4de9ac9669175c0ea5c6c51ffc596dfb49320aaa6f6c57eff58cef069"
 dependencies = [
  "anyhow",
  "cc",
- "cfg-if 1.0.0",
+ "cfg-if",
  "indexmap",
  "libc",
  "log",

--- a/crates/libcontainer/Cargo.toml
+++ b/crates/libcontainer/Cargo.toml
@@ -36,7 +36,6 @@ libseccomp = { version = "0.3.0", optional=true }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 rust-criu = "0.4.0"
-clone3 = "0.2.3"
 regex = "1.8.4"
 thiserror = "1.0.24"
 tracing = { version = "0.1.37", features = ["attributes"]}

--- a/crates/libcontainer/src/process/fork.rs
+++ b/crates/libcontainer/src/process/fork.rs
@@ -8,8 +8,6 @@ pub enum CloneError {
     Clone(#[source] nix::Error),
 }
 
-type Result<T> = std::result::Result<T, CloneError>;
-
 #[derive(Debug, thiserror::Error)]
 pub enum CallbackError {
     #[error(transparent)]
@@ -19,11 +17,12 @@ pub enum CallbackError {
     #[error(transparent)]
     InitProcess(#[from] crate::process::container_init_process::InitProcessError),
     // Need a fake error for testing
-    #[error("unknown")]
     #[cfg(test)]
+    #[error("unknown")]
     Test,
 }
 
+type Result<T> = std::result::Result<T, CloneError>;
 type CallbackResult<T> = std::result::Result<T, CallbackError>;
 
 // Fork/Clone a sibling process that shares the same parent as the calling
@@ -37,14 +36,22 @@ pub fn container_clone_sibling<F: FnOnce() -> CallbackResult<i32>>(
     child_name: &str,
     cb: F,
 ) -> Result<Pid> {
-    let mut clone = clone3::Clone3::default();
     // Note: normally, an exit signal is required, but when using
     // `CLONE_PARENT`, the `clone3` will return EINVAL if an exit signal is set.
     // The older `clone` will not return EINVAL in this case. Instead it ignores
-    // the exit signal bits in the glibc wrapper.
-    clone.flag_parent();
+    // the exit signal bits in the glibc wrapper. Therefore, we explicitly set
+    // the exit_signal to None here, so this works for both version of clone.
+    container_clone(child_name, cb, libc::CLONE_PARENT as u64, None)
+}
 
-    container_clone(child_name, cb, clone)
+// Execute the cb in another process. Make the fork works more like thread_spawn
+// or clone, so it is easier to reason. Compared to clone call, fork is easier
+// to use since fork will magically take care of all the variable copying. If
+// using clone, we would have to manually make sure all the variables are
+// correctly send to the new process, especially Rust borrow checker will be a
+// lot of hassel to deal with every details.
+pub fn container_fork<F: FnOnce() -> CallbackResult<i32>>(child_name: &str, cb: F) -> Result<Pid> {
+    container_clone(child_name, cb, 0, Some(SIGCHLD as u64))
 }
 
 // A simple clone wrapper to clone3 so we can share this logic in different
@@ -54,20 +61,18 @@ pub fn container_clone_sibling<F: FnOnce() -> CallbackResult<i32>>(
 fn container_clone<F: FnOnce() -> CallbackResult<i32>>(
     child_name: &str,
     cb: F,
-    mut clone_cmd: clone3::Clone3,
+    flags: u64,
+    exit_signal: Option<u64>,
 ) -> Result<Pid> {
     // Return the child's pid in case of parent/calling process, and for the
     // cloned process, run the callback function, and exit with the same exit
     // code returned by the callback. If there was any error when trying to run
     // callback, exit with -1
-    match unsafe {
-        clone_cmd
-            .call()
-            .map_err(|err| CloneError::Clone(nix::errno::from_i32(err.0)))?
-    } {
+    match clone_wrapper(flags, exit_signal) {
+        -1 => Err(CloneError::Clone(nix::Error::last())),
         0 => {
-            prctl::set_name(child_name).expect("failed to set name");
             // Inside the cloned process
+            prctl::set_name(child_name).expect("failed to set name");
             let ret = match cb() {
                 Err(error) => {
                     tracing::debug!("failed to run child process in clone: {:?}", error);
@@ -81,18 +86,89 @@ fn container_clone<F: FnOnce() -> CallbackResult<i32>>(
     }
 }
 
-// Execute the cb in another process. Make the fork works more like thread_spawn
-// or clone, so it is easier to reason. Compared to clone call, fork is easier
-// to use since fork will magically take care of all the variable copying. If
-// using clone, we would have to manually make sure all the variables are
-// correctly send to the new process, especially Rust borrow checker will be a
-// lot of hassel to deal with every details.
-pub fn container_fork<F: FnOnce() -> CallbackResult<i32>>(child_name: &str, cb: F) -> Result<Pid> {
-    // Using `clone3` to mimic the effect of `fork`.
-    let mut clone = clone3::Clone3::default();
-    clone.exit_signal(SIGCHLD as u64);
+#[repr(C)]
+struct clone3_args {
+    flags: u64,
+    pidfd: u64,
+    child_tid: u64,
+    parent_tid: u64,
+    exit_signal: u64,
+    stack: u64,
+    stack_size: u64,
+    tls: u64,
+    set_tid: u64,
+    set_tid_size: u64,
+    cgroup: u64,
+}
 
-    container_clone(child_name, cb, clone)
+// clone_wrapper wraps the logic of using `clone3` with fallback behavior when
+// `clone3` is either not available or blocked. While `libcontainer` maintains a
+// minimum kernel version where `clone3` is available, we have found that in
+// real life, places would choose to block `clone3`. This is mostly due to
+// seccomp profile can't effectively filter `clone3` calls because the clone
+// flags are inside the clone_args, not part of the variables like the `clone`
+// call. Therefore, we try `clone3` first, but fallback to `clone` when ENOSYS
+// is returned.
+fn clone_wrapper(flags: u64, exit_signal: Option<u64>) -> i32 {
+    let mut args = clone3_args {
+        flags,
+        pidfd: 0,
+        child_tid: 0,
+        parent_tid: 0,
+        exit_signal: exit_signal.unwrap_or(0),
+        stack: 0,
+        stack_size: 0,
+        tls: 0,
+        set_tid: 0,
+        set_tid_size: 0,
+        cgroup: 0,
+    };
+    let args_ptr = &mut args as *mut clone3_args;
+    let args_size = std::mem::size_of::<clone3_args>();
+    // We strategically choose to use the raw syscall here because it is simpler
+    // for our usecase. We don't have to care about all the other usecases that
+    // clone syscalls supports in general.
+    match unsafe { libc::syscall(libc::SYS_clone3, args_ptr, args_size) } {
+        -1 if nix::Error::last() == nix::Error::ENOSYS => {
+            // continue to fallback to clone syscall
+        }
+        ret => {
+            return ret as i32;
+        }
+    };
+
+    let ret = unsafe {
+        // We choose to use the raw clone syscall here instead of the glibc
+        // wrapper version for the following reasons:
+        //
+        // 1. the raw syscall behaves more like the fork and clone3 call, so the
+        // substitution is more natural in the case of a fallback. We do not
+        // need to create a new function for the child to execute. Like fork and
+        // clone3, the clone raw syscall will start the child from the point of
+        // clone call.
+        //
+        // 2. the raw clone syscall can take null or 0 for the child stack as
+        // arguement. The syscall will do copy on write with the existing stack
+        // and takes care of child stack allocation. Correctly allocate a child
+        // stack is a pain when we previously implemented the logic using the
+        // glibc clone wrapper.
+        //
+        // The strategically use of the raw clone syscall is safe here because
+        // we are using a specific subset of the clone flags to launch
+        // processes. Unlike the general clone syscall where a number of
+        // usecases are supported such as launching thread, we want a behavior
+        // that is more similar to fork.
+        libc::syscall(
+            libc::SYS_clone,
+            flags | exit_signal.unwrap_or(0), // flags
+            0,                                // stack
+            0,                                // parent_tid
+            0,                                // child_tid
+            0,                                // tls
+        )
+    };
+
+    ret as i32
 }
 
 #[cfg(test)]
@@ -177,6 +253,69 @@ mod test {
                 std::process::exit(0);
             }
         };
+
+        Ok(())
+    }
+
+    // This test depends on libseccomp to work.
+    #[cfg(feature = "libseccomp")]
+    #[test]
+    fn test_clone_fallback() -> Result<()> {
+        use crate::test_utils::TestCallbackError;
+        use oci_spec::runtime::{
+            Arch, LinuxSeccompAction, LinuxSeccompBuilder, LinuxSyscallBuilder,
+        };
+
+        fn has_clone3() -> bool {
+            // We use the probe syscall to check if the kernel supports clone3 or
+            // seccomp has successfully blocked clone3.
+            let res = unsafe { libc::syscall(libc::SYS_clone3, 0, 0) };
+            let err = (res == -1)
+                .then(std::io::Error::last_os_error)
+                .expect("probe syscall should not succeed");
+            err.raw_os_error() != Some(libc::ENOSYS)
+        }
+
+        // To test the fallback behavior, we will create a seccomp rule that
+        // blocks `clone3` as ENOSYS.
+        let syscall = LinuxSyscallBuilder::default()
+            .names(vec![String::from("clone3")])
+            .action(LinuxSeccompAction::ScmpActErrno)
+            .errno_ret(libc::ENOSYS as u32)
+            .build()?;
+        let seccomp_profile = LinuxSeccompBuilder::default()
+            .default_action(LinuxSeccompAction::ScmpActAllow)
+            .architectures(vec![Arch::ScmpArchNative])
+            .syscalls(vec![syscall])
+            .build()?;
+
+        crate::test_utils::test_in_child_process(|| {
+            // We use seccomp to block `clone3`
+            let _ = prctl::set_no_new_privileges(true);
+            crate::seccomp::initialize_seccomp(&seccomp_profile)
+                .expect("failed to initialize seccomp");
+
+            if has_clone3() {
+                return Err(TestCallbackError::Custom(
+                    "clone3 is not blocked by seccomp".into(),
+                ));
+            }
+
+            let pid = container_fork("test:child", || Ok(0)).map_err(|err| err.to_string())?;
+            match waitpid(pid, None).expect("wait pid failed.") {
+                WaitStatus::Exited(p, status) => {
+                    assert_eq!(pid, p);
+                    assert_eq!(status, 0);
+                }
+                _ => {
+                    return Err(TestCallbackError::Custom(
+                        "failed to wait on the child process".into(),
+                    ));
+                }
+            };
+
+            Ok(())
+        })?;
 
         Ok(())
     }


### PR DESCRIPTION
Fix #2030 

Potentially controversial:

- Removed the use of `clone3` crate. Our usecase for the clone3 syscall is very specific and do not need to support everything. I can easily replace the clone3 crate with a few lines of code, so I did it in this PR. We usually favors safe syscall wrappers like `nix` over `libc`, but I believe the save is worth it here.
- We use the raw `clone` syscall instead of `glibc` wrapper. Details are in the comments.
- Using raw syscalls for both clone and clone3 actually makes the code well organized. For our usecase, they share the input types.

Otherwise, this PR does what the RFC outline. Unit tests using seccomp profile to simulate clone3 being blocked are added.

Also, I implemented fallback for `ENOSYS` only. Technically, we can add `EPERM` to the list as well.