### PR TITLE
Add one label to generate release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,21 @@
+changelog:
+  exclude:
+    authors:
+      - dependabot
+  categories:
+    - title: 💪 Improvements
+      labels:
+        - kind/feature
+    - title: 🐛 Bug Fixes
+      labels:
+        - kind/bug
+    - title: 📖 Documentation improvements
+      labels:
+        - kind/documentation
+    - title: 🧪 Test improvements and Misc Fixes
+      labels:
+        - kind/test
+        - kind/cleanup
+    - title: Other Changes
+      labels:
+        - "*"

--- a/.github/workflows/label.yaml
+++ b/.github/workflows/label.yaml
@@ -1,0 +1,17 @@
+name: 🏷️ Pull Request Labels
+
+on:
+  pull_request:
+    types: [opened, labeled, unlabeled, synchronize]
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: mheap/github-action-required-labels@v5
+        with:
+          mode: exactly
+          count: 1
+          labels: "kind/feature, kind/bug, kind/documentation, kind/test, kind/cleanup, dependencies"


### PR DESCRIPTION
Make the heaviest of release tasks, the generation of release notes, much easier.