### PR TITLE
[Trivial] exclude the oci-runtime-test from the typos

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -4,6 +4,7 @@
 [files]
 extend-exclude = [
     "**/*.svg",
+    "tests/oci-runtime-tests/**"
 ]
 
 [default.extend-identifiers]


### PR DESCRIPTION
The oci runtime test in Go is maintained separately and used as a submodule. For us, there is no reason to check the typos.