### PR TITLE
Increate musl CI test timeout to 20

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -77,7 +77,7 @@ jobs:
     needs: [changes]
     if: needs.changes.outputs.any_modified == 'true'
     runs-on: ubuntu-22.04
-    timeout-minutes: 15
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v3
       # We do not use `actions-rust-lang/setup-rust-toolchain` here because we


### PR DESCRIPTION
Recently there were several cancellations in CI due to musl tests getting timed out. This increases timeout from 15->20 mins, as in most of those cases the test running is underway, and our unit tests should be finished within the increases 5 minutes.