### PR TITLE
Use syscall type to delay the creation of syscall struct.

### DIFF
--- a/crates/libcontainer/src/container/builder.rs
+++ b/crates/libcontainer/src/container/builder.rs
@@ -1,18 +1,19 @@
 use crate::error::{ErrInvalidID, LibcontainerError};
+use crate::syscall::syscall::SyscallType;
+use crate::utils::PathBufExt;
 use crate::workload::default::DefaultExecutor;
 use crate::workload::{Executor, ExecutorManager};
-use crate::{syscall::Syscall, utils::PathBufExt};
 use std::path::PathBuf;
 
 use super::{init_builder::InitContainerBuilder, tenant_builder::TenantContainerBuilder};
 
-pub struct ContainerBuilder<'a> {
+pub struct ContainerBuilder {
     /// Id of the container
     pub(super) container_id: String,
     /// Root directory for container state
     pub(super) root_path: PathBuf,
     /// Interface to operating system primitives
-    pub(super) syscall: &'a dyn Syscall,
+    pub(super) syscall: SyscallType,
     /// File which will be used to communicate the pid of the
     /// container process to the higher level runtime
     pub(super) pid_file: Option<PathBuf>,
@@ -32,12 +33,11 @@ pub struct ContainerBuilder<'a> {
 ///
 /// ```no_run
 /// use libcontainer::container::builder::ContainerBuilder;
-/// use libcontainer::syscall::syscall::create_syscall;
-/// use libcontainer::workload::default::DefaultExecutor;
+/// use libcontainer::syscall::syscall::SyscallType;
 ///
 /// ContainerBuilder::new(
 ///     "74f1a4cb3801".to_owned(),
-///     create_syscall().as_ref(),
+///     SyscallType::default(),
 /// )
 /// .with_root_path("/run/containers/youki").expect("invalid root path")
 /// .with_pid_file(Some("/var/run/docker.pid")).expect("invalid pid file")
@@ -45,7 +45,7 @@ pub struct ContainerBuilder<'a> {
 /// .as_init("/var/run/docker/bundle")
 /// .build();
 /// ```
-impl<'a> ContainerBuilder<'a> {
+impl ContainerBuilder {
     /// Generates the base configuration for a container which can be
     /// transformed into either a init container or a tenant container
     ///
@@ -53,15 +53,14 @@ impl<'a> ContainerBuilder<'a> {
     ///
     /// ```no_run
     /// use libcontainer::container::builder::ContainerBuilder;
-    /// use libcontainer::syscall::syscall::create_syscall;
-    /// use libcontainer::workload::default::DefaultExecutor;
+    /// use libcontainer::syscall::syscall::SyscallType;
     ///
     /// let builder = ContainerBuilder::new(
     ///     "74f1a4cb3801".to_owned(),
-    ///     create_syscall().as_ref(),
+    ///     SyscallType::default(),
     /// );
     /// ```
-    pub fn new(container_id: String, syscall: &'a dyn Syscall) -> Self {
+    pub fn new(container_id: String, syscall: SyscallType) -> Self {
         let root_path = PathBuf::from("/run/youki");
         Self {
             container_id,
@@ -117,19 +116,18 @@ impl<'a> ContainerBuilder<'a> {
     ///
     /// ```no_run
     /// # use libcontainer::container::builder::ContainerBuilder;
-    /// # use libcontainer::syscall::syscall::create_syscall;
-    /// # use libcontainer::workload::default::DefaultExecutor;
+    /// # use libcontainer::syscall::syscall::SyscallType;
     ///
     /// ContainerBuilder::new(
     ///     "74f1a4cb3801".to_owned(),
-    ///     create_syscall().as_ref(),
+    ///     SyscallType::default(),
     /// )
     /// .as_tenant()
     /// .with_container_args(vec!["sleep".to_owned(), "9001".to_owned()])
     /// .build();
     /// ```
     #[allow(clippy::wrong_self_convention)]
-    pub fn as_tenant(self) -> TenantContainerBuilder<'a> {
+    pub fn as_tenant(self) -> TenantContainerBuilder {
         TenantContainerBuilder::new(self)
     }
 
@@ -138,19 +136,18 @@ impl<'a> ContainerBuilder<'a> {
     ///
     /// ```no_run
     /// # use libcontainer::container::builder::ContainerBuilder;
-    /// # use libcontainer::syscall::syscall::create_syscall;
-    /// # use libcontainer::workload::default::DefaultExecutor;
+    /// # use libcontainer::syscall::syscall::SyscallType;
     ///
     /// ContainerBuilder::new(
     ///     "74f1a4cb3801".to_owned(),
-    ///     create_syscall().as_ref(),
+    ///     SyscallType::default(),
     /// )
     /// .as_init("/var/run/docker/bundle")
     /// .with_systemd(false)
     /// .build();
     /// ```
     #[allow(clippy::wrong_self_convention)]
-    pub fn as_init<P: Into<PathBuf>>(self, bundle: P) -> InitContainerBuilder<'a> {
+    pub fn as_init<P: Into<PathBuf>>(self, bundle: P) -> InitContainerBuilder {
         InitContainerBuilder::new(self, bundle.into())
     }
 
@@ -159,12 +156,11 @@ impl<'a> ContainerBuilder<'a> {
     ///
     /// ```no_run
     /// # use libcontainer::container::builder::ContainerBuilder;
-    /// # use libcontainer::syscall::syscall::create_syscall;
-    /// # use libcontainer::workload::default::DefaultExecutor;
+    /// # use libcontainer::syscall::syscall::SyscallType;
     ///
     /// ContainerBuilder::new(
     ///     "74f1a4cb3801".to_owned(),
-    ///     create_syscall().as_ref(),
+    ///     SyscallType::default(),
     /// )
     /// .with_root_path("/run/containers/youki").expect("invalid root path");
     /// ```
@@ -184,12 +180,11 @@ impl<'a> ContainerBuilder<'a> {
     ///
     /// ```no_run
     /// # use libcontainer::container::builder::ContainerBuilder;
-    /// # use libcontainer::syscall::syscall::create_syscall;
-    /// # use libcontainer::workload::default::DefaultExecutor;
+    /// # use libcontainer::syscall::syscall::SyscallType;
     ///
     /// ContainerBuilder::new(
     ///     "74f1a4cb3801".to_owned(),
-    ///     create_syscall().as_ref(),
+    ///     SyscallType::default(),
     /// )
     /// .with_pid_file(Some("/var/run/docker.pid")).expect("invalid pid file");
     /// ```
@@ -214,12 +209,11 @@ impl<'a> ContainerBuilder<'a> {
     ///
     /// ```no_run
     /// # use libcontainer::container::builder::ContainerBuilder;
-    /// # use libcontainer::syscall::syscall::create_syscall;
-    /// # use libcontainer::workload::default::DefaultExecutor;
+    /// # use libcontainer::syscall::syscall::SyscallType;
     ///
     /// ContainerBuilder::new(
     ///     "74f1a4cb3801".to_owned(),
-    ///     create_syscall().as_ref(),
+    ///     SyscallType::default(),
     /// )
     /// .with_console_socket(Some("/var/run/docker/sock.tty"));
     /// ```
@@ -234,12 +228,11 @@ impl<'a> ContainerBuilder<'a> {
     ///
     /// ```no_run
     /// # use libcontainer::container::builder::ContainerBuilder;
-    /// # use libcontainer::syscall::syscall::create_syscall;
-    /// # use libcontainer::workload::default::DefaultExecutor;
+    /// # use libcontainer::syscall::syscall::SyscallType;
     ///
     /// ContainerBuilder::new(
     ///     "74f1a4cb3801".to_owned(),
-    ///     create_syscall().as_ref(),
+    ///     SyscallType::default(),
     /// )
     /// .with_preserved_fds(5);
     /// ```
@@ -253,12 +246,12 @@ impl<'a> ContainerBuilder<'a> {
     ///
     /// ```no_run
     /// # use libcontainer::container::builder::ContainerBuilder;
-    /// # use libcontainer::syscall::syscall::create_syscall;
+    /// # use libcontainer::syscall::syscall::SyscallType;
     /// # use libcontainer::workload::default::DefaultExecutor;
     ///
     /// ContainerBuilder::new(
     ///     "74f1a4cb3801".to_owned(),
-    ///     create_syscall().as_ref(),
+    ///     SyscallType::default(),
     /// )
     /// .with_executor(vec![Box::<DefaultExecutor>::default()]);
     /// ```
@@ -276,8 +269,7 @@ impl<'a> ContainerBuilder<'a> {
 
 #[cfg(test)]
 mod tests {
-    use crate::container::builder::ContainerBuilder;
-    use crate::syscall::syscall::create_syscall;
+    use crate::{container::builder::ContainerBuilder, syscall::syscall::SyscallType};
     use anyhow::{Context, Result};
     use std::path::PathBuf;
 
@@ -285,42 +277,41 @@ mod tests {
     fn test_failable_functions() -> Result<()> {
         let root_path_temp_dir = tempfile::tempdir().context("failed to create temp dir")?;
         let pid_file_temp_dir = tempfile::tempdir().context("failed to create temp dir")?;
-        let syscall = create_syscall();
+        let syscall = SyscallType::default();
 
-        ContainerBuilder::new("74f1a4cb3801".to_owned(), syscall.as_ref())
+        ContainerBuilder::new("74f1a4cb3801".to_owned(), syscall)
             .with_root_path(root_path_temp_dir.path())?
             .with_pid_file(Some(pid_file_temp_dir.path().join("fake.pid")))?
             .with_console_socket(Some("/var/run/docker/sock.tty"))
             .as_init("/var/run/docker/bundle");
 
         // accept None pid file.
-        ContainerBuilder::new("74f1a4cb3801".to_owned(), syscall.as_ref())
-            .with_pid_file::<PathBuf>(None)?;
+        ContainerBuilder::new("74f1a4cb3801".to_owned(), syscall).with_pid_file::<PathBuf>(None)?;
 
         // accept absolute root path which does not exist
         let abs_root_path = PathBuf::from("/not/existing/path");
-        let path_builder = ContainerBuilder::new("74f1a4cb3801".to_owned(), syscall.as_ref())
+        let path_builder = ContainerBuilder::new("74f1a4cb3801".to_owned(), syscall)
             .with_root_path(&abs_root_path)
             .context("build container")?;
         assert_eq!(path_builder.root_path, abs_root_path);
 
         // accept relative root path which does not exist
         let cwd = std::env::current_dir().context("get current dir")?;
-        let path_builder = ContainerBuilder::new("74f1a4cb3801".to_owned(), syscall.as_ref())
+        let path_builder = ContainerBuilder::new("74f1a4cb3801".to_owned(), syscall)
             .with_root_path("./not/existing/path")
             .context("build container")?;
         assert_eq!(path_builder.root_path, cwd.join("not/existing/path"));
 
         // accept absolute pid path which does not exist
         let abs_pid_path = PathBuf::from("/not/existing/path");
-        let path_builder = ContainerBuilder::new("74f1a4cb3801".to_owned(), syscall.as_ref())
+        let path_builder = ContainerBuilder::new("74f1a4cb3801".to_owned(), syscall)
             .with_pid_file(Some(&abs_pid_path))
             .context("build container")?;
         assert_eq!(path_builder.pid_file, Some(abs_pid_path));
 
         // accept relative pid path which does not exist
         let cwd = std::env::current_dir().context("get current dir")?;
-        let path_builder = ContainerBuilder::new("74f1a4cb3801".to_owned(), syscall.as_ref())
+        let path_builder = ContainerBuilder::new("74f1a4cb3801".to_owned(), syscall)
             .with_pid_file(Some("./not/existing/path"))
             .context("build container")?;
         assert_eq!(path_builder.pid_file, Some(cwd.join("not/existing/path")));
@@ -330,22 +321,21 @@ mod tests {
 
     #[test]
     fn test_validate_id() -> Result<()> {
-        let syscall = create_syscall();
+        let syscall = SyscallType::default();
         // validate container_id
-        let result = ContainerBuilder::new("$#".to_owned(), syscall.as_ref()).validate_id();
+        let result = ContainerBuilder::new("$#".to_owned(), syscall).validate_id();
         assert!(result.is_err());
 
-        let result = ContainerBuilder::new(".".to_owned(), syscall.as_ref()).validate_id();
+        let result = ContainerBuilder::new(".".to_owned(), syscall).validate_id();
         assert!(result.is_err());
 
-        let result = ContainerBuilder::new("..".to_owned(), syscall.as_ref()).validate_id();
+        let result = ContainerBuilder::new("..".to_owned(), syscall).validate_id();
         assert!(result.is_err());
 
-        let result = ContainerBuilder::new("...".to_owned(), syscall.as_ref()).validate_id();
+        let result = ContainerBuilder::new("...".to_owned(), syscall).validate_id();
         assert!(result.is_ok());
 
-        let result =
-            ContainerBuilder::new("74f1a4cb3801".to_owned(), syscall.as_ref()).validate_id();
+        let result = ContainerBuilder::new("74f1a4cb3801".to_owned(), syscall).validate_id();
         assert!(result.is_ok());
         Ok(())
     }

--- a/crates/libcontainer/src/container/builder_impl.rs
+++ b/crates/libcontainer/src/container/builder_impl.rs
@@ -9,7 +9,7 @@ use crate::{
         intel_rdt::delete_resctrl_subdirectory,
     },
     rootless::Rootless,
-    syscall::Syscall,
+    syscall::syscall::SyscallType,
     utils,
     workload::ExecutorManager,
 };
@@ -22,7 +22,7 @@ pub(super) struct ContainerBuilderImpl<'a> {
     /// Flag indicating if an init or a tenant container should be created
     pub container_type: ContainerType,
     /// Interface to operating system primitives
-    pub syscall: &'a dyn Syscall,
+    pub syscall: SyscallType,
     /// Flag indicating if systemd should be used for cgroup management
     pub use_systemd: bool,
     /// Id of the container

--- a/crates/libcontainer/src/container/container_delete.rs
+++ b/crates/libcontainer/src/container/container_delete.rs
@@ -13,13 +13,12 @@ impl Container {
     ///
     /// ```no_run
     /// use libcontainer::container::builder::ContainerBuilder;
-    /// use libcontainer::syscall::syscall::create_syscall;
-    /// use libcontainer::workload::default::DefaultExecutor;
+    /// use libcontainer::syscall::syscall::SyscallType;
     ///
     /// # fn main() -> anyhow::Result<()> {
     /// let mut container = ContainerBuilder::new(
     ///     "74f1a4cb3801".to_owned(),
-    ///     create_syscall().as_ref(),
+    ///     SyscallType::default(),
     /// )
     /// .as_init("/var/run/docker/bundle")
     /// .build()?;

--- a/crates/libcontainer/src/container/container_events.rs
+++ b/crates/libcontainer/src/container/container_events.rs
@@ -12,13 +12,12 @@ impl Container {
     ///
     /// ```no_run
     /// use libcontainer::container::builder::ContainerBuilder;
-    /// use libcontainer::syscall::syscall::create_syscall;
-    /// use libcontainer::workload::default::DefaultExecutor;
+    /// use libcontainer::syscall::syscall::SyscallType;
     ///
     /// # fn main() -> anyhow::Result<()> {
     /// let mut container = ContainerBuilder::new(
     ///     "74f1a4cb3801".to_owned(),
-    ///     create_syscall().as_ref(),
+    ///     SyscallType::default(),
     /// )
     /// .as_init("/var/run/docker/bundle")
     /// .build()?;

--- a/crates/libcontainer/src/container/container_kill.rs
+++ b/crates/libcontainer/src/container/container_kill.rs
@@ -10,14 +10,13 @@ impl Container {
     ///
     /// ```no_run
     /// use libcontainer::container::builder::ContainerBuilder;
-    /// use libcontainer::syscall::syscall::create_syscall;
-    /// use libcontainer::workload::default::DefaultExecutor;
+    /// use libcontainer::syscall::syscall::SyscallType;
     /// use nix::sys::signal::Signal;
     ///
     /// # fn main() -> anyhow::Result<()> {
     /// let mut container = ContainerBuilder::new(
     ///     "74f1a4cb3801".to_owned(),
-    ///     create_syscall().as_ref(),
+    ///     SyscallType::default(),
     /// )
     /// .as_init("/var/run/docker/bundle")
     /// .build()?;

--- a/crates/libcontainer/src/container/container_pause.rs
+++ b/crates/libcontainer/src/container/container_pause.rs
@@ -10,13 +10,12 @@ impl Container {
     ///
     /// ```no_run
     /// use libcontainer::container::builder::ContainerBuilder;
-    /// use libcontainer::syscall::syscall::create_syscall;
-    /// use libcontainer::workload::default::DefaultExecutor;
+    /// use libcontainer::syscall::syscall::SyscallType;
     ///
     /// # fn main() -> anyhow::Result<()> {
     /// let mut container = ContainerBuilder::new(
     ///     "74f1a4cb3801".to_owned(),
-    ///     create_syscall().as_ref(),
+    ///     SyscallType::default(),
     /// )
     /// .as_init("/var/run/docker/bundle")
     /// .build()?;

--- a/crates/libcontainer/src/container/container_resume.rs
+++ b/crates/libcontainer/src/container/container_resume.rs
@@ -11,13 +11,12 @@ impl Container {
     ///
     /// ```no_run
     /// use libcontainer::container::builder::ContainerBuilder;
-    /// use libcontainer::syscall::syscall::create_syscall;
-    /// use libcontainer::workload::default::DefaultExecutor;
+    /// use libcontainer::syscall::syscall::SyscallType;
     ///
     /// # fn main() -> anyhow::Result<()> {
     /// let mut container = ContainerBuilder::new(
     ///     "74f1a4cb3801".to_owned(),
-    ///     create_syscall().as_ref(),
+    ///     SyscallType::default(),
     /// )
     /// .as_init("/var/run/docker/bundle")
     /// .build()?;

--- a/crates/libcontainer/src/container/container_start.rs
+++ b/crates/libcontainer/src/container/container_start.rs
@@ -15,13 +15,12 @@ impl Container {
     ///
     /// ```no_run
     /// use libcontainer::container::builder::ContainerBuilder;
-    /// use libcontainer::syscall::syscall::create_syscall;
-    /// use libcontainer::workload::default::DefaultExecutor;
+    /// use libcontainer::syscall::syscall::SyscallType;
     ///
     /// # fn main() -> anyhow::Result<()> {
     /// let mut container = ContainerBuilder::new(
     ///     "74f1a4cb3801".to_owned(),
-    ///     create_syscall().as_ref(),
+    ///     SyscallType::default(),
     /// )
     /// .as_init("/var/run/docker/bundle")
     /// .build()?;

--- a/crates/libcontainer/src/container/init_builder.rs
+++ b/crates/libcontainer/src/container/init_builder.rs
@@ -20,17 +20,17 @@ use super::{
 };
 
 // Builder that can be used to configure the properties of a new container
-pub struct InitContainerBuilder<'a> {
-    base: ContainerBuilder<'a>,
+pub struct InitContainerBuilder {
+    base: ContainerBuilder,
     bundle: PathBuf,
     use_systemd: bool,
     detached: bool,
 }
 
-impl<'a> InitContainerBuilder<'a> {
+impl InitContainerBuilder {
     /// Generates the base configuration for a new container from which
     /// configuration methods can be chained
-    pub(super) fn new(builder: ContainerBuilder<'a>, bundle: PathBuf) -> Self {
+    pub(super) fn new(builder: ContainerBuilder, bundle: PathBuf) -> Self {
         Self {
             base: builder,
             bundle,

--- a/crates/libcontainer/src/container/tenant_builder.rs
+++ b/crates/libcontainer/src/container/tenant_builder.rs
@@ -32,8 +32,8 @@ const TENANT_TTY: &str = "tenant-tty-";
 
 /// Builder that can be used to configure the properties of a process
 /// that will join an existing container sandbox
-pub struct TenantContainerBuilder<'a> {
-    base: ContainerBuilder<'a>,
+pub struct TenantContainerBuilder {
+    base: ContainerBuilder,
     env: HashMap<String, String>,
     cwd: Option<PathBuf>,
     args: Vec<String>,
@@ -43,11 +43,11 @@ pub struct TenantContainerBuilder<'a> {
     detached: bool,
 }
 
-impl<'a> TenantContainerBuilder<'a> {
+impl TenantContainerBuilder {
     /// Generates the base configuration for a process that will join
     /// an existing container sandbox from which configuration methods
     /// can be chained
-    pub(super) fn new(builder: ContainerBuilder<'a>) -> Self {
+    pub(super) fn new(builder: ContainerBuilder) -> Self {
         Self {
             base: builder,
             env: HashMap::new(),

--- a/crates/libcontainer/src/process/args.rs
+++ b/crates/libcontainer/src/process/args.rs
@@ -4,8 +4,9 @@ use std::os::unix::prelude::RawFd;
 use std::path::PathBuf;
 
 use crate::rootless::Rootless;
+use crate::syscall::syscall::SyscallType;
 use crate::workload::ExecutorManager;
-use crate::{container::Container, notify_socket::NotifyListener, syscall::Syscall};
+use crate::{container::Container, notify_socket::NotifyListener};
 
 #[derive(Debug, Copy, Clone)]
 pub enum ContainerType {
@@ -17,7 +18,7 @@ pub struct ContainerArgs<'a> {
     /// Indicates if an init or a tenant container should be created
     pub container_type: ContainerType,
     /// Interface to operating system primitives
-    pub syscall: &'a dyn Syscall,
+    pub syscall: SyscallType,
     /// OCI compliant runtime spec
     pub spec: &'a Spec,
     /// Root filesystem of the container

--- a/crates/libcontainer/src/process/container_init_process.rs
+++ b/crates/libcontainer/src/process/container_init_process.rs
@@ -332,7 +332,7 @@ pub fn container_init_process(
     main_sender: &mut channel::MainSender,
     init_receiver: &mut channel::InitReceiver,
 ) -> Result<()> {
-    let syscall = args.syscall;
+    let syscall = args.syscall.create_syscall();
     let spec = args.spec;
     let linux = spec.linux().as_ref().ok_or(MissingSpecError::Linux)?;
     let proc = spec.process().as_ref().ok_or(MissingSpecError::Process)?;
@@ -354,7 +354,7 @@ pub fn container_init_process(
         })?;
     }
 
-    apply_rest_namespaces(&namespaces, spec, syscall)?;
+    apply_rest_namespaces(&namespaces, spec, syscall.as_ref())?;
 
     if let Some(true) = proc.no_new_privileges() {
         let _ = prctl::set_no_new_privileges(true);
@@ -452,7 +452,7 @@ pub fn container_init_process(
     if let Some(paths) = linux.readonly_paths() {
         // mount readonly path
         for path in paths {
-            readonly_path(Path::new(path), syscall).map_err(|err| {
+            readonly_path(Path::new(path), syscall.as_ref()).map_err(|err| {
                 tracing::error!(?err, ?path, "failed to set readonly path");
                 err
             })?;
@@ -462,7 +462,7 @@ pub fn container_init_process(
     if let Some(paths) = linux.masked_paths() {
         // mount masked path
         for path in paths {
-            masked_path(Path::new(path), linux.mount_label(), syscall).map_err(|err| {
+            masked_path(Path::new(path), linux.mount_label(), syscall.as_ref()).map_err(|err| {
                 tracing::error!(?err, ?path, "failed to set masked path");
                 err
             })?;
@@ -486,7 +486,7 @@ pub fn container_init_process(
         }
     };
 
-    set_supplementary_gids(proc.user(), args.rootless, syscall).map_err(|err| {
+    set_supplementary_gids(proc.user(), args.rootless, syscall.as_ref()).map_err(|err| {
         tracing::error!(?err, "failed to set supplementary gids");
         err
     })?;
@@ -576,12 +576,12 @@ pub fn container_init_process(
         tracing::warn!("seccomp not available, unable to enforce no_new_privileges!")
     }
 
-    capabilities::reset_effective(syscall).map_err(|err| {
+    capabilities::reset_effective(syscall.as_ref()).map_err(|err| {
         tracing::error!(?err, "failed to reset effective capabilities");
         InitProcessError::SyscallOther(err)
     })?;
     if let Some(caps) = proc.capabilities() {
-        capabilities::drop_privileges(caps, syscall).map_err(|err| {
+        capabilities::drop_privileges(caps, syscall.as_ref()).map_err(|err| {
             tracing::error!(?err, "failed to drop capabilities");
             InitProcessError::SyscallOther(err)
         })?;

--- a/crates/libcontainer/src/process/container_intermediate_process.rs
+++ b/crates/libcontainer/src/process/container_intermediate_process.rs
@@ -39,7 +39,7 @@ pub fn container_intermediate_process(
 ) -> Result<Pid> {
     let (inter_sender, inter_receiver) = intermediate_chan;
     let (init_sender, init_receiver) = init_chan;
-    let command = &args.syscall;
+    let command = args.syscall.create_syscall();
     let spec = &args.spec;
     let linux = spec.linux().as_ref().ok_or(MissingSpecError::Linux)?;
     let namespaces = Namespaces::try_from(linux.namespaces().as_ref())?;

--- a/crates/libcontainer/src/syscall/syscall.rs
+++ b/crates/libcontainer/src/syscall/syscall.rs
@@ -56,10 +56,31 @@ pub trait Syscall {
     ) -> Result<()>;
 }
 
-pub fn create_syscall() -> Box<dyn Syscall> {
-    if cfg!(test) {
-        Box::<TestHelperSyscall>::default()
-    } else {
-        Box::new(LinuxSyscall)
+#[derive(Clone, Copy)]
+pub enum SyscallType {
+    Linux,
+    Test,
+}
+
+impl Default for SyscallType {
+    fn default() -> Self {
+        if cfg!(test) {
+            SyscallType::Test
+        } else {
+            SyscallType::Linux
+        }
     }
+}
+
+impl SyscallType {
+    pub fn create_syscall(&self) -> Box<dyn Syscall> {
+        match self {
+            SyscallType::Linux => Box::new(LinuxSyscall),
+            SyscallType::Test => Box::<TestHelperSyscall>::default(),
+        }
+    }
+}
+
+pub fn create_syscall() -> Box<dyn Syscall> {
+    SyscallType::default().create_syscall()
 }

--- a/crates/youki/src/commands/create.rs
+++ b/crates/youki/src/commands/create.rs
@@ -2,7 +2,7 @@
 use anyhow::Result;
 use std::path::PathBuf;
 
-use libcontainer::{container::builder::ContainerBuilder, syscall::syscall::create_syscall};
+use libcontainer::{container::builder::ContainerBuilder, syscall::syscall::SyscallType};
 use liboci_cli::Create;
 
 use crate::workload::executor::default_executors;
@@ -13,8 +13,7 @@ use crate::workload::executor::default_executors;
 // it is running, it is just another process, and has attributes such as pid, file descriptors, etc.
 // associated with it like any other process.
 pub fn create(args: Create, root_path: PathBuf, systemd_cgroup: bool) -> Result<()> {
-    let syscall = create_syscall();
-    ContainerBuilder::new(args.container_id.clone(), syscall.as_ref())
+    ContainerBuilder::new(args.container_id.clone(), SyscallType::default())
         .with_executor(default_executors())?
         .with_pid_file(args.pid_file.as_ref())?
         .with_console_socket(args.console_socket.as_ref())

--- a/crates/youki/src/commands/exec.rs
+++ b/crates/youki/src/commands/exec.rs
@@ -2,14 +2,13 @@ use anyhow::Result;
 use nix::sys::wait::{waitpid, WaitStatus};
 use std::path::PathBuf;
 
-use libcontainer::{container::builder::ContainerBuilder, syscall::syscall::create_syscall};
+use libcontainer::{container::builder::ContainerBuilder, syscall::syscall::SyscallType};
 use liboci_cli::Exec;
 
 use crate::workload::executor::default_executors;
 
 pub fn exec(args: Exec, root_path: PathBuf) -> Result<i32> {
-    let syscall = create_syscall();
-    let pid = ContainerBuilder::new(args.container_id.clone(), syscall.as_ref())
+    let pid = ContainerBuilder::new(args.container_id.clone(), SyscallType::default())
         .with_executor(default_executors())?
         .with_root_path(root_path)?
         .with_console_socket(args.console_socket.as_ref())

--- a/crates/youki/src/commands/run.rs
+++ b/crates/youki/src/commands/run.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
 use anyhow::{Context, Result};
-use libcontainer::{container::builder::ContainerBuilder, syscall::syscall::create_syscall};
+use libcontainer::{container::builder::ContainerBuilder, syscall::syscall::SyscallType};
 use liboci_cli::Run;
 use nix::{
     sys::{
@@ -15,8 +15,7 @@ use nix::{
 use crate::workload::executor::default_executors;
 
 pub fn run(args: Run, root_path: PathBuf, systemd_cgroup: bool) -> Result<i32> {
-    let syscall = create_syscall();
-    let mut container = ContainerBuilder::new(args.container_id.clone(), syscall.as_ref())
+    let mut container = ContainerBuilder::new(args.container_id.clone(), SyscallType::default())
         .with_executor(default_executors())?
         .with_pid_file(args.pid_file.as_ref())?
         .with_console_socket(args.console_socket.as_ref())


### PR DESCRIPTION
Pulling out changes from #2121 

Included #2150 to disable musl test. Will rebase once #2150 is merged.

Details:

In this PR we propose to store a SyscallType instead of syscall structure. The syscall structure itself is am empty struct, so we can delay the creation. In this way, we don't have to pass this reference through the fork/clone boundary. The eventual goal is not to use lifetime reference in the `container_args` structure.
