### PR TITLE
Refactor the libcgroups interface

### DIFF
--- a/crates/libcgroups/src/systemd/manager.rs
+++ b/crates/libcgroups/src/systemd/manager.rs
@@ -180,7 +180,7 @@ impl Manager {
         container_name: String,
         use_system: bool,
     ) -> Result<Self, SystemdManagerError> {
-        let mut destructured_path = cgroups_path.as_path().try_into()?;
+        let mut destructured_path: CgroupsPath = cgroups_path.as_path().try_into()?;
         ensure_parent_unit(&mut destructured_path, use_system);
 
         let client = match use_system {

--- a/crates/libcgroups/src/v1/manager.rs
+++ b/crates/libcgroups/src/v1/manager.rs
@@ -82,10 +82,10 @@ pub enum V1ManagerError {
 
 impl Manager {
     /// Constructs a new cgroup manager with cgroups_path being relative to the root of the subsystem
-    pub fn new(cgroup_path: PathBuf) -> Result<Self, V1ManagerError> {
+    pub fn new(cgroup_path: &Path) -> Result<Self, V1ManagerError> {
         let mut subsystems = HashMap::<CtrlType, PathBuf>::new();
         for subsystem in CONTROLLERS {
-            if let Ok(subsystem_path) = Self::get_subsystem_path(&cgroup_path, subsystem) {
+            if let Ok(subsystem_path) = Self::get_subsystem_path(cgroup_path, subsystem) {
                 subsystems.insert(*subsystem, subsystem_path);
             } else {
                 tracing::warn!("cgroup {} not supported on this system", subsystem);

--- a/crates/libcontainer/src/container/builder_impl.rs
+++ b/crates/libcontainer/src/container/builder_impl.rs
@@ -73,11 +73,11 @@ impl<'a> ContainerBuilderImpl<'a> {
             &self.container_id,
             self.rootless.is_some(),
         );
-        let cmanager = libcgroups::common::create_cgroup_manager(
-            cgroups_path,
-            self.use_systemd || self.rootless.is_some(),
-            &self.container_id,
-        )?;
+        let cgroup_config = libcgroups::common::CgroupConfig {
+            cgroup_path: cgroups_path,
+            systemd_cgroup: self.use_systemd || self.rootless.is_some(),
+            container_name: self.container_id.to_owned(),
+        };
         let process = self
             .spec
             .process()
@@ -141,11 +141,11 @@ impl<'a> ContainerBuilderImpl<'a> {
             spec: self.spec,
             rootfs: &self.rootfs,
             console_socket: self.console_socket,
-            notify_socket,
+            notify_listener,
             preserve_fds: self.preserve_fds,
             container: &self.container,
             rootless: &self.rootless,
-            cgroup_manager: cmanager,
+            cgroup_config,
             detached: self.detached,
             executor_manager: &self.executor_manager,
         };
@@ -186,11 +186,12 @@ impl<'a> ContainerBuilderImpl<'a> {
             &self.container_id,
             self.rootless.is_some(),
         );
-        let cmanager = libcgroups::common::create_cgroup_manager(
-            cgroups_path,
-            self.use_systemd || self.rootless.is_some(),
-            &self.container_id,
-        )?;
+        let cmanager =
+            libcgroups::common::create_cgroup_manager(libcgroups::common::CgroupConfig {
+                cgroup_path: cgroups_path,
+                systemd_cgroup: self.use_systemd || self.rootless.is_some(),
+                container_name: self.container_id.to_string(),
+            })?;
 
         let mut errors = Vec::new();
 

--- a/crates/libcontainer/src/container/builder_impl.rs
+++ b/crates/libcontainer/src/container/builder_impl.rs
@@ -93,8 +93,10 @@ impl<'a> ContainerBuilderImpl<'a> {
         // Need to create the notify socket before we pivot root, since the unix
         // domain socket used here is outside of the rootfs of container. During
         // exec, need to create the socket before we enter into existing mount
-        // namespace.
-        let notify_socket: NotifyListener = NotifyListener::new(&self.notify_path)?;
+        // namespace. We also need to create to socket before entering into the
+        // user namespace in the case that the path is located in paths only
+        // root can access.
+        let notify_listener = NotifyListener::new(&self.notify_path)?;
 
         // If Out-of-memory score adjustment is set in specification.  set the score
         // value for the current process check

--- a/crates/libcontainer/src/container/container_delete.rs
+++ b/crates/libcontainer/src/container/container_delete.rs
@@ -81,11 +81,12 @@ impl Container {
                     // remove the cgroup created for the container
                     // check https://man7.org/linux/man-pages/man7/cgroups.7.html
                     // creating and removing cgroups section for more information on cgroups
-                    let use_systemd = self.systemd();
                     let cmanager = libcgroups::common::create_cgroup_manager(
-                        &config.cgroup_path,
-                        use_systemd,
-                        self.id(),
+                        libcgroups::common::CgroupConfig {
+                            cgroup_path: config.cgroup_path.to_owned(),
+                            systemd_cgroup: self.systemd(),
+                            container_name: self.id().to_string(),
+                        },
                     )?;
                     cmanager.remove().map_err(|err| {
                         tracing::error!(cgroup_path = ?config.cgroup_path, "failed to remove cgroup due to: {err:?}");

--- a/crates/libcontainer/src/container/container_events.rs
+++ b/crates/libcontainer/src/container/container_events.rs
@@ -33,11 +33,12 @@ impl Container {
             return Err(LibcontainerError::IncorrectStatus);
         }
 
-        let cgroups_path = self.spec()?.cgroup_path;
-        let use_systemd = self.systemd();
-
         let cgroup_manager =
-            libcgroups::common::create_cgroup_manager(cgroups_path, use_systemd, self.id())?;
+            libcgroups::common::create_cgroup_manager(libcgroups::common::CgroupConfig {
+                cgroup_path: self.spec()?.cgroup_path,
+                systemd_cgroup: self.systemd(),
+                container_name: self.id().to_string(),
+            })?;
         match stats {
             true => {
                 let stats = cgroup_manager.stats()?;

--- a/crates/libcontainer/src/container/container_pause.rs
+++ b/crates/libcontainer/src/container/container_pause.rs
@@ -32,10 +32,12 @@ impl Container {
             return Err(LibcontainerError::IncorrectStatus);
         }
 
-        let cgroups_path = self.spec()?.cgroup_path;
-        let use_systemd = self.systemd();
         let cmanager =
-            libcgroups::common::create_cgroup_manager(cgroups_path, use_systemd, self.id())?;
+            libcgroups::common::create_cgroup_manager(libcgroups::common::CgroupConfig {
+                cgroup_path: self.spec()?.cgroup_path,
+                systemd_cgroup: self.systemd(),
+                container_name: self.id().to_string(),
+            })?;
         cmanager.freeze(FreezerState::Frozen)?;
 
         tracing::debug!("saving paused status");

--- a/crates/libcontainer/src/container/container_resume.rs
+++ b/crates/libcontainer/src/container/container_resume.rs
@@ -34,10 +34,12 @@ impl Container {
             return Err(LibcontainerError::IncorrectStatus);
         }
 
-        let cgroups_path = self.spec()?.cgroup_path;
-        let use_systemd = self.systemd();
         let cmanager =
-            libcgroups::common::create_cgroup_manager(cgroups_path, use_systemd, self.id())?;
+            libcgroups::common::create_cgroup_manager(libcgroups::common::CgroupConfig {
+                cgroup_path: self.spec()?.cgroup_path,
+                systemd_cgroup: self.systemd(),
+                container_name: self.id().to_string(),
+            })?;
         // resume the frozen container
         cmanager.freeze(FreezerState::Thawed)?;
 

--- a/crates/libcontainer/src/notify_socket.rs
+++ b/crates/libcontainer/src/notify_socket.rs
@@ -170,10 +170,7 @@ mod test {
         let socket_path = tempdir.path().join("notify.sock");
         // listener needs to be created first because it will create the socket.
         let listener = NotifyListener::new(&socket_path).unwrap();
-        let mut socket = NotifySocket::new({
-            let socket_path = socket_path.clone();
-            socket_path
-        });
+        let mut socket = NotifySocket::new(socket_path.clone());
         // This is safe without race because the unix domain socket is already
         // created. It is OK for the socket to send the start notification
         // before the listener wait is called.

--- a/crates/libcontainer/src/notify_socket.rs
+++ b/crates/libcontainer/src/notify_socket.rs
@@ -99,12 +99,12 @@ impl NotifyListener {
 impl Clone for NotifyListener {
     fn clone(&self) -> Self {
         let fd = self.socket.as_raw_fd();
-        // This is safe because we just duplicate a valid fd. Theoratically, to
-        // truely clone a unix listener, we have to use dup(2) to duplicate the
+        // This is safe because we just duplicate a valid fd. Theoretically, to
+        // truly clone a unix listener, we have to use dup(2) to duplicate the
         // fd, and then use from_raw_fd to create a new UnixListener. However,
         // for our purposes, fd is just an integer to pass around for the same
         // socket. Our main usage is to pass the notify_listener across process
-        // boundry. Since fd tables are cloned during clone/fork calls, this
+        // boundary. Since fd tables are cloned during clone/fork calls, this
         // should be safe to use, as long as we be careful with not closing the
         // same fd in different places. If we observe an issue, we will switch
         // to `dup`.

--- a/crates/libcontainer/src/process/args.rs
+++ b/crates/libcontainer/src/process/args.rs
@@ -3,10 +3,11 @@ use oci_spec::runtime::Spec;
 use std::os::unix::prelude::RawFd;
 use std::path::PathBuf;
 
+use crate::container::Container;
+use crate::notify_socket::NotifyListener;
 use crate::rootless::Rootless;
 use crate::syscall::syscall::SyscallType;
 use crate::workload::ExecutorManager;
-use crate::{container::Container, notify_socket::NotifyListener};
 
 #[derive(Debug, Copy, Clone)]
 pub enum ContainerType {
@@ -26,7 +27,7 @@ pub struct ContainerArgs<'a> {
     /// Socket to communicate the file descriptor of the ptty
     pub console_socket: Option<RawFd>,
     /// The Unix Domain Socket to communicate container start
-    pub notify_socket: NotifyListener,
+    pub notify_listener: NotifyListener,
     /// File descriptors preserved/passed to the container init process.
     pub preserve_fds: i32,
     /// Container state

--- a/crates/libcontainer/src/process/args.rs
+++ b/crates/libcontainer/src/process/args.rs
@@ -1,4 +1,4 @@
-use libcgroups::common::AnyCgroupManager;
+use libcgroups::common::CgroupConfig;
 use oci_spec::runtime::Spec;
 use std::os::unix::prelude::RawFd;
 use std::path::PathBuf;
@@ -34,8 +34,8 @@ pub struct ContainerArgs<'a> {
     pub container: &'a Option<Container>,
     /// Options for rootless containers
     pub rootless: &'a Option<Rootless<'a>>,
-    /// Cgroup Manager
-    pub cgroup_manager: AnyCgroupManager,
+    /// Cgroup Manager Config
+    pub cgroup_config: CgroupConfig,
     /// If the container is to be run in detached mode
     pub detached: bool,
     /// Manage the functions that actually run on the container

--- a/crates/libcontainer/src/process/container_init_process.rs
+++ b/crates/libcontainer/src/process/container_init_process.rs
@@ -341,6 +341,7 @@ pub fn container_init_process(
     let hooks = spec.hooks().as_ref();
     let container = args.container.as_ref();
     let namespaces = Namespaces::try_from(linux.namespaces().as_ref())?;
+    let notify_listener = &args.notify_listener;
 
     setsid().map_err(|err| {
         tracing::error!(?err, "failed to setsid to create a session");
@@ -652,13 +653,11 @@ pub fn container_init_process(
     })?;
 
     // listing on the notify socket for container start command
-    args.notify_socket
-        .wait_for_container_start()
-        .map_err(|err| {
-            tracing::error!(?err, "failed to wait for container start");
-            err
-        })?;
-    args.notify_socket.close().map_err(|err| {
+    notify_listener.wait_for_container_start().map_err(|err| {
+        tracing::error!(?err, "failed to wait for container start");
+        err
+    })?;
+    notify_listener.close().map_err(|err| {
         tracing::error!(?err, "failed to close notify socket");
         err
     })?;

--- a/crates/libcontainer/src/process/container_intermediate_process.rs
+++ b/crates/libcontainer/src/process/container_intermediate_process.rs
@@ -43,6 +43,8 @@ pub fn container_intermediate_process(
     let spec = &args.spec;
     let linux = spec.linux().as_ref().ok_or(MissingSpecError::Linux)?;
     let namespaces = Namespaces::try_from(linux.namespaces().as_ref())?;
+    let cgroup_manager =
+        libcgroups::common::create_cgroup_manager(args.cgroup_config.to_owned()).unwrap();
 
     // this needs to be done before we create the init process, so that the init
     // process will already be captured by the cgroup. It also needs to be done
@@ -55,7 +57,7 @@ pub fn container_intermediate_process(
     // the cgroup of the process will form the root of the cgroup hierarchy in
     // the cgroup namespace.
     apply_cgroups(
-        &args.cgroup_manager,
+        &cgroup_manager,
         linux.resources().as_ref(),
         matches!(args.container_type, ContainerType::InitContainer),
     )?;

--- a/crates/youki/src/commands/mod.rs
+++ b/crates/youki/src/commands/mod.rs
@@ -59,12 +59,11 @@ fn create_cgroup_manager<P: AsRef<Path>>(
     container_id: &str,
 ) -> Result<AnyCgroupManager> {
     let container = load_container(root_path, container_id)?;
-    let cgroups_path = container.spec()?.cgroup_path;
-    let systemd_cgroup = container.systemd();
-
     Ok(libcgroups::common::create_cgroup_manager(
-        cgroups_path,
-        systemd_cgroup,
-        container.id(),
+        libcgroups::common::CgroupConfig {
+            cgroup_path: container.spec()?.cgroup_path,
+            systemd_cgroup: container.systemd(),
+            container_name: container.id().to_string(),
+        },
     )?)
 }


### PR DESCRIPTION
- Refactored the cgroup creation into a struct instead of individual parameters. This reduce the amount of container_args field we have to carry across the process boundry.
- Refactored the use of &Path vs. PathBuf in the interface.
- Tag along since it is too small. Minor updates to the notify listener comments and variable name. Also makes it clone-able.

I have 3 more PR.