### PR TITLE
refactored executor and executor manager

### DIFF
--- a/crates/libcontainer/src/container/builder.rs
+++ b/crates/libcontainer/src/container/builder.rs
@@ -1,8 +1,7 @@
 use crate::error::{ErrInvalidID, LibcontainerError};
 use crate::syscall::syscall::SyscallType;
 use crate::utils::PathBufExt;
-use crate::workload::default::DefaultExecutor;
-use crate::workload::{Executor, ExecutorManager};
+use crate::workload::{self, Executor};
 use std::path::PathBuf;
 
 use super::{init_builder::InitContainerBuilder, tenant_builder::TenantContainerBuilder};
@@ -23,7 +22,7 @@ pub struct ContainerBuilder {
     pub(super) preserve_fds: i32,
     /// Manage the functions that actually run on the container
     /// Default executes the specified execution of a generic command
-    pub(super) executor_manager: ExecutorManager,
+    pub(super) executor: Executor,
 }
 
 /// Builder that can be used to configure the common properties of
@@ -69,9 +68,7 @@ impl ContainerBuilder {
             pid_file: None,
             console_socket: None,
             preserve_fds: 0,
-            executor_manager: ExecutorManager {
-                executors: vec![Box::<DefaultExecutor>::default()],
-            },
+            executor: workload::default::get_executor(),
         }
     }
 
@@ -247,23 +244,17 @@ impl ContainerBuilder {
     /// ```no_run
     /// # use libcontainer::container::builder::ContainerBuilder;
     /// # use libcontainer::syscall::syscall::SyscallType;
-    /// # use libcontainer::workload::default::DefaultExecutor;
+    /// # use libcontainer::workload::default::get_executor;
     ///
     /// ContainerBuilder::new(
     ///     "74f1a4cb3801".to_owned(),
     ///     SyscallType::default(),
     /// )
-    /// .with_executor(vec![Box::<DefaultExecutor>::default()]);
+    /// .with_executor(get_executor());
     /// ```
-    pub fn with_executor(
-        mut self,
-        executors: Vec<Box<dyn Executor>>,
-    ) -> Result<Self, LibcontainerError> {
-        if executors.is_empty() {
-            return Err(LibcontainerError::NoExecutors);
-        };
-        self.executor_manager = ExecutorManager { executors };
-        Ok(self)
+    pub fn with_executor(mut self, executor: Executor) -> Self {
+        self.executor = executor;
+        self
     }
 }
 

--- a/crates/libcontainer/src/container/builder.rs
+++ b/crates/libcontainer/src/container/builder.rs
@@ -20,8 +20,8 @@ pub struct ContainerBuilder {
     pub(super) console_socket: Option<PathBuf>,
     /// File descriptors to be passed into the container process
     pub(super) preserve_fds: i32,
-    /// Manage the functions that actually run on the container
-    /// Default executes the specified execution of a generic command
+    /// The function that actually runs on the container init process. Default
+    /// is to execute the specified command in the oci spec.
     pub(super) executor: Executor,
 }
 

--- a/crates/libcontainer/src/container/builder_impl.rs
+++ b/crates/libcontainer/src/container/builder_impl.rs
@@ -11,7 +11,7 @@ use crate::{
     rootless::Rootless,
     syscall::syscall::SyscallType,
     utils,
-    workload::ExecutorManager,
+    workload::Executor,
 };
 use libcgroups::common::CgroupManager;
 use nix::unistd::Pid;
@@ -47,7 +47,7 @@ pub(super) struct ContainerBuilderImpl<'a> {
     /// If the container is to be run in detached mode
     pub detached: bool,
     /// Default executes the specified execution of a generic command
-    pub executor_manager: ExecutorManager,
+    pub executor: Executor,
 }
 
 impl<'a> ContainerBuilderImpl<'a> {
@@ -147,7 +147,7 @@ impl<'a> ContainerBuilderImpl<'a> {
             rootless: &self.rootless,
             cgroup_config,
             detached: self.detached,
-            executor_manager: &self.executor_manager,
+            executor: self.executor.clone(),
         };
 
         let (init_pid, need_to_clean_up_intel_rdt_dir) =

--- a/crates/libcontainer/src/container/init_builder.rs
+++ b/crates/libcontainer/src/container/init_builder.rs
@@ -106,7 +106,7 @@ impl InitContainerBuilder {
             container: Some(container.clone()),
             preserve_fds: self.base.preserve_fds,
             detached: self.detached,
-            executor_manager: self.base.executor_manager,
+            executor: self.base.executor,
         };
 
         builder_impl.create()?;

--- a/crates/libcontainer/src/container/tenant_builder.rs
+++ b/crates/libcontainer/src/container/tenant_builder.rs
@@ -139,7 +139,7 @@ impl TenantContainerBuilder {
             container: None,
             preserve_fds: self.base.preserve_fds,
             detached: self.detached,
-            executor_manager: self.base.executor_manager,
+            executor: self.base.executor,
         };
 
         let pid = builder_impl.create()?;

--- a/crates/libcontainer/src/process/args.rs
+++ b/crates/libcontainer/src/process/args.rs
@@ -7,8 +7,7 @@ use crate::container::Container;
 use crate::notify_socket::NotifyListener;
 use crate::rootless::Rootless;
 use crate::syscall::syscall::SyscallType;
-use crate::workload::ExecutorManager;
-
+use crate::workload::Executor;
 #[derive(Debug, Copy, Clone)]
 pub enum ContainerType {
     InitContainer,
@@ -39,5 +38,5 @@ pub struct ContainerArgs<'a> {
     /// If the container is to be run in detached mode
     pub detached: bool,
     /// Manage the functions that actually run on the container
-    pub executor_manager: &'a ExecutorManager,
+    pub executor: Executor,
 }

--- a/crates/libcontainer/src/process/container_init_process.rs
+++ b/crates/libcontainer/src/process/container_init_process.rs
@@ -69,7 +69,7 @@ pub enum InitProcessError {
     #[error(transparent)]
     NotifyListener(#[from] notify_socket::NotifyListenerError),
     #[error(transparent)]
-    Workload(#[from] workload::ExecutorManagerError),
+    Workload(#[from] workload::ExecutorError),
     #[error("invalid io priority class: {0}")]
     IoPriorityClass(String),
 }
@@ -679,7 +679,7 @@ pub fn container_init_process(
     }
 
     if proc.args().is_some() {
-        args.executor_manager.exec(spec).map_err(|err| {
+        (args.executor)(spec).map_err(|err| {
             tracing::error!(?err, "failed to execute payload");
             err
         })?;

--- a/crates/libcontainer/src/workload/default.rs
+++ b/crates/libcontainer/src/workload/default.rs
@@ -5,13 +5,8 @@ use oci_spec::runtime::Spec;
 
 use super::{Executor, ExecutorError, EMPTY};
 
-const EXECUTOR_NAME: &str = "default";
-
-#[derive(Default)]
-pub struct DefaultExecutor {}
-
-impl Executor for DefaultExecutor {
-    fn exec(&self, spec: &Spec) -> Result<(), ExecutorError> {
+pub fn get_executor() -> Executor {
+    Box::new(|spec: &Spec| -> Result<(), ExecutorError> {
         tracing::debug!("executing workload with default handler");
         let args = spec
             .process()
@@ -41,13 +36,5 @@ impl Executor for DefaultExecutor {
         // After execvp is called, the process is replaced with the container
         // payload through execvp, so it should never reach here.
         unreachable!();
-    }
-
-    fn can_handle(&self, _: &Spec) -> bool {
-        true
-    }
-
-    fn name(&self) -> &'static str {
-        EXECUTOR_NAME
-    }
+    })
 }

--- a/crates/libcontainer/src/workload/default.rs
+++ b/crates/libcontainer/src/workload/default.rs
@@ -5,6 +5,8 @@ use oci_spec::runtime::Spec;
 
 use super::{Executor, ExecutorError, EMPTY};
 
+/// Return the default executor. The default executor will execute the command
+/// specified in the oci spec.
 pub fn get_executor() -> Executor {
     Box::new(|spec: &Spec| -> Result<(), ExecutorError> {
         tracing::debug!("executing workload with default handler");

--- a/crates/libcontainer/src/workload/mod.rs
+++ b/crates/libcontainer/src/workload/mod.rs
@@ -12,52 +12,8 @@ pub enum ExecutorError {
     Execution(#[from] Box<dyn std::error::Error + Send + Sync>),
     #[error("{0}")]
     Other(String),
+    #[error("{0} executor can't handle spec")]
+    CantHandle(&'static str),
 }
 
-pub trait Executor {
-    /// Executes the workload
-    fn exec(&self, spec: &Spec) -> Result<(), ExecutorError>;
-
-    /// Checks if the handler is able to handle the workload
-    fn can_handle(&self, spec: &Spec) -> bool;
-
-    /// The name of the handler
-    fn name(&self) -> &'static str;
-}
-
-#[derive(Debug, thiserror::Error)]
-pub enum ExecutorManagerError {
-    #[error("failed executor {name}")]
-    ExecutionFailed {
-        source: Box<dyn std::error::Error + Send + Sync>,
-        name: String,
-    },
-    #[error("failed to find an executor that satisfies all requirements")]
-    NoExecutorFound,
-}
-
-/// Manage the functions that actually run on the container
-pub struct ExecutorManager {
-    pub executors: Vec<Box<dyn Executor>>,
-}
-
-impl ExecutorManager {
-    pub fn exec(&self, spec: &Spec) -> Result<(), ExecutorManagerError> {
-        if self.executors.is_empty() {
-            return Err(ExecutorManagerError::NoExecutorFound);
-        };
-
-        for executor in self.executors.iter() {
-            if executor.can_handle(spec) {
-                return executor.exec(spec).map_err(|e| {
-                    tracing::error!(err = ?e, name = ?executor.name(), "failed to execute workload");
-                    ExecutorManagerError::ExecutionFailed {
-                        source: e.into(),
-                        name: executor.name().to_string(),
-                    }
-                });
-            }
-        }
-        Err(ExecutorManagerError::NoExecutorFound)
-    }
-}
+pub type Executor = Box<fn(&Spec) -> Result<(), ExecutorError>>;

--- a/crates/youki/src/commands/create.rs
+++ b/crates/youki/src/commands/create.rs
@@ -5,7 +5,7 @@ use std::path::PathBuf;
 use libcontainer::{container::builder::ContainerBuilder, syscall::syscall::SyscallType};
 use liboci_cli::Create;
 
-use crate::workload::executor::default_executors;
+use crate::workload::executor::default_executor;
 
 // One thing to note is that in the end, container is just another process in Linux
 // it has specific/different control group, namespace, using which program executing in it
@@ -14,7 +14,7 @@ use crate::workload::executor::default_executors;
 // associated with it like any other process.
 pub fn create(args: Create, root_path: PathBuf, systemd_cgroup: bool) -> Result<()> {
     ContainerBuilder::new(args.container_id.clone(), SyscallType::default())
-        .with_executor(default_executors())?
+        .with_executor(default_executor())
         .with_pid_file(args.pid_file.as_ref())?
         .with_console_socket(args.console_socket.as_ref())
         .with_root_path(root_path)?

--- a/crates/youki/src/commands/exec.rs
+++ b/crates/youki/src/commands/exec.rs
@@ -5,11 +5,11 @@ use std::path::PathBuf;
 use libcontainer::{container::builder::ContainerBuilder, syscall::syscall::SyscallType};
 use liboci_cli::Exec;
 
-use crate::workload::executor::default_executors;
+use crate::workload::executor::default_executor;
 
 pub fn exec(args: Exec, root_path: PathBuf) -> Result<i32> {
     let pid = ContainerBuilder::new(args.container_id.clone(), SyscallType::default())
-        .with_executor(default_executors())?
+        .with_executor(default_executor())
         .with_root_path(root_path)?
         .with_console_socket(args.console_socket.as_ref())
         .with_pid_file(args.pid_file.as_ref())?

--- a/crates/youki/src/commands/run.rs
+++ b/crates/youki/src/commands/run.rs
@@ -12,11 +12,11 @@ use nix::{
     unistd::Pid,
 };
 
-use crate::workload::executor::default_executors;
+use crate::workload::executor::default_executor;
 
 pub fn run(args: Run, root_path: PathBuf, systemd_cgroup: bool) -> Result<i32> {
     let mut container = ContainerBuilder::new(args.container_id.clone(), SyscallType::default())
-        .with_executor(default_executors())?
+        .with_executor(default_executor())
         .with_pid_file(args.pid_file.as_ref())?
         .with_console_socket(args.console_socket.as_ref())
         .with_root_path(root_path)?

--- a/crates/youki/src/workload/executor.rs
+++ b/crates/youki/src/workload/executor.rs
@@ -1,13 +1,29 @@
-use libcontainer::workload::{default::DefaultExecutor, Executor};
+use libcontainer::oci_spec::runtime::Spec;
+use libcontainer::workload::{Executor, ExecutorError};
 
-pub fn default_executors() -> Vec<Box<dyn Executor>> {
-    vec![
+pub fn default_executor() -> Executor {
+    Box::new(|spec: &Spec| -> Result<(), ExecutorError> {
         #[cfg(feature = "wasm-wasmer")]
-        Box::<super::wasmer::WasmerExecutor>::default(),
+        match super::wasmer::get_executor()(spec) {
+            Ok(_) => return Ok(()),
+            Err(ExecutorError::CantHandle(_)) => (),
+            Err(err) => return Err(err),
+        }
         #[cfg(feature = "wasm-wasmedge")]
-        Box::<super::wasmedge::WasmEdgeExecutor>::default(),
+        match super::wasmedge::get_executor()(spec) {
+            Ok(_) => return Ok(()),
+            Err(ExecutorError::CantHandle(_)) => (),
+            Err(err) => return Err(err),
+        }
         #[cfg(feature = "wasm-wasmtime")]
-        Box::<super::wasmtime::WasmtimeExecutor>::default(),
-        Box::<DefaultExecutor>::default(),
-    ]
+        match super::wasmtime::get_executor()(spec) {
+            Ok(_) => return Ok(()),
+            Err(ExecutorError::CantHandle(_)) => (),
+            Err(err) => return Err(err),
+        }
+
+        // Leave the default executor as the last option, which executes normal
+        // container workloads.
+        libcontainer::workload::default::get_executor()(spec)
+    })
 }

--- a/crates/youki/src/workload/wasmedge.rs
+++ b/crates/youki/src/workload/wasmedge.rs
@@ -8,11 +8,14 @@ use libcontainer::workload::{Executor, ExecutorError};
 
 const EXECUTOR_NAME: &str = "wasmedge";
 
-#[derive(Default)]
-pub struct WasmEdgeExecutor {}
+pub fn get_executor() -> Executor {
+    Box::new(|spec: &Spec| -> Result<(), ExecutorError> {
+        if !can_handle(spec) {
+            return Err(ExecutorError::CantHandle(EXECUTOR_NAME));
+        }
 
-impl Executor for WasmEdgeExecutor {
-    fn exec(&self, spec: &Spec) -> Result<(), ExecutorError> {
+        tracing::debug!("executing workload with wasmedge handler");
+
         // parse wasi parameters
         let args = get_args(spec);
         let mut cmd = args[0].clone();
@@ -55,25 +58,21 @@ impl Executor for WasmEdgeExecutor {
             .map_err(|err| ExecutorError::Execution(err))?;
 
         Ok(())
-    }
+    })
+}
 
-    fn can_handle(&self, spec: &Spec) -> bool {
-        if let Some(annotations) = spec.annotations() {
-            if let Some(handler) = annotations.get("run.oci.handler") {
-                return handler == "wasm";
-            }
-
-            if let Some(variant) = annotations.get("module.wasm.image/variant") {
-                return variant == "compat";
-            }
+fn can_handle(spec: &Spec) -> bool {
+    if let Some(annotations) = spec.annotations() {
+        if let Some(handler) = annotations.get("run.oci.handler") {
+            return handler == "wasm";
         }
 
-        false
+        if let Some(variant) = annotations.get("module.wasm.image/variant") {
+            return variant == "compat";
+        }
     }
 
-    fn name(&self) -> &'static str {
-        EXECUTOR_NAME
-    }
+    false
 }
 
 fn get_args(spec: &Spec) -> &[String] {

--- a/crates/youki/src/workload/wasmer.rs
+++ b/crates/youki/src/workload/wasmer.rs
@@ -6,11 +6,12 @@ use libcontainer::workload::{Executor, ExecutorError, EMPTY};
 
 const EXECUTOR_NAME: &str = "wasmer";
 
-#[derive(Default)]
-pub struct WasmerExecutor {}
+pub fn get_executor() -> Executor {
+    Box::new(|spec: &Spec| -> Result<(), ExecutorError> {
+        if !can_handle(spec) {
+            return Err(ExecutorError::CantHandle(EXECUTOR_NAME));
+        }
 
-impl Executor for WasmerExecutor {
-    fn exec(&self, spec: &Spec) -> Result<(), ExecutorError> {
         tracing::debug!("executing workload with wasmer handler");
         let process = spec.process().as_ref();
 
@@ -75,25 +76,21 @@ impl Executor for WasmerExecutor {
         wasi_env.cleanup(&mut store, None);
 
         Ok(())
-    }
+    })
+}
 
-    fn can_handle(&self, spec: &Spec) -> bool {
-        if let Some(annotations) = spec.annotations() {
-            if let Some(handler) = annotations.get("run.oci.handler") {
-                return handler == "wasm";
-            }
-
-            if let Some(variant) = annotations.get("module.wasm.image/variant") {
-                return variant == "compat";
-            }
+fn can_handle(spec: &Spec) -> bool {
+    if let Some(annotations) = spec.annotations() {
+        if let Some(handler) = annotations.get("run.oci.handler") {
+            return handler == "wasm";
         }
 
-        false
+        if let Some(variant) = annotations.get("module.wasm.image/variant") {
+            return variant == "compat";
+        }
     }
 
-    fn name(&self) -> &'static str {
-        EXECUTOR_NAME
-    }
+    false
 }
 
 #[cfg(test)]
@@ -112,7 +109,7 @@ mod tests {
             .build()
             .context("build spec")?;
 
-        assert!(WasmerExecutor::default().can_handle(&spec));
+        assert!(can_handle(&spec));
 
         Ok(())
     }
@@ -126,7 +123,7 @@ mod tests {
             .build()
             .context("build spec")?;
 
-        assert!(WasmerExecutor::default().can_handle(&spec));
+        assert!(can_handle(&spec));
 
         Ok(())
     }
@@ -135,7 +132,7 @@ mod tests {
     fn test_can_handle_no_execute() -> Result<()> {
         let spec = SpecBuilder::default().build().context("build spec")?;
 
-        assert!(!WasmerExecutor::default().can_handle(&spec));
+        assert!(!can_handle(&spec));
 
         Ok(())
     }

--- a/crates/youki/src/workload/wasmtime.rs
+++ b/crates/youki/src/workload/wasmtime.rs
@@ -6,12 +6,13 @@ use libcontainer::workload::{Executor, ExecutorError, EMPTY};
 
 const EXECUTOR_NAME: &str = "wasmtime";
 
-#[derive(Default)]
-pub struct WasmtimeExecutor {}
+pub fn get_executor() -> Executor {
+    Box::new(|spec: &Spec| -> Result<(), ExecutorError> {
+        if !can_handle(spec) {
+            return Err(ExecutorError::CantHandle(EXECUTOR_NAME));
+        }
 
-impl Executor for WasmtimeExecutor {
-    fn exec(&self, spec: &Spec) -> Result<(), ExecutorError> {
-        tracing::info!("Executing workload with wasmtime handler");
+        tracing::debug!("executing workload with wasmtime handler");
         let process = spec.process().as_ref();
 
         let args = spec
@@ -85,23 +86,19 @@ impl Executor for WasmtimeExecutor {
         start
             .call(&mut store, &[], &mut [])
             .map_err(|err| ExecutorError::Execution(err.into()))
-    }
+    })
+}
 
-    fn can_handle(&self, spec: &Spec) -> bool {
-        if let Some(annotations) = spec.annotations() {
-            if let Some(handler) = annotations.get("run.oci.handler") {
-                return handler == "wasm";
-            }
-
-            if let Some(variant) = annotations.get("module.wasm.image/variant") {
-                return variant == "compat";
-            }
+fn can_handle(spec: &Spec) -> bool {
+    if let Some(annotations) = spec.annotations() {
+        if let Some(handler) = annotations.get("run.oci.handler") {
+            return handler == "wasm";
         }
 
-        false
+        if let Some(variant) = annotations.get("module.wasm.image/variant") {
+            return variant == "compat";
+        }
     }
 
-    fn name(&self) -> &'static str {
-        EXECUTOR_NAME
-    }
+    false
 }

--- a/docs/src/developer/libcontainer.md
+++ b/docs/src/developer/libcontainer.md
@@ -23,7 +23,21 @@ This crate also provides an interface for Apparmor which is another Linux Kernel
 - tty module which daels with providing terminal interface to the container process
   - [pseudoterminal man page](https://man7.org/linux/man-pages/man7/pty.7.html) : Information about the pseudoterminal system, useful to understand console_socket parameter in create subcommand
 
-#### Namespaces : namespaces provide isolation of resources such as filesystem, process ids networks etc on kernel level. This module contains structs and functions related to applying or un-applying namespaces to the calling process.
+#### Executor
+
+By default and traditionally, the executor forks and execs into the binary
+command that specified in the oci spec. Using executors, we can override this
+behavior. For example, `youki` uses executor to implement running wasm
+workloads. Instead of running the command specified in the process section of
+the OCI spec, the wasm related executors can choose to execute wasm code
+instead. The executor will run at the end of the container init process.
+
+The API accepts only a single executor, so when using multiple executors, (try
+wasm first, then defaults to running a binary), the users should compose
+multiple executors into a single executor. The executor will return an error
+when the executor can't handle the workload.
+
+#### Namespaces : namespaces provide isolation of resources such as filesystem, process ids networks etc on kernel level. This module contains structs and functions related to applying or un-applying namespaces to the calling process
 
 - [pid namespace man page](https://man7.org/linux/man-pages/man7/pid_namespaces.7.html)
 - [CLONE_NEWUSER flag](https://man7.org/linux/man-pages/man2/clone.2.html)
@@ -40,7 +54,7 @@ Pausing a container indicates suspending all processes in it. This can be done w
 - [cgroups man page](https://man7.org/linux/man-pages/man7/cgroups.7.html)
 - [freezer cgroup kernel documentation](https://www.kernel.org/doc/Documentation/cgroup-v1/freezer-subsystem.txt)
 
-#### The following are some resources that can help understand with various Linux features used in the code of this crate.
+#### The following are some resources that can help understand with various Linux features used in the code of this crate
 
 - [oom-score-adj](https://dev.to/rrampage/surviving-the-linux-oom-killer-2ki9)
 - [unshare man page](https://man7.org/linux/man-pages/man1/unshare.1.html)


### PR DESCRIPTION
Refactored the executor and executor manager to be clone-able and more ergonomics.

Removed the use of executor manager with a vector of executor. Instead we favor composing executors into a new executor. Composing also allows the implementer to be precise about the execution orders. The old executor manager with its vector implementation is not explicit enough about the order when multiple executor is involved.

Re-implement the executor to be a function pointer instead of the Fn family traits. Traits will type erase and difficult to deal with when implementing clone.

Refactored the wasm related exectors to use the new scheme.