### PR TITLE
Make container_args clone-able

### DIFF
--- a/crates/libcontainer/src/channel.rs
+++ b/crates/libcontainer/src/channel.rs
@@ -18,12 +18,13 @@ pub enum ChannelError {
     #[error("channel connection broken")]
     BrokenChannel,
 }
-
+#[derive(Clone)]
 pub struct Receiver<T> {
     receiver: RawFd,
     phantom: PhantomData<T>,
 }
 
+#[derive(Clone)]
 pub struct Sender<T> {
     sender: RawFd,
     phantom: PhantomData<T>,

--- a/crates/libcontainer/src/container/builder_impl.rs
+++ b/crates/libcontainer/src/container/builder_impl.rs
@@ -16,9 +16,9 @@ use crate::{
 use libcgroups::common::CgroupManager;
 use nix::unistd::Pid;
 use oci_spec::runtime::Spec;
-use std::{fs, io::Write, os::unix::prelude::RawFd, path::PathBuf};
+use std::{fs, io::Write, os::unix::prelude::RawFd, path::PathBuf, rc::Rc};
 
-pub(super) struct ContainerBuilderImpl<'a> {
+pub(super) struct ContainerBuilderImpl {
     /// Flag indicating if an init or a tenant container should be created
     pub container_type: ContainerType,
     /// Interface to operating system primitives
@@ -28,7 +28,7 @@ pub(super) struct ContainerBuilderImpl<'a> {
     /// Id of the container
     pub container_id: String,
     /// OCI compliant runtime spec
-    pub spec: &'a Spec,
+    pub spec: Rc<Spec>,
     /// Root filesystem of the container
     pub rootfs: PathBuf,
     /// File which will be used to communicate the pid of the
@@ -37,7 +37,7 @@ pub(super) struct ContainerBuilderImpl<'a> {
     /// Socket to communicate the file descriptor of the ptty
     pub console_socket: Option<RawFd>,
     /// Options for rootless containers
-    pub rootless: Option<Rootless<'a>>,
+    pub rootless: Option<Rootless>,
     /// Path to the Unix Domain Socket to communicate container start
     pub notify_path: PathBuf,
     /// Container state
@@ -50,7 +50,7 @@ pub(super) struct ContainerBuilderImpl<'a> {
     pub executor: Executor,
 }
 
-impl<'a> ContainerBuilderImpl<'a> {
+impl ContainerBuilderImpl {
     pub(super) fn create(&mut self) -> Result<Pid, LibcontainerError> {
         match self.run_container() {
             Ok(pid) => Ok(pid),
@@ -138,13 +138,13 @@ impl<'a> ContainerBuilderImpl<'a> {
         let container_args = ContainerArgs {
             container_type: self.container_type,
             syscall: self.syscall,
-            spec: self.spec,
-            rootfs: &self.rootfs,
+            spec: Rc::clone(&self.spec),
+            rootfs: self.rootfs.to_owned(),
             console_socket: self.console_socket,
             notify_listener,
             preserve_fds: self.preserve_fds,
-            container: &self.container,
-            rootless: &self.rootless,
+            container: self.container.to_owned(),
+            rootless: self.rootless.to_owned(),
             cgroup_config,
             detached: self.detached,
             executor: self.executor.clone(),

--- a/crates/libcontainer/src/container/init_builder.rs
+++ b/crates/libcontainer/src/container/init_builder.rs
@@ -4,6 +4,7 @@ use rootless::Rootless;
 use std::{
     fs,
     path::{Path, PathBuf},
+    rc::Rc,
 };
 
 use crate::{
@@ -99,7 +100,7 @@ impl InitContainerBuilder {
             pid_file: self.base.pid_file,
             console_socket: csocketfd,
             use_systemd: self.use_systemd,
-            spec: &spec,
+            spec: Rc::new(spec),
             rootfs,
             rootless,
             notify_path,

--- a/crates/libcontainer/src/container/tenant_builder.rs
+++ b/crates/libcontainer/src/container/tenant_builder.rs
@@ -8,6 +8,7 @@ use oci_spec::runtime::{
 };
 use procfs::process::Namespace;
 
+use std::rc::Rc;
 use std::{
     collections::HashMap,
     convert::TryFrom,
@@ -132,7 +133,7 @@ impl TenantContainerBuilder {
             pid_file: self.base.pid_file,
             console_socket: csocketfd,
             use_systemd,
-            spec: &spec,
+            spec: Rc::new(spec),
             rootfs,
             rootless,
             notify_path: notify_path.clone(),

--- a/crates/libcontainer/src/process/args.rs
+++ b/crates/libcontainer/src/process/args.rs
@@ -2,6 +2,7 @@ use libcgroups::common::CgroupConfig;
 use oci_spec::runtime::Spec;
 use std::os::unix::prelude::RawFd;
 use std::path::PathBuf;
+use std::rc::Rc;
 
 use crate::container::Container;
 use crate::notify_socket::NotifyListener;
@@ -14,15 +15,16 @@ pub enum ContainerType {
     TenantContainer { exec_notify_fd: RawFd },
 }
 
-pub struct ContainerArgs<'a> {
+#[derive(Clone)]
+pub struct ContainerArgs {
     /// Indicates if an init or a tenant container should be created
     pub container_type: ContainerType,
     /// Interface to operating system primitives
     pub syscall: SyscallType,
     /// OCI compliant runtime spec
-    pub spec: &'a Spec,
+    pub spec: Rc<Spec>,
     /// Root filesystem of the container
-    pub rootfs: &'a PathBuf,
+    pub rootfs: PathBuf,
     /// Socket to communicate the file descriptor of the ptty
     pub console_socket: Option<RawFd>,
     /// The Unix Domain Socket to communicate container start
@@ -30,9 +32,9 @@ pub struct ContainerArgs<'a> {
     /// File descriptors preserved/passed to the container init process.
     pub preserve_fds: i32,
     /// Container state
-    pub container: &'a Option<Container>,
+    pub container: Option<Container>,
     /// Options for rootless containers
-    pub rootless: &'a Option<Rootless<'a>>,
+    pub rootless: Option<Rootless>,
     /// Cgroup Manager Config
     pub cgroup_config: CgroupConfig,
     /// If the container is to be run in detached mode

--- a/crates/libcontainer/src/process/channel.rs
+++ b/crates/libcontainer/src/process/channel.rs
@@ -40,6 +40,7 @@ pub fn main_channel() -> Result<(MainSender, MainReceiver), ChannelError> {
     Ok((MainSender { sender }, MainReceiver { receiver }))
 }
 
+#[derive(Clone)]
 pub struct MainSender {
     sender: Sender<Message>,
 }
@@ -87,6 +88,7 @@ impl MainSender {
     }
 }
 
+#[derive(Clone)]
 pub struct MainReceiver {
     receiver: Receiver<Message>,
 }
@@ -193,6 +195,7 @@ pub fn intermediate_channel() -> Result<(IntermediateSender, IntermediateReceive
     ))
 }
 
+#[derive(Clone)]
 pub struct IntermediateSender {
     sender: Sender<Message>,
 }
@@ -212,6 +215,7 @@ impl IntermediateSender {
     }
 }
 
+#[derive(Clone)]
 pub struct IntermediateReceiver {
     receiver: Receiver<Message>,
 }
@@ -248,6 +252,7 @@ pub fn init_channel() -> Result<(InitSender, InitReceiver), ChannelError> {
     Ok((InitSender { sender }, InitReceiver { receiver }))
 }
 
+#[derive(Clone)]
 pub struct InitSender {
     sender: Sender<Message>,
 }
@@ -266,6 +271,7 @@ impl InitSender {
     }
 }
 
+#[derive(Clone)]
 pub struct InitReceiver {
     receiver: Receiver<Message>,
 }

--- a/crates/libcontainer/src/process/container_init_process.rs
+++ b/crates/libcontainer/src/process/container_init_process.rs
@@ -335,11 +335,11 @@ pub fn container_init_process(
     init_receiver: &mut channel::InitReceiver,
 ) -> Result<()> {
     let syscall = args.syscall.create_syscall();
-    let spec = args.spec;
+    let spec = &args.spec;
     let linux = spec.linux().as_ref().ok_or(MissingSpecError::Linux)?;
     let proc = spec.process().as_ref().ok_or(MissingSpecError::Process)?;
     let mut envs: Vec<String> = proc.env().as_ref().unwrap_or(&vec![]).clone();
-    let rootfs_path = args.rootfs;
+    let rootfs_path = &args.rootfs;
     let hooks = spec.hooks().as_ref();
     let container = args.container.as_ref();
     let namespaces = Namespaces::try_from(linux.namespaces().as_ref())?;
@@ -492,7 +492,7 @@ pub fn container_init_process(
         }
     };
 
-    set_supplementary_gids(proc.user(), args.rootless, syscall.as_ref()).map_err(|err| {
+    set_supplementary_gids(proc.user(), &args.rootless, syscall.as_ref()).map_err(|err| {
         tracing::error!(?err, "failed to set supplementary gids");
         err
     })?;

--- a/crates/libcontainer/src/process/container_main_process.rs
+++ b/crates/libcontainer/src/process/container_main_process.rs
@@ -222,7 +222,7 @@ mod tests {
         let tmp = tempfile::tempdir()?;
         let id_mapper = RootlessIDMapper::new_test(tmp.path().to_path_buf());
         let rootless = Rootless {
-            uid_mappings: Some(&uid_mappings),
+            uid_mappings: Some(uid_mappings),
             privileged: true,
             rootless_id_mapper: id_mapper.clone(),
             ..Default::default()
@@ -277,7 +277,7 @@ mod tests {
         let tmp = tempfile::tempdir()?;
         let id_mapper = RootlessIDMapper::new_test(tmp.path().to_path_buf());
         let rootless = Rootless {
-            gid_mappings: Some(&gid_mappings),
+            gid_mappings: Some(gid_mappings),
             rootless_id_mapper: id_mapper.clone(),
             ..Default::default()
         };

--- a/crates/libcontainer/src/process/message.rs
+++ b/crates/libcontainer/src/process/message.rs
@@ -2,7 +2,7 @@ use core::fmt;
 use serde::{Deserialize, Serialize};
 
 /// Used as a wrapper for messages to be sent between child and parent processes
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub enum Message {
     IntermediateReady(i32),
     InitReady,


### PR DESCRIPTION
Make the container_args clone-able and remove the use of references. Container_args is passed to the intermediate and init process, so we need to make sure it can across the clone process boundry safely by allowing passing of the container_args ownership to the new process.