### PR TITLE
Update CI go version to 1.20

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -37,9 +37,9 @@ jobs:
         with:
           repository: containerd/containerd
           ref: v1.6.20
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v4
         with:
-          go-version: '1.19.9'
+          go-version: '1.20'
           cache: true
       - run: sudo apt-get -y update
       - run: sudo apt-get install -y pkg-config libsystemd-dev libdbus-glib-1-dev libelf-dev libseccomp-dev btrfs-progs libbtrfs-dev
@@ -89,9 +89,9 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
       - name: Install just
         uses: taiki-e/install-action@just
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v4
         with:
-          go-version: '1.19.9'
+          go-version: '1.20'
           cache: true
           cache-dependency-path: tests/oci-runtime-tests/src/github.com/opencontainers/runtime-tools/go.sum
       - name: Download youki binary

--- a/.github/workflows/podman_tests.yaml
+++ b/.github/workflows/podman_tests.yaml
@@ -23,7 +23,7 @@ jobs:
           repository: containers/podman
       - uses: actions/setup-go@v4
         with:
-          go-version: '1.18'
+          go-version: '1.20'
       - name: Build podman
         run: make binaries 
       - name: Install tools


### PR DESCRIPTION
The podman tests in CI were failing because podman failing to build. Podman was failing to build beacuse of of its dependencies need atleast go 1.19. Updated all go install actions to install go 1.20 .