### PR TITLE
Fix podman tests to properly run

### DIFF
--- a/.github/workflows/podman_tests.yaml
+++ b/.github/workflows/podman_tests.yaml
@@ -3,33 +3,53 @@ name: Test for podman
 on:
   schedule:
   - cron: "0 0 * * *"
+  workflow_dispatch:
 
 jobs:
   podman-tests:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - name: Install just
         uses: taiki-e/install-action@just
       - name: Install requirements
         run: sudo env PATH=$PATH just ci-prepare
-      - run: just youki-dev
-      - run: sudo cp youki /usr/local/bin
-      - name: Install requirements for Podman
-        run: sudo apt-get install -y pkg-config libsystemd-dev libdbus-glib-1-dev libelf-dev libseccomp-dev libgpgme-dev bats
+      - name: Install skopeo and podman requirements
+        run: sudo apt-get install -y pkg-config libsystemd-dev libdbus-glib-1-dev libelf-dev libseccomp-dev libgpgme-dev libassuan-dev libbtrfs-dev libdevmapper-dev bats socat
+      
+      # setup go
+      - uses: actions/setup-go@v4
+        with:
+          go-version: '1.20'
+      
+      # build skopeo
+      # These build steps are taken from https://github.com/containers/skopeo/issues/1648#issuecomment-1132161659
+      - name: Download skopeo 1.13.1 source # because ubuntu 22.04 does not have latest, and podman tests depend on that
+        run: mkdir /tmp/skopeo && curl -fsSL "https://github.com/containers/skopeo/archive/v1.13.1.tar.gz" | tar -xzf - -C /tmp/skopeo --strip-components=1
+      - name: Build skopeo
+        run: cd /tmp/skopeo && DISABLE_DOCS=1 make
+      - name: copy skopeo binaries
+        run: sudo cp /tmp/skopeo/bin/skopeo /usr/local/bin/skopeo && sudo cp /tmp/skopeo/default-policy.json /etc/containers/policy.json
+      - name: Skopeo version
+        run: skopeo --version
+
+      # build youki
+      - run: just youki-release
+      - run: sudo rm /usr/bin/crun && sudo cp youki /usr/local/bin && sudo cp youki /usr/bin/crun
+
+      # build podman
       - name: Clone podman repository
         uses: actions/checkout@v3
         with:
           repository: containers/podman
-      - uses: actions/setup-go@v4
-        with:
-          go-version: '1.20'
       - name: Build podman
         run: make binaries 
       - name: Install tools
         run: make install.tools
+      
+      # run tests
       - name: Run podman test
-        run: sudo OCI_RUNTIME=/usr/local/bin/youki ./hack/bats 2>&1 | tee build.log 
+        run: BATS_TEST_TMPDIR=$(mktemp -d --tmpdir=${BATS_TMPDIR:-/tmp} podman_bats.XXXXXX) && PODMAN_TMPDIR=$BATS_TEST_TMPDIR && OCI_RUNTIME=/usr/local/bin/youki sudo make localsystem 2>&1 | tee build.log 
       - name: Adding Summary
         run: |
-          echo "Total tests: 577 Failed tests: $(cat build.log | grep " ok " | wc -l)" >> $GITHUB_STEP_SUMMARY
+          echo "Total tests: 600+ Failed tests: $(cat build.log | grep " ok " | wc -l)" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
Currently almost all of the podman tests are failing to run. The CI doesn't fail because we are intentionally ignoring the failures. Many of the tests use skopeo to download certain container image for the test. Unfortunately the default version on ubuntu for skopeo is 1.4.0, however a certain cmd option used by the tests to download the images only exist in newer versions. 
Thus now we clone the 1.13.1 release and build the skopeo in the CI itself. Moreover we use the makefile target `localsystem` instead of directly running bats command. This also adds a `workflow_dispatch` for podman CI so we can run them easily on specific branches that we want.

As it stands now, the current main have ~76 failing tests in rootful mode. Several of them are due to incorrect configuration of env, for eg some tests expect an ssh key to be configured etc. However, these kind of failing tests can be ignored, as they are not invoking youki. The rest of the failing tests might indicate something wrong in youki-podman interfacing, and should be fixed.

On the other hand onrootless mode, currently ~279 tests are failing with current main and on my branch where rootless is fixed. The main branch failures were expected, and have the expected error message, however I need to figure out and fix the them when I make my rootless PR if possible.

In long term, I think we should fix all youki-related failures, ignore others, and make it so that any failures will fail CI. Then we can have a label based trigger, where after all review and testing is done (for big PRs only) we add a lable like `run-podman-tests` and it will trigger CI for that , after which it can be merged. (That is not done in this PR)