### PR TITLE
Rename the rootless struct  to UserNamespaceConfig

### DIFF
--- a/MirgationGuide.md
+++ b/MirgationGuide.md
@@ -1,0 +1,14 @@
+This contains information for migrating library versions.
+
+## V0.1.0 -> v0.2.0
+
+### libcontainer
+
+- The `Rootless` struct has been re-named as `UserNamespaceConfig` , `RootlessIDMapper` has been re-named to `UserNamespaceIDMapper` , and correspondingly the `RootlessError` has been re-named to `UserNamespaceError` . This is due to the fact that the structure was to be used for containers when a new user namespace is to be created, and that is not strictly only for rootless uses. Accordingly, the fields of various structs has been updated to reflect this change :
+    - rootless (module name) -> user_ns
+    - Rootless::rootless_id_mapper -> UserNamespaceConfig::id_mapper
+    - LibcontainerError::Rootless -> LibcontainerError::UserNamespace
+    - ContainerBuilderImpl::rootless -> ContainerBuilderImpl::user_ns_config
+    - ContainerArgs::rootless -> ContainerArgs::user_ns_config
+
+- Changes that will occur for properly running in rootless mode : TODO (@YJDoc2)

--- a/crates/libcontainer/src/config.rs
+++ b/crates/libcontainer/src/config.rs
@@ -47,7 +47,7 @@ pub struct YoukiConfig {
 }
 
 impl<'a> YoukiConfig {
-    pub fn from_spec(spec: &'a Spec, container_id: &str, rootless: bool) -> Result<Self> {
+    pub fn from_spec(spec: &'a Spec, container_id: &str, new_user_ns: bool) -> Result<Self> {
         Ok(YoukiConfig {
             hooks: spec.hooks().clone(),
             cgroup_path: utils::get_cgroup_path(
@@ -56,7 +56,7 @@ impl<'a> YoukiConfig {
                     .ok_or(ConfigError::MissingLinux)?
                     .cgroups_path(),
                 container_id,
-                rootless,
+                new_user_ns,
             ),
         })
     }

--- a/crates/libcontainer/src/container/init_builder.rs
+++ b/crates/libcontainer/src/container/init_builder.rs
@@ -1,11 +1,11 @@
 use nix::unistd;
 use oci_spec::runtime::Spec;
-use rootless::Rootless;
 use std::{
     fs,
     path::{Path, PathBuf},
     rc::Rc,
 };
+use user_ns::UserNamespaceConfig;
 
 use crate::{
     apparmor,
@@ -13,7 +13,7 @@ use crate::{
     error::{ErrInvalidSpec, LibcontainerError, MissingSpecError},
     notify_socket::NOTIFY_FILE,
     process::args::ContainerType,
-    rootless, tty,
+    tty, user_ns,
 };
 
 use super::{
@@ -86,8 +86,8 @@ impl InitContainerBuilder {
             None
         };
 
-        let rootless = Rootless::new(&spec)?;
-        let config = YoukiConfig::from_spec(&spec, container.id(), rootless.is_some())?;
+        let user_ns_config = UserNamespaceConfig::new(&spec)?;
+        let config = YoukiConfig::from_spec(&spec, container.id(), user_ns_config.is_some())?;
         config.save(&container_dir).map_err(|err| {
             tracing::error!(?container_dir, "failed to save config: {}", err);
             err
@@ -102,7 +102,7 @@ impl InitContainerBuilder {
             use_systemd: self.use_systemd,
             spec: Rc::new(spec),
             rootfs,
-            rootless,
+            user_ns_config,
             notify_path,
             container: Some(container.clone()),
             preserve_fds: self.base.preserve_fds,

--- a/crates/libcontainer/src/container/tenant_builder.rs
+++ b/crates/libcontainer/src/container/tenant_builder.rs
@@ -23,7 +23,7 @@ use std::{
 use crate::error::{ErrInvalidSpec, LibcontainerError, MissingSpecError};
 use crate::process::args::ContainerType;
 use crate::{capabilities::CapabilityExt, container::builder_impl::ContainerBuilderImpl};
-use crate::{notify_socket::NotifySocket, rootless::Rootless, tty, utils};
+use crate::{notify_socket::NotifySocket, tty, user_ns::UserNamespaceConfig, utils};
 
 use super::{builder::ContainerBuilder, Container};
 
@@ -119,7 +119,7 @@ impl TenantContainerBuilder {
         let csocketfd = self.setup_tty_socket(&container_dir)?;
 
         let use_systemd = self.should_use_systemd(&container);
-        let rootless = Rootless::new(&spec)?;
+        let user_ns_config = UserNamespaceConfig::new(&spec)?;
 
         let (read_end, write_end) =
             pipe2(OFlag::O_CLOEXEC).map_err(LibcontainerError::OtherSyscall)?;
@@ -135,7 +135,7 @@ impl TenantContainerBuilder {
             use_systemd,
             spec: Rc::new(spec),
             rootfs,
-            rootless,
+            user_ns_config,
             notify_path: notify_path.clone(),
             container: None,
             preserve_fds: self.base.preserve_fds,

--- a/crates/libcontainer/src/error.rs
+++ b/crates/libcontainer/src/error.rs
@@ -35,7 +35,7 @@ pub enum LibcontainerError {
     #[error(transparent)]
     Tty(#[from] crate::tty::TTYError),
     #[error(transparent)]
-    Rootless(#[from] crate::rootless::RootlessError),
+    UserNamespace(#[from] crate::user_ns::UserNamespaceError),
     #[error(transparent)]
     NotifyListener(#[from] crate::notify_socket::NotifyListenerError),
     #[error(transparent)]

--- a/crates/libcontainer/src/lib.rs
+++ b/crates/libcontainer/src/lib.rs
@@ -9,13 +9,13 @@ pub mod namespaces;
 pub mod notify_socket;
 pub mod process;
 pub mod rootfs;
-pub mod rootless;
 #[cfg(feature = "libseccomp")]
 pub mod seccomp;
 pub mod signal;
 pub mod syscall;
 pub mod test_utils;
 pub mod tty;
+pub mod user_ns;
 pub mod utils;
 pub mod workload;
 

--- a/crates/libcontainer/src/process/args.rs
+++ b/crates/libcontainer/src/process/args.rs
@@ -6,8 +6,8 @@ use std::rc::Rc;
 
 use crate::container::Container;
 use crate::notify_socket::NotifyListener;
-use crate::rootless::Rootless;
 use crate::syscall::syscall::SyscallType;
+use crate::user_ns::UserNamespaceConfig;
 use crate::workload::Executor;
 #[derive(Debug, Copy, Clone)]
 pub enum ContainerType {
@@ -33,8 +33,8 @@ pub struct ContainerArgs {
     pub preserve_fds: i32,
     /// Container state
     pub container: Option<Container>,
-    /// Options for rootless containers
-    pub rootless: Option<Rootless>,
+    /// Options for new namespace creation
+    pub user_ns_config: Option<UserNamespaceConfig>,
     /// Cgroup Manager Config
     pub cgroup_config: CgroupConfig,
     /// If the container is to be run in detached mode

--- a/crates/libcontainer/src/utils.rs
+++ b/crates/libcontainer/src/utils.rs
@@ -147,11 +147,11 @@ pub fn get_user_home(uid: u32) -> Option<PathBuf> {
 pub fn get_cgroup_path(
     cgroups_path: &Option<PathBuf>,
     container_id: &str,
-    rootless: bool,
+    new_user_ns: bool,
 ) -> PathBuf {
     match cgroups_path {
         Some(cpath) => cpath.clone(),
-        None => match rootless {
+        None => match new_user_ns {
             false => PathBuf::from(container_id),
             true => PathBuf::from(format!(":youki:{container_id}")),
         },

--- a/crates/youki/src/commands/info.rs
+++ b/crates/youki/src/commands/info.rs
@@ -5,7 +5,7 @@ use std::{fs, path::Path};
 
 use anyhow::Result;
 use clap::Parser;
-use libcontainer::rootless;
+use libcontainer::user_ns;
 use procfs::{CpuInfo, Meminfo};
 
 #[cfg(feature = "v2")]
@@ -211,7 +211,7 @@ pub fn print_namespaces() {
         print_feature_status(&content, "CONFIG_UTS_NS", FeatureDisplay::new("uts"));
         print_feature_status(&content, "CONFIG_IPC_NS", FeatureDisplay::new("ipc"));
 
-        let user_display = match rootless::unprivileged_user_ns_enabled() {
+        let user_display = match user_ns::unprivileged_user_ns_enabled() {
             Ok(false) => FeatureDisplay::with_status("user", "enabled (root only)", "disabled"),
             _ => FeatureDisplay::new("user"),
         };

--- a/crates/youki/src/rootpath.rs
+++ b/crates/youki/src/rootpath.rs
@@ -1,5 +1,5 @@
 use anyhow::{bail, Result};
-use libcontainer::rootless::rootless_required;
+use libcontainer::user_ns::rootless_required;
 use libcontainer::utils::create_dir_all_with_mode;
 use nix::libc;
 use nix::sys::stat::Mode;

--- a/docs/src/user/libcontainer.md
+++ b/docs/src/user/libcontainer.md
@@ -22,7 +22,7 @@ This exposes several modules, each dealing with a specific aspect of working wit
 
 - `rootfs` : this contains modules which deal with rootfs, which is minimal filesystem that is provided to the container.
 
-- `rootless` : this deals with running containers in a rootless configuration, that is running containers without needing root permissions.
+- `user_ns` : this deals with running containers in with new user namespace, usually rootless containers will use this, that is running containers without needing root permissions.
 
 - `seccomp` : this deals with setting up seccomp for container process. It uses libseccomp crate in order to do that.
 


### PR DESCRIPTION
The current `Rootless` struct has more to do with creating a new user namespace that rootless containers. For example, it is possible and valid that a root user will run a container with new user ns, and in such case the current code treats it as "running in rootless" . This PR simply re-names stuff, but does not actually change any functionality.  This is roughly 1st of 3 parts for making podman rootless work.

The main changes here are changing the `rootless.rs` file to `user_ns.rs` , and changing the struct names 
- Rootless -> UserNamespaceConfig
- RootlessIDMapper -> UserNamespaceIDMapper
- RootlessError -> UserNamespaceError

Few of the struct members are also renamed to reflect these. Apart from this file, changes in other files are simply to update for these re-naming. If you have any better idea for the names, feel free to comment.