### PR TITLE
Extend wait time for auto-merge

### DIFF
--- a/.github/workflows/dependabot_auto.yaml
+++ b/.github/workflows/dependabot_auto.yaml
@@ -32,11 +32,11 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Automerge
         id: automerge
-        uses: pascalgn/automerge-action@v0.15.5
+        uses: pascalgn/automerge-action@v0.15.6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           MERGE_LABELS: dependencies
           MERGE_REQUIRED_APPROVALS: 1
-          MERGE_RETRY_SLEEP: 120000
+          MERGE_RETRY_SLEEP: 300000
           MERGE_DELETE_BRANCH: true
           MERGE_FILTER_AUTHOR: dependabot[bot]


### PR DESCRIPTION
I found sometimes 120000 `ms` * 6(default retry number) is not enough.
```
Run pascalgn/automerge-action@v0.15.5
2023-08-18T00:26:5[9](https://github.com/containers/youki/actions/runs/5897312264/job/15996739428#step:4:10).[12](https://github.com/containers/youki/actions/runs/5897312264/job/15996739428#step:4:13)9Z INFO  Event name: pull_request
2023-08-[18](https://github.com/containers/youki/actions/runs/5897312264/job/15996739428#step:4:19)T00:26:59.679Z INFO  Skipping PR update, required label missing: automerge
[20](https://github.com/containers/youki/actions/runs/5897312264/job/15996739428#step:4:21)23-08-18T00:26:59.680Z INFO  Merging PR #2274 (auto merged) chore(deps): bump quote from 1.0.32 to 1.0.33
2023-08-18T00:26:59.681Z INFO  Current PR status: mergeable_state: blocked
2023-08-18T00:26:59.681Z INFO  Retrying after 120000 ms ... (1/6)
2023-08-18T00:28:59.993Z INFO  Current PR status: mergeable_state: blocked
2023-08-18T00:28:59.994Z INFO  Retrying after 120000 ms ... (2/6)
2023-08-18T00:31:00.456Z INFO  Current PR status: mergeable_state: blocked
2023-08-18T00:31:00.456Z INFO  Retrying after 120000 ms ... (3/6)
2023-08-18T00:33:00.807Z INFO  Current PR status: mergeable_state: blocked
2023-08-18T00:33:00.807Z INFO  Retrying after 120000 ms ... (4/6)
2023-08-18T00:35:01.3[21](https://github.com/containers/youki/actions/runs/5897312264/job/15996739428#step:4:22)Z INFO  Current PR status: mergeable_state: blocked
2023-08-18T00:35:01.3[22](https://github.com/containers/youki/actions/runs/5897312264/job/15996739428#step:4:23)Z INFO  Retrying after 120000 ms ... (5/6)
20[23](https://github.com/containers/youki/actions/runs/5897312264/job/15996739428#step:4:24)-08-18T00:37:01.750Z INFO  Current PR status: mergeable_state: blocked
2023-08-18T00:37:01.750Z INFO  Retrying after 120000 ms ... (6/6)
2023-08-18T00:39:02.187Z INFO  Current PR status: mergeable_state: blocked
2023-08-18T00:39:02.187Z INFO  PR not ready to be merged after 6 tries
2023-08-18T00:39:02.188Z INFO  Action result: { mergeResult: 'not_ready', pullRequestNumber: 2274 }
```