### PR TITLE
Change rootless required function and privilege decision

### DIFF
--- a/crates/libcontainer/src/container/init_builder.rs
+++ b/crates/libcontainer/src/container/init_builder.rs
@@ -88,10 +88,6 @@ impl InitContainerBuilder {
 
         let user_ns_config = UserNamespaceConfig::new(&spec)?;
 
-        if utils::rootless_required() && !utils::is_in_new_userns() && user_ns_config.is_none() {
-            return Err(LibcontainerError::NoUserNamespace);
-        }
-
         let config = YoukiConfig::from_spec(&spec, container.id(), user_ns_config.is_some())?;
         config.save(&container_dir).map_err(|err| {
             tracing::error!(?container_dir, "failed to save config: {}", err);
@@ -196,6 +192,8 @@ impl InitContainerBuilder {
                 }
             }
         }
+
+        utils::validate_spec_for_new_user_ns(spec)?;
 
         Ok(())
     }

--- a/crates/libcontainer/src/container/tenant_builder.rs
+++ b/crates/libcontainer/src/container/tenant_builder.rs
@@ -121,6 +121,10 @@ impl TenantContainerBuilder {
         let use_systemd = self.should_use_systemd(&container);
         let user_ns_config = UserNamespaceConfig::new(&spec)?;
 
+        if utils::rootless_required() && !utils::is_in_new_userns() && user_ns_config.is_none() {
+            return Err(LibcontainerError::NoUserNamespace);
+        }
+
         let (read_end, write_end) =
             pipe2(OFlag::O_CLOEXEC).map_err(LibcontainerError::OtherSyscall)?;
 

--- a/crates/libcontainer/src/container/tenant_builder.rs
+++ b/crates/libcontainer/src/container/tenant_builder.rs
@@ -121,10 +121,6 @@ impl TenantContainerBuilder {
         let use_systemd = self.should_use_systemd(&container);
         let user_ns_config = UserNamespaceConfig::new(&spec)?;
 
-        if utils::rootless_required() && !utils::is_in_new_userns() && user_ns_config.is_none() {
-            return Err(LibcontainerError::NoUserNamespace);
-        }
-
         let (read_end, write_end) =
             pipe2(OFlag::O_CLOEXEC).map_err(LibcontainerError::OtherSyscall)?;
 
@@ -227,6 +223,8 @@ impl TenantContainerBuilder {
                 }
             }
         }
+
+        utils::validate_spec_for_new_user_ns(spec)?;
 
         Ok(())
     }

--- a/crates/libcontainer/src/error.rs
+++ b/crates/libcontainer/src/error.rs
@@ -22,6 +22,8 @@ pub enum LibcontainerError {
     InvalidInput(String),
     #[error("requires at least one executors")]
     NoExecutors,
+    #[error("rootless container requires valid user namespace definition")]
+    NoUserNamespace,
 
     // Invalid inputs
     #[error(transparent)]

--- a/crates/libcontainer/src/process/container_init_process.rs
+++ b/crates/libcontainer/src/process/container_init_process.rs
@@ -376,7 +376,8 @@ pub fn container_init_process(
             })?;
         }
 
-        let bind_service = namespaces.get(LinuxNamespaceType::User)?.is_some();
+        let bind_service =
+            namespaces.get(LinuxNamespaceType::User)?.is_some() || utils::is_in_new_userns();
         let rootfs = RootFS::new();
         rootfs
             .prepare_rootfs(

--- a/crates/libcontainer/src/utils.rs
+++ b/crates/libcontainer/src/utils.rs
@@ -10,6 +10,10 @@ use std::path::{Component, Path, PathBuf};
 use nix::sys::stat::Mode;
 use nix::sys::statfs;
 use nix::unistd::{Uid, User};
+use oci_spec::runtime::Spec;
+
+use crate::error::LibcontainerError;
+use crate::user_ns::UserNamespaceConfig;
 
 #[derive(Debug, thiserror::Error)]
 pub enum PathBufExtError {
@@ -273,10 +277,28 @@ pub fn rootless_required() -> bool {
     is_in_new_userns()
 }
 
+/// checks if given spec is valid for current user namespace setup
+pub fn validate_spec_for_new_user_ns(spec: &Spec) -> Result<(), LibcontainerError> {
+    let config = UserNamespaceConfig::new(spec)?;
+
+    // In case of rootless, there are 2 possible cases :
+    // we have a new user ns specified in the spec
+    // or the youki is launched in a new user ns (this is how podman does it)
+    // So here, we check if rootless is required,
+    // but we are neither in a new user ns nor a new user ns is specified in spec
+    // then it is an error
+    if rootless_required() && !is_in_new_userns() && config.is_none() {
+        return Err(LibcontainerError::NoUserNamespace);
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_utils;
     use anyhow::{bail, Result};
+    use serial_test::serial;
 
     #[test]
     pub fn test_get_unix_user() {
@@ -378,5 +400,37 @@ mod tests {
         }
 
         Ok(())
+    }
+
+    // the following test is marked as serial because
+    // we are doing unshare of user ns and fork, so better to run in serial,
+    #[test]
+    #[serial]
+    fn test_userns_spec_validation() -> Result<(), test_utils::TestError> {
+        use nix::sched::{unshare, CloneFlags};
+        // default rootful spec
+        let rootful_spec = Spec::default();
+        // as we are not in a user ns, and spec does not have user ns
+        // we should get error here
+        assert!(validate_spec_for_new_user_ns(&rootful_spec).is_err());
+
+        let rootless_spec = Spec::rootless(1000, 1000);
+        // because the spec contains user ns info, we should not get error
+        assert!(validate_spec_for_new_user_ns(&rootless_spec).is_ok());
+
+        test_utils::test_in_child_process(|| {
+            unshare(CloneFlags::CLONE_NEWUSER).unwrap();
+            // here we are in a new user namespace
+            let rootful_spec = Spec::default();
+            // because we are already in a new user ns, it is fine if spec
+            // does not have user ns, and because the test is running as
+            // non root
+            assert!(validate_spec_for_new_user_ns(&rootful_spec).is_ok());
+
+            let rootless_spec = Spec::rootless(1000, 1000);
+            // following should succeed irrespective if we're in user ns or not
+            assert!(validate_spec_for_new_user_ns(&rootless_spec).is_ok());
+            Ok(())
+        })
     }
 }

--- a/crates/libcontainer/src/utils.rs
+++ b/crates/libcontainer/src/utils.rs
@@ -258,6 +258,21 @@ pub fn ensure_procfs(path: &Path) -> Result<(), EnsureProcfsError> {
     Ok(())
 }
 
+pub fn is_in_new_userns() -> bool {
+    let uid_map_path = "/proc/self/uid_map";
+    let content = std::fs::read_to_string(uid_map_path)
+        .unwrap_or_else(|_| panic!("failed to read {}", uid_map_path));
+    !content.contains("4294967295")
+}
+
+/// Checks if rootless mode needs to be used
+pub fn rootless_required() -> bool {
+    if !nix::unistd::geteuid().is_root() {
+        return true;
+    }
+    is_in_new_userns()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/youki/src/observability.rs
+++ b/crates/youki/src/observability.rs
@@ -73,7 +73,13 @@ where
     let log_level_filter = tracing_subscriber::filter::LevelFilter::from(level);
     let log_format = detect_log_format(config.log_format.as_deref())
         .with_context(|| "failed to detect log format")?;
-    let systemd_journald = if config.systemd_log {
+
+    #[cfg(debug_assertions)]
+    let journald = true;
+    #[cfg(not(debug_assertions))]
+    let journald = config.systemd_log;
+
+    let systemd_journald = if journald {
         Some(tracing_journald::layer()?.with_syslog_identifier("youki".to_string()))
     } else {
         None

--- a/crates/youki/src/rootpath.rs
+++ b/crates/youki/src/rootpath.rs
@@ -1,6 +1,6 @@
 use anyhow::{bail, Result};
-use libcontainer::user_ns::rootless_required;
 use libcontainer::utils::create_dir_all_with_mode;
+use libcontainer::utils::rootless_required;
 use nix::libc;
 use nix::sys::stat::Mode;
 use nix::unistd::getuid;


### PR DESCRIPTION
This fixes various checks that we do with regard to root user, in order to make rootless containers work properly. 
Primarily, we not only check that the uid of user is 0, but along with that we also check the uid map file to see if available range is max. If the range is not, that means we are in a new user namespace, and thus might not be actual root user, and thus we should not do things that requires root user permissions. This is 2nd out of 3 PRs for making youki work with podman in rootless. Even though even with this PR youki still does not work with podman in rootless mode (as dbus connection is still incorrect), I have merged this branch with my dbus->zbus branch and tested that with correct dbus connection logic, youki works with podman in rootless context. The main validation for this right now is that this PR does not change/break any existing functionality.

---

A side note that I noticed while making this : not all logs and errors that we are generating are actually getting displayed when using youki. For example, as of now, we verify the binary before running the container, and error if it does not exist. However, the podman log simply errors out, not showing anything, whereas with runc proper log of missing executable is shown : 
```sh
# Youki
podman run --runtime $PWD/youki busybox /bin/bash
DEBUG youki: started by user 0 with ArgsOs { inner: ["...../youki/youki", "delete", "--force", "9c937d43d590695b71556382fd6d9f4baa51c9780c7969b94e7c7753ad542487"] }
DEBUG youki::commands::delete: start deleting 9c937d43d590695b71556382fd6d9f4baa51c9780c7969b94e7c7753ad542487
Error: container create failed (no logs from conmon): EOF
```

```sh
# runc
podman run --runtime runc busybox /bin/bash
Error: runc create failed: unable to start container process: exec: "/bin/bash": stat /bin/bash: no such file or directory: OCI runtime attempted to invoke a command that was not found
```

I'm pretty sure that we are generating similar error and propagating that upwards. This is similarly observed in actual `journalctl` logs (after always enabling them for debug in this PR) , that not all of tracing logs are shown. cCan this be because with namespace change that we do in intermediate/init process, those logs are not getting forwarded properly?