### PR TITLE
Doc test and justfile test target refactoring

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -101,7 +101,7 @@ jobs:
       - name: Add the permission to run
         run: chmod +x ./youki
       - name: Run integration tests
-        run: just oci-tests
+        run: just test-oci
 
   oci-validation-rust:
     runs-on: ubuntu-22.04

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,8 +22,8 @@ jobs:
         run: just youki-release
       - name: test
         # TODO(utam0k): The feature test needs nightly
-        # run: just unittest featuretest oci-tests
-        run: just unittest oci-tests
+        # run: just test-basic featuretest test-oci
+        run: just test-basic test-oci
 
   upload:
     name: Upload

--- a/README.md
+++ b/README.md
@@ -292,7 +292,7 @@ Go and node-tap are required to run integration tests. See the [opencontainers/r
 
 ```bash
 git submodule update --init --recursive
-just oci-tests
+just test-oci
 ```
 
 ### Setting up Vagrant

--- a/justfile
+++ b/justfile
@@ -34,10 +34,9 @@ test-oci: oci-tests rust-oci-tests
 # run all tests except rust-oci 
 test-all: unittest test-features oci-tests containerd-test # currently not doing rust-oci here
 
-# run cargo unittests
-unittest:
-    cd ./crates
-    LD_LIBRARY_PATH=${HOME}/.wasmedge/lib cargo test --all --all-targets --all-features
+# run cargo doc tests
+test-doc:
+    cargo test --doc
 
 # run permutated feature compilation tests
 test-features:

--- a/justfile
+++ b/justfile
@@ -29,10 +29,17 @@ rust-oci-tests-bin:
 # Tests
 
 # run oci tests
-test-oci: oci-tests rust-oci-tests
+test-oci: test-oci rust-oci-tests
 
 # run all tests except rust-oci 
-test-all: unittest test-features oci-tests containerd-test # currently not doing rust-oci here
+test-all: test-basic test-features oci-tests containerd-test # currently not doing rust-oci here
+
+# run basic tests
+test-basic: test-unit test-doc
+
+# run cargo unit tests
+test-unit:
+    cargo test --lib --bins --all --all-targets --all-features
 
 # run cargo doc tests
 test-doc:
@@ -47,7 +54,7 @@ test-musl:
     {{ cwd }}/scripts/musl_test.sh
 
 # run oci integration tests
-oci-tests: 
+test-oci: 
     {{ cwd }}/scripts/oci_integration_tests.sh {{ cwd }}
 
 # run rust oci integration tests
@@ -89,7 +96,7 @@ bin-kind:
 # Clean
 
 # Clean kind test env
-clean-test-kind:
+test-kind-clean:
 	kind delete cluster --name {{ KIND_CLUSTER_NAME }}
 
 # misc


### PR DESCRIPTION
- Separated doc test into a separated justfile recipe
- Refactor the name of the test related to recipe to follow the same pattern of `test-*`.