### PR TITLE
Update Migration Guide for 0.2.0 release

### DIFF
--- a/MirgationGuide.md
+++ b/MirgationGuide.md
@@ -8,12 +8,10 @@ This contains information for migrating library versions.
 
 - The `Rootless` struct has been re-named as `UserNamespaceConfig` , `RootlessIDMapper` has been re-named to `UserNamespaceIDMapper` , and correspondingly the `RootlessError` has been re-named to `UserNamespaceError` . This is due to the fact that the structure was to be used for containers when a new user namespace is to be created, and that is not strictly only for rootless uses. Accordingly, the fields of various structs has been updated to reflect this change :
   - rootless (module name) -> user_ns
-  - Rootless::rootless_id_mapper -> UserNamespaceConfig::id_mapper
+  - Rootless.rootless_id_mapper -> UserNamespaceConfig.id_mapper
   - LibcontainerError::Rootless -> LibcontainerError::UserNamespace
-  - ContainerBuilderImpl::rootless -> ContainerBuilderImpl::user_ns_config
-  - ContainerArgs::rootless -> ContainerArgs::user_ns_config
-
-- Changes that will occur for properly running in rootless mode : TODO (@YJDoc2)
+  - ContainerBuilderImpl.rootless -> ContainerBuilderImpl.user_ns_config
+  - ContainerArgs.rootless -> ContainerArgs.user_ns_config
 
 - Executor now contains 2 methods for implementation. We introduce a `validate` step in addition to execute. The `validate` should validate the input OCI spec. The step runs after all the namespaces are entered and rootfs is pivoted.
 


### PR DESCRIPTION
Removes the TODO for fixing podman that I had left, because that change is still WIP, and will not be released in 0.2.0 .