### PR TITLE
update nix to 0.27.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1747,7 +1747,7 @@ dependencies = [
  "flate2",
  "libcgroups",
  "libcontainer",
- "nix",
+ "nix 0.27.1",
  "num_cpus",
  "oci-spec",
  "once_cell",
@@ -1906,7 +1906,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75adb4021282a72ca63ebbc0e4247750ad74ede68ff062d247691072d709ad8b"
 dependencies = [
  "cc",
- "nix",
+ "nix 0.26.2",
  "num_cpus",
  "pkg-config",
 ]
@@ -1929,7 +1929,7 @@ dependencies = [
  "libbpf-sys",
  "libc",
  "mockall",
- "nix",
+ "nix 0.27.1",
  "oci-spec",
  "procfs",
  "quickcheck",
@@ -1955,7 +1955,7 @@ dependencies = [
  "libc",
  "libcgroups",
  "libseccomp",
- "nix",
+ "nix 0.27.1",
  "oci-spec",
  "once_cell",
  "prctl",
@@ -2236,6 +2236,18 @@ dependencies = [
  "memoffset 0.7.1",
  "pin-utils",
  "static_assertions",
+]
+
+[[package]]
+name = "nix"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
+dependencies = [
+ "bitflags 2.4.0",
+ "cfg-if",
+ "libc",
+ "memoffset 0.9.0",
 ]
 
 [[package]]
@@ -2613,7 +2625,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "059a34f111a9dee2ce1ac2826a68b24601c4298cfeb1a587c3cb493d5ab46f52"
 dependencies = [
  "libc",
- "nix",
+ "nix 0.26.2",
 ]
 
 [[package]]
@@ -3116,7 +3128,7 @@ name = "runtimetest"
 version = "0.0.1"
 dependencies = [
  "anyhow",
- "nix",
+ "nix 0.27.1",
  "oci-spec",
 ]
 
@@ -5737,7 +5749,7 @@ dependencies = [
  "libcgroups",
  "libcontainer",
  "liboci-cli",
- "nix",
+ "nix 0.27.1",
  "once_cell",
  "pentacle",
  "procfs",

--- a/crates/libcgroups/Cargo.toml
+++ b/crates/libcgroups/Cargo.toml
@@ -16,21 +16,21 @@ keywords = ["youki", "container", "cgroups"]
 default = ["v1", "v2", "systemd"]
 v1 = []
 v2 = []
-systemd = ["v2"]
-cgroupsv2_devices = ["rbpf", "libbpf-sys", "errno", "libc"]
+systemd = ["v2", "nix/socket", "nix/uio"]
+cgroupsv2_devices = ["rbpf", "libbpf-sys", "errno", "libc", "nix/dir"]
 
 [dependencies]
-nix = "0.26.2"
+nix = { version = "0.27.1", features = ["signal", "user", "fs"] }
 procfs = "0.15.1"
 oci-spec = { version = "~0.6.2", features = ["runtime"] }
 fixedbitset = "0.4.2"
 serde = { version = "1.0", features = ["derive"] }
-rbpf = {version = "0.2.0", optional = true }
+rbpf = { version = "0.2.0", optional = true }
 libbpf-sys = { version = "1.2.1", optional = true }
 errno = { version = "0.3.4", optional = true }
 libc = { version = "0.2.148", optional = true }
 thiserror = "1.0.49"
-tracing = { version = "0.1.37", features = ["attributes"]}
+tracing = { version = "0.1.37", features = ["attributes"] }
 
 [dev-dependencies]
 anyhow = "1.0"

--- a/crates/libcgroups/src/systemd/dbus_native/dbus.rs
+++ b/crates/libcgroups/src/systemd/dbus_native/dbus.rs
@@ -122,7 +122,7 @@ impl DbusConnection {
     /// Open a new dbus connection to given address
     /// authenticating as user with given uid
     pub fn new(addr: &str, uid: u32, system: bool) -> Result<Self> {
-        // Use ManuallyDrop to keep the socket open. 
+        // Use ManuallyDrop to keep the socket open.
         let socket = std::mem::ManuallyDrop::new(socket::socket(
             socket::AddressFamily::Unix,
             socket::SockType::Stream,

--- a/crates/libcgroups/src/systemd/dbus_native/dbus.rs
+++ b/crates/libcgroups/src/systemd/dbus_native/dbus.rs
@@ -7,7 +7,6 @@ use super::utils::{DbusError, Result, SystemdClientError};
 use nix::sys::socket;
 use std::collections::HashMap;
 use std::io::{IoSlice, IoSliceMut};
-use std::mem::ManuallyDrop;
 use std::os::fd::AsRawFd;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicU32, Ordering};
@@ -123,7 +122,8 @@ impl DbusConnection {
     /// Open a new dbus connection to given address
     /// authenticating as user with given uid
     pub fn new(addr: &str, uid: u32, system: bool) -> Result<Self> {
-        let socket = ManuallyDrop::new(socket::socket(
+        // Use ManuallyDrop to keep the socket open. 
+        let socket = std::mem::ManuallyDrop::new(socket::socket(
             socket::AddressFamily::Unix,
             socket::SockType::Stream,
             socket::SockFlag::empty(),

--- a/crates/libcontainer/Cargo.toml
+++ b/crates/libcontainer/Cargo.toml
@@ -22,23 +22,35 @@ cgroupsv2_devices = ["libcgroups/cgroupsv2_devices"]
 [dependencies]
 bitflags = "2.4.0"
 caps = "0.5.5"
-chrono = { version = "0.4", default-features = false, features = ["clock", "serde"] }
+chrono = { version = "0.4", default-features = false, features = [
+    "clock",
+    "serde",
+] }
 fastrand = "^2.0.1"
 futures = { version = "0.3", features = ["thread-pool"] }
 libc = "0.2.148"
-nix = "0.26.2"
+nix = { version = "0.27.1", features = [
+    "socket",
+    "sched",
+    "mount",
+    "mman",
+    "resource",
+    "dir",
+    "term",
+    "hostname",
+] }
 oci-spec = { version = "~0.6.2", features = ["runtime"] }
 once_cell = "1.18.0"
 procfs = "0.15.1"
 prctl = "1.0.0"
 libcgroups = { version = "0.2.0", path = "../libcgroups", default-features = false }
-libseccomp = { version = "0.3.0", optional=true }
+libseccomp = { version = "0.3.0", optional = true }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 rust-criu = "0.4.0"
 regex = "1.9.6"
 thiserror = "1.0.49"
-tracing = { version = "0.1.37", features = ["attributes"]}
+tracing = { version = "0.1.37", features = ["attributes"] }
 safe-path = "0.1.0"
 
 [dev-dependencies]

--- a/crates/libcontainer/src/channel.rs
+++ b/crates/libcontainer/src/channel.rs
@@ -216,6 +216,8 @@ fn unix_channel() -> Result<(RawFd, RawFd), ChannelError> {
         None,
         socket::SockFlag::SOCK_CLOEXEC,
     )?;
+    // It is not straightforward to share the OwnedFd across forks, so we 
+    // treat them as i32. We use ManuallyDrop to keep the connection open. 
     let f1 = std::mem::ManuallyDrop::new(f1);
     let f2 = std::mem::ManuallyDrop::new(f2);
 

--- a/crates/libcontainer/src/channel.rs
+++ b/crates/libcontainer/src/channel.rs
@@ -216,8 +216,8 @@ fn unix_channel() -> Result<(RawFd, RawFd), ChannelError> {
         None,
         socket::SockFlag::SOCK_CLOEXEC,
     )?;
-    // It is not straightforward to share the OwnedFd across forks, so we 
-    // treat them as i32. We use ManuallyDrop to keep the connection open. 
+    // It is not straightforward to share the OwnedFd across forks, so we
+    // treat them as i32. We use ManuallyDrop to keep the connection open.
     let f1 = std::mem::ManuallyDrop::new(f1);
     let f2 = std::mem::ManuallyDrop::new(f2);
 

--- a/crates/libcontainer/src/process/fork.rs
+++ b/crates/libcontainer/src/process/fork.rs
@@ -1,4 +1,4 @@
-use std::{ffi::c_int, num::NonZeroUsize};
+use std::{ffi::c_int, fs::File, num::NonZeroUsize};
 
 use libc::SIGCHLD;
 use nix::{
@@ -164,12 +164,14 @@ fn clone(cb: CloneCb, flags: u64, exit_signal: Option<u64>) -> Result<Pid, Clone
     // do not use MAP_GROWSDOWN since it is not well supported.
     // Ref: https://man7.org/linux/man-pages/man2/mmap.2.html
     let child_stack = unsafe {
-        mman::mmap(
+        // Since nix = "0.27.1", `mmap()` requires a generic type `F: AsFd`.
+        // `::<File>` doesn't have any meaning because we won't use it.
+        mman::mmap::<File>(
             None,
             NonZeroUsize::new(default_stack_size).ok_or(CloneError::ZeroStackSize)?,
             mman::ProtFlags::PROT_READ | mman::ProtFlags::PROT_WRITE,
             mman::MapFlags::MAP_PRIVATE | mman::MapFlags::MAP_ANONYMOUS | mman::MapFlags::MAP_STACK,
-            -1,
+            None,
             0,
         )
         .map_err(CloneError::StackAllocation)?

--- a/crates/libcontainer/src/syscall/linux.rs
+++ b/crates/libcontainer/src/syscall/linux.rs
@@ -13,6 +13,7 @@ use nix::{
 use oci_spec::runtime::LinuxRlimit;
 use std::ffi::{CStr, CString, OsStr};
 use std::fs;
+use std::os::fd::BorrowedFd;
 use std::os::unix::ffi::OsStrExt;
 use std::os::unix::fs::symlink;
 use std::os::unix::io::RawFd;
@@ -305,7 +306,8 @@ impl Syscall for LinuxSyscall {
 
     /// Set namespace for process
     fn set_ns(&self, rawfd: i32, nstype: CloneFlags) -> Result<()> {
-        nix::sched::setns(rawfd, nstype)?;
+        let fd = unsafe { BorrowedFd::borrow_raw(rawfd) };
+        nix::sched::setns(fd, nstype)?;
         Ok(())
     }
 

--- a/crates/libcontainer/src/tty.rs
+++ b/crates/libcontainer/src/tty.rs
@@ -81,7 +81,7 @@ pub fn setup_console_socket(
         linked: linked.to_path_buf().into(),
         console_socket_path: console_socket_path.to_path_buf().into(),
     })?;
-
+    // Using ManuallyDrop to keep the socket open.
     let csocketfd = std::mem::ManuallyDrop::new(
         socket::socket(
             socket::AddressFamily::Unix,
@@ -117,6 +117,7 @@ pub fn setup_console(console_fd: &RawFd) -> Result<()> {
     let iov = [IoSlice::new(pty_name)];
 
     let [master, slave] = [openpty_result.master, openpty_result.slave];
+    // Use ManuallyDrop to keep FDs open. 
     let master = std::mem::ManuallyDrop::new(master);
     let slave = std::mem::ManuallyDrop::new(slave);
 

--- a/crates/libcontainer/src/tty.rs
+++ b/crates/libcontainer/src/tty.rs
@@ -117,7 +117,7 @@ pub fn setup_console(console_fd: &RawFd) -> Result<()> {
     let iov = [IoSlice::new(pty_name)];
 
     let [master, slave] = [openpty_result.master, openpty_result.slave];
-    // Use ManuallyDrop to keep FDs open. 
+    // Use ManuallyDrop to keep FDs open.
     let master = std::mem::ManuallyDrop::new(master);
     let slave = std::mem::ManuallyDrop::new(slave);
 

--- a/crates/libcontainer/src/utils.rs
+++ b/crates/libcontainer/src/utils.rs
@@ -4,7 +4,6 @@ use std::collections::HashMap;
 use std::fs::{self, DirBuilder, File};
 use std::os::linux::fs::MetadataExt;
 use std::os::unix::fs::DirBuilderExt;
-use std::os::unix::prelude::AsRawFd;
 use std::path::{Component, Path, PathBuf};
 
 use nix::sys::stat::Mode;
@@ -249,7 +248,7 @@ pub fn ensure_procfs(path: &Path) -> Result<(), EnsureProcfsError> {
         tracing::error!(?err, ?path, "failed to open procfs file");
         err
     })?;
-    let fstat_info = statfs::fstatfs(&procfs_fd.as_raw_fd()).map_err(|err| {
+    let fstat_info = statfs::fstatfs(&procfs_fd).map_err(|err| {
         tracing::error!(?err, ?path, "failed to fstatfs the procfs");
         err
     })?;

--- a/crates/youki/Cargo.toml
+++ b/crates/youki/Cargo.toml
@@ -31,7 +31,7 @@ chrono = { version = "0.4", default-features = false, features = ["clock", "serd
 libcgroups = { version = "0.2.0", path = "../libcgroups", default-features = false }
 libcontainer = { version = "0.2.0", path = "../libcontainer", default-features = false }
 liboci-cli = { version = "0.2.0", path = "../liboci-cli" }
-nix = "0.26.2"
+nix = "0.27.1"
 once_cell = "1.18.0"
 pentacle = "1.0.0"
 procfs = "0.15.1"

--- a/tests/rust-integration-tests/integration_test/Cargo.toml
+++ b/tests/rust-integration-tests/integration_test/Cargo.toml
@@ -9,7 +9,7 @@ chrono = { version = "0.4", default-features = false, features = ["clock"] }
 flate2 = "1.0"
 libcgroups = { path = "../../../crates/libcgroups" }
 libcontainer = { path = "../../../crates/libcontainer" }
-nix = "0.26.2"
+nix = "0.27.1"
 num_cpus = "1.16"
 oci-spec = { version = "0.6.1", features = ["runtime"] }
 once_cell = "1.18.0"

--- a/tests/rust-integration-tests/integration_test/src/tests/seccomp_notify/seccomp_agent.rs
+++ b/tests/rust-integration-tests/integration_test/src/tests/seccomp_notify/seccomp_agent.rs
@@ -31,7 +31,7 @@ pub fn recv_seccomp_listener(seccomp_listener: &Path) -> SeccompAgentResult {
         None,
     )
     .context("failed to create seccomp listener socket")?;
-    let socket = socket;
+
     socket::bind(socket.as_raw_fd(), &addr).context("failed to bind to seccomp listener socket")?;
     // Force the backlog to be 1 so in the case of an error, only one connection
     // from clients will be waiting.

--- a/tests/rust-integration-tests/runtimetest/Cargo.toml
+++ b/tests/rust-integration-tests/runtimetest/Cargo.toml
@@ -5,6 +5,6 @@ edition = "2021"
 
 [dependencies]
 oci-spec = { version = "0.6.1", features = ["runtime"] }
-nix = "0.26.2"
+nix = "0.27.1"
 anyhow = "1.0"
 


### PR DESCRIPTION
I'm currently working on issue #2317.

**note: the following content is now outdated**

In the code changes I've made, there are two things that might raise questions:
1. The use of `std::mem::forget()`.
2. The use of an `unsafe` function `OwnedFd::from_raw_fd()`.

I use `forget()` because some functions in the `nix` library now return an `OwnedFd`. This helps avoid accidentally closing the file descriptor too soon by preventing its automatic drop. Maybe fully relying on `OwnedFd` to manage the fd's lifetime instead of manually calling close on RawFd is a better approach, but I think this could require quite a bit of code changes.

I also use `OwnedFd::from_raw_fd()` because of the `nix` library. The `nix::sched::setns()` function now requires an `Fd: AsFd` as one of its parameters, and I couldn't find a better way to convert an `i32` into `Fd: AsFd`.

Additionally, this is my first time contributing code to an open-source repository. If there are any important details I've missed, please let me know.