### PR TITLE
Add initial tests for rootless podman

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -127,3 +127,26 @@ jobs:
         run: just runtimetest rust-oci-tests-bin
       - name: Validate tests on youki
         run: just rust-oci-tests
+
+  rootless-podman-test:
+    runs-on: ubuntu-22.04
+    needs: [youki-build]
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: recursive
+      - name: Setup Rust toolchain and cache
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+      - name: Install just
+        uses: taiki-e/install-action@just
+      - name: Install requirements
+        run: sudo env PATH=$PATH just ci-prepare
+      - name: Download youki binary
+        uses: actions/download-artifact@v3
+        with:
+          name: youki
+      - name: Add the permission to run
+        run: chmod +x ./youki
+      - name: Run tests
+        run: just test-rootless-podman

--- a/justfile
+++ b/justfile
@@ -65,6 +65,11 @@ rust-oci-tests: youki-release runtimetest rust-oci-tests-bin
 validate-rust-oci-runc: runtimetest rust-oci-tests-bin
     {{ cwd }}/scripts/rust_integration_tests.sh runc
 
+# test podman rootless works with youki
+test-rootless-podman:
+    {{ cwd }}/tests/rootless-tests/run.sh {{ cwd }}/youki
+
+
 # run containerd integration tests
 containerd-test: youki-dev
     VAGRANT_VAGRANTFILE=Vagrantfile.containerd2youki vagrant up

--- a/tests/rootless-tests/run.sh
+++ b/tests/rootless-tests/run.sh
@@ -1,0 +1,18 @@
+# This is a temporary test-collection for validating youki runs correctly with podman in rootless mode
+# This will be moved to a proper rust based test crate, similar to rust-integration tests soon
+
+set -ex
+
+runtime=$1
+
+podman rm --force --ignore create-test # remove if existing
+
+podman create --runtime $runtime --name create-test hello-world
+log=$(podman start -a create-test)
+echo $log | grep "This message shows that your installation appears to be working correctly"
+podman rm create-test
+
+rand=$(head -c 10 /dev/random | base64)
+
+log=$(podman run --runtime $runtime fedora echo "$rand")
+echo $log | grep $rand


### PR DESCRIPTION
This adds a simple script for validating rootless podman works with youki, now that #2370 is merged. This is not a "proper" test, just a basic bash script which will error if any of the steps error out ; but I'm planning out a small refactoring of rust integration tests, and these tests will be easier to implement in rust once that is done. So  I'll be porting the script to proper crate once that is done. This, in the meantime, will make sure we don't accidentally regress the rootless support.