### PR TITLE
Add a `no-clone3` feature to disable `clone3`

### DIFF
--- a/crates/libcontainer/Cargo.toml
+++ b/crates/libcontainer/Cargo.toml
@@ -18,6 +18,7 @@ systemd = ["libcgroups/systemd", "v2"]
 v2 = ["libcgroups/v2"]
 v1 = ["libcgroups/v1"]
 cgroupsv2_devices = ["libcgroups/cgroupsv2_devices"]
+no-clone3 = []
 
 [dependencies]
 bitflags = "2.4.0"


### PR DESCRIPTION
This PR adds a `no-clone3` feature that disables the use of `clone3` in `libcontainer`.

This can be used to counteract the undefined behaviour introduced by using a raw `sysall` for `clone3`, which leads to problem in `musl` and on `glibc` when the main process uses threads.

See https://github.com/containerd/runwasi/issues/347