### PR TITLE
Use static build of wasmedge

### DIFF
--- a/crates/youki/Cargo.toml
+++ b/crates/youki/Cargo.toml
@@ -16,8 +16,9 @@ systemd = ["libcgroups/systemd", "libcontainer/systemd", "v2"]
 v2 = ["libcgroups/v2", "libcontainer/v2"]
 v1 = ["libcgroups/v1", "libcontainer/v1"]
 cgroupsv2_devices = ["libcgroups/cgroupsv2_devices", "libcontainer/cgroupsv2_devices"]
+
 wasm-wasmer = ["wasmer", "wasmer-wasix"]
-wasm-wasmedge = ["wasmedge-sdk/standalone"]
+wasm-wasmedge = ["wasmedge-sdk/standalone", "wasmedge-sdk/static"]
 wasm-wasmtime = ["wasmtime", "wasmtime-wasi"]
 
 [dependencies.clap]

--- a/docs/src/user/webassembly.md
+++ b/docs/src/user/webassembly.md
@@ -6,7 +6,7 @@ There are 3 things you need to do to run a WebAssembly module with youki.
 2. Build a container image with the WebAssembly module
 3. Run the container with youki
 
-## Build youki with `wasm-wasmedge` or `wasm-wasmer` feature flag enabled
+## Build youki with `wasm-wasmedge`, `wasm-wasmer`, or `wasm-wasmtime` feature flag enabled
 
 - Run `build.sh` with `-f wasm-wasmedge` option.
 
@@ -14,24 +14,16 @@ There are 3 things you need to do to run a WebAssembly module with youki.
     ./scripts/build.sh -o . -r -f wasm-wasmedge
     ```
 
-    > The `wasm-wasmedge` feature will install WasmEdge Runtime library in the `$HOME/.wasmedge` directory.
-    > To make the library available in your system, run the following command:
-    >
-    > ```bash
-    > export LD_LIBRARY_PATH=$HOME/.wasmedge/lib
-    > ```
-    >
-    > or
-    >
-    > ```bash
-    > source $HOME/.wasmedge/env
-    > ```
-    >
-
 - Run `build.sh` with `-f wasm-wasmer` option.
 
     ```bash
     ./scripts/build.sh -o . -r -f wasm-wasmer
+    ```
+
+- Run `build.sh` with `-f wasm-wasmtime` option.
+
+    ```bash
+    ./scripts/build.sh -o . -r -f wasm-wasmtime
     ```
 
 ## Build a container image with the WebAssembly module

--- a/justfile
+++ b/justfile
@@ -39,7 +39,7 @@ test-basic: test-unit test-doc
 
 # run cargo unit tests
 test-unit:
-    LD_LIBRARY_PATH=${HOME}/.wasmedge/lib cargo test --lib --bins --all --all-targets --all-features --no-fail-fast
+    cargo test --lib --bins --all --all-targets --all-features --no-fail-fast
 
 # run cargo doc tests
 test-doc:


### PR DESCRIPTION
WasmEdge supports static linking, which avoid having to use `LD_LIBRARY_PATH`.
This PR enables that feature.