### PR TITLE
Specify the protobuf crate because of the rust-criu crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1958,6 +1958,7 @@ dependencies = [
  "once_cell",
  "prctl",
  "procfs",
+ "protobuf",
  "quickcheck",
  "rand",
  "regex",

--- a/crates/libcontainer/Cargo.toml
+++ b/crates/libcontainer/Cargo.toml
@@ -48,6 +48,7 @@ libseccomp = { version = "0.3.0", optional = true }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 rust-criu = "0.4.0"
+protobuf = "= 3.2.0" # https://github.com/checkpoint-restore/rust-criu/issues/19
 regex = "1.10.2"
 thiserror = "1.0.50"
 tracing = { version = "0.1.40", features = ["attributes"] }


### PR DESCRIPTION
Workaround: https://github.com/checkpoint-restore/rust-criu/issues/19