### PR TITLE
Fix the config of the dependenda bot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,4 +10,5 @@ updates:
       - dependency-type: indirect
     groups:
       patch:
-        update-types: patch
+        update-types: 
+        - patch


### PR DESCRIPTION
              @utam0k It seems that `update-type` strictly requires an array, so check is failing on master : https://github.com/containers/youki/runs/18288323874

_Originally posted by @YJDoc2 in https://github.com/containers/youki/issues/2496#issuecomment-1790152216_
            