### PR TITLE
test(integration_test): port 'runtime-tools/validation/linux_seccomp'

### DIFF
--- a/tests/integration_test/src/main.rs
+++ b/tests/integration_test/src/main.rs
@@ -10,6 +10,7 @@ use crate::tests::linux_ns_itype::get_ns_itype_tests;
 use crate::tests::mounts_recursive::get_mounts_recursive_test;
 use crate::tests::pidfile::get_pidfile_test;
 use crate::tests::readonly_paths::get_ro_paths_test;
+use crate::tests::seccomp::get_seccomp_test;
 use crate::tests::seccomp_notify::get_seccomp_notify_test;
 use crate::tests::sysctl::get_sysctl_test;
 use crate::tests::tlb::get_tlb_test;
@@ -95,6 +96,7 @@ fn main() -> Result<()> {
     let cgroup_v1_memory = cgroups::memory::get_test_group();
     let cgroup_v1_network = cgroups::network::get_test_group();
     let cgroup_v1_blkio = cgroups::blkio::get_test_group();
+    let seccomp = get_seccomp_test();
     let seccomp_notify = get_seccomp_notify_test();
     let ro_paths = get_ro_paths_test();
     let hostname = get_hostname_test();
@@ -114,6 +116,7 @@ fn main() -> Result<()> {
     tm.add_test_group(Box::new(cgroup_v1_memory));
     tm.add_test_group(Box::new(cgroup_v1_network));
     tm.add_test_group(Box::new(cgroup_v1_blkio));
+    tm.add_test_group(Box::new(seccomp));
     tm.add_test_group(Box::new(seccomp_notify));
     tm.add_test_group(Box::new(ro_paths));
     tm.add_test_group(Box::new(hostname));

--- a/tests/integration_test/src/tests/mod.rs
+++ b/tests/integration_test/src/tests/mod.rs
@@ -8,6 +8,7 @@ pub mod linux_ns_itype;
 pub mod mounts_recursive;
 pub mod pidfile;
 pub mod readonly_paths;
+pub mod seccomp;
 pub mod seccomp_notify;
 pub mod sysctl;
 pub mod tlb;

--- a/tests/integration_test/src/tests/seccomp/mod.rs
+++ b/tests/integration_test/src/tests/seccomp/mod.rs
@@ -28,7 +28,6 @@ fn seccomp_test() -> TestResult {
     let spec = create_spec(
         LinuxSeccompBuilder::default()
             .default_action(LinuxSeccompAction::ScmpActAllow)
-            .architectures(vec![Arch::ScmpArchX86_64])
             .syscalls(vec![LinuxSyscallBuilder::default()
                 .names(vec![String::from("getcwd")])
                 .action(LinuxSeccompAction::ScmpActErrno)

--- a/tests/integration_test/src/tests/seccomp/mod.rs
+++ b/tests/integration_test/src/tests/seccomp/mod.rs
@@ -1,5 +1,5 @@
 use oci_spec::runtime::{
-    Arch, LinuxBuilder, LinuxSeccomp, LinuxSeccompAction, LinuxSeccompBuilder, LinuxSyscallBuilder,
+    LinuxBuilder, LinuxSeccomp, LinuxSeccompAction, LinuxSeccompBuilder, LinuxSyscallBuilder,
     ProcessBuilder, Spec, SpecBuilder,
 };
 use test_framework::{Test, TestGroup, TestResult};

--- a/tests/integration_test/src/tests/seccomp/mod.rs
+++ b/tests/integration_test/src/tests/seccomp/mod.rs
@@ -1,0 +1,49 @@
+use oci_spec::runtime::{
+    Arch, LinuxBuilder, LinuxSeccomp, LinuxSeccompAction, LinuxSeccompBuilder, LinuxSyscallBuilder,
+    ProcessBuilder, Spec, SpecBuilder,
+};
+use test_framework::{Test, TestGroup, TestResult};
+
+use crate::utils::test_inside_container;
+
+fn create_spec(seccomp: LinuxSeccomp) -> Spec {
+    SpecBuilder::default()
+        .linux(
+            LinuxBuilder::default()
+                .seccomp(seccomp)
+                .build()
+                .expect("error in building linux config"),
+        )
+        .process(
+            ProcessBuilder::default()
+                .args(vec!["runtimetest".to_string(), "seccomp".to_string()])
+                .build()
+                .expect("error in creating process config"),
+        )
+        .build()
+        .unwrap()
+}
+
+fn seccomp_test() -> TestResult {
+    let spec = create_spec(
+        LinuxSeccompBuilder::default()
+            .default_action(LinuxSeccompAction::ScmpActAllow)
+            .architectures(vec![Arch::ScmpArchX86_64])
+            .syscalls(vec![LinuxSyscallBuilder::default()
+                .names(vec![String::from("getcwd")])
+                .action(LinuxSeccompAction::ScmpActErrno)
+                .build()
+                .unwrap()])
+            .build()
+            .unwrap(),
+    );
+    test_inside_container(spec, &|_| Ok(()))
+}
+
+pub fn get_seccomp_test() -> TestGroup {
+    let mut test_group = TestGroup::new("seccomp");
+    let seccomp_test = Test::new("seccomp_test", Box::new(seccomp_test));
+    test_group.add(vec![Box::new(seccomp_test)]);
+
+    test_group
+}

--- a/tests/runtimetest/src/main.rs
+++ b/tests/runtimetest/src/main.rs
@@ -33,6 +33,7 @@ fn main() {
         "readonly_paths" => tests::validate_readonly_paths(&spec),
         "set_host_name" => tests::validate_hostname(&spec),
         "mounts_recursive" => tests::validate_mounts_recursive(&spec),
+        "seccomp" => tests::validate_seccomp(&spec),
         "sysctl" => tests::validate_sysctl(&spec),
         _ => eprintln!("error due to unexpected execute test name: {execute_test}"),
     }

--- a/tests/runtimetest/src/tests.rs
+++ b/tests/runtimetest/src/tests.rs
@@ -1,6 +1,7 @@
 use crate::utils::{self, test_read_access, test_write_access};
 use anyhow::{bail, Result};
 use nix::errno::Errno;
+use nix::unistd::getcwd;
 use oci_spec::runtime::Spec;
 use std::fs::{self, read_dir};
 use std::path::Path;
@@ -264,6 +265,21 @@ pub fn validate_mounts_recursive(spec: &Spec) {
                     }
                 }
             }
+        }
+    }
+}
+
+pub fn validate_seccomp(spec: &Spec) {
+    let linux = spec.linux().as_ref().unwrap();
+    if linux.seccomp().is_some() {
+        if let Err(errno) = getcwd() {
+            if errno != Errno::EPERM {
+                eprintln!("'getcwd()' failed with unexpected error code 'EPERM', found '{errno}'");
+            }
+        } else {
+            eprintln!(
+                "'getcwd()' syscall succeeded. It was expected to fail due to seccomp policies."
+            );
         }
     }
 }

--- a/tests/runtimetest/src/tests.rs
+++ b/tests/runtimetest/src/tests.rs
@@ -274,7 +274,7 @@ pub fn validate_seccomp(spec: &Spec) {
     if linux.seccomp().is_some() {
         if let Err(errno) = getcwd() {
             if errno != Errno::EPERM {
-                eprintln!("'getcwd()' failed with unexpected error code 'EPERM', found '{errno}'");
+                eprintln!("'getcwd()' failed with unexpected error code '{errno}', expected  'EPERM'");
             }
         } else {
             eprintln!(

--- a/tests/runtimetest/src/tests.rs
+++ b/tests/runtimetest/src/tests.rs
@@ -274,7 +274,9 @@ pub fn validate_seccomp(spec: &Spec) {
     if linux.seccomp().is_some() {
         if let Err(errno) = getcwd() {
             if errno != Errno::EPERM {
-                eprintln!("'getcwd()' failed with unexpected error code '{errno}', expected  'EPERM'");
+                eprintln!(
+                    "'getcwd()' failed with unexpected error code '{errno}', expected  'EPERM'"
+                );
             }
         } else {
             eprintln!(


### PR DESCRIPTION
#361

This pull request ports the [`runtime-tools/validation/linux_seccomp`](https://github.com/opencontainers/runtime-tools/blob/master/validation/linux_seccomp/linux_seccomp.go) test case to `tests/integration_test/src/tests/seccomp/mod.rs`.
