### PR TITLE
Fix emulated cgroups v1 subsystem when running docker-in-docker

### DIFF
--- a/crates/libcontainer/src/rootfs/mount.rs
+++ b/crates/libcontainer/src/rootfs/mount.rs
@@ -87,7 +87,7 @@ impl Mount {
                         panic!("libcontainer can't run in a Legacy or Hybrid cgroup setup without the v1 feature");
                         #[cfg(feature = "v1")]
                         self.mount_cgroup_v1(mount, options).map_err(|err| {
-                            tracing::error!("failed to mount cgroup v2: {}", err);
+                            tracing::error!("failed to mount cgroup v1: {}", err);
                             err
                         })?
                     }
@@ -171,10 +171,28 @@ impl Mount {
         tracing::debug!("cgroup mounts: {:?}", host_mounts);
 
         // get process cgroups
+        let ppid = std::os::unix::process::parent_id();
+        let ppid = if ppid == 0 { std::process::id() } else { ppid };
+        let root_cgroups = Process::new(ppid as i32)?.cgroups()?.0;
         let process_cgroups: HashMap<String, String> = Process::myself()?
             .cgroups()?
             .into_iter()
-            .map(|c| (c.controllers.join(","), c.pathname))
+            .map(|c| {
+                let hierarchy = c.hierarchy;
+                // When youki itself is running inside a container, the cgroup path
+                // will include the path of pid-1, which needs to be stripped before
+                // mounting.
+                let root_pathname = root_cgroups
+                    .iter()
+                    .find(|c| c.hierarchy == hierarchy)
+                    .map(|c| c.pathname.as_ref())
+                    .unwrap_or("");
+                let path = c
+                    .pathname
+                    .strip_prefix(root_pathname)
+                    .unwrap_or(&c.pathname);
+                (c.controllers.join(","), path.to_owned())
+            })
             .collect();
         tracing::debug!("Process cgroups: {:?}", process_cgroups);
 

--- a/crates/libcontainer/src/rootfs/mount.rs
+++ b/crates/libcontainer/src/rootfs/mount.rs
@@ -172,6 +172,7 @@ impl Mount {
 
         // get process cgroups
         let ppid = std::os::unix::process::parent_id();
+        // The non-zero ppid means that the PID Namespace is not separated.
         let ppid = if ppid == 0 { std::process::id() } else { ppid };
         let root_cgroups = Process::new(ppid as i32)?.cgroups()?.0;
         let process_cgroups: HashMap<String, String> = Process::myself()?

--- a/crates/youki/src/observability.rs
+++ b/crates/youki/src/observability.rs
@@ -80,7 +80,15 @@ where
     let journald = config.systemd_log;
 
     let systemd_journald = if journald {
-        Some(tracing_journald::layer()?.with_syslog_identifier("youki".to_string()))
+        match tracing_journald::layer() {
+            Ok(layer) => Some(layer.with_syslog_identifier("youki".to_string())),
+            Err(err) => {
+                // Do not fail if we can't open syslog, just print a warning.
+                // This is the case in, e.g., docker-in-docker.
+                eprintln!("failed to initialize syslog logging: {:?}", err);
+                None
+            }
+        }
     } else {
         None
     };


### PR DESCRIPTION
Fixes #2528.

Normally the pid-1 cgroup path is empty, but this is not the case when running inside a container.
This needs to be accounted on for the cgroups subsystem emulation.
This PR fixes the source of the mountpoints for the emulated cgroups subsystem by stripping the cgroup paths of pid-1 from the mountpoint source path.

I also makes the failure to setup tracing to syslog a warning instead of fatal, as that fails with the `docker` image used for _docker-in-docker_.

I would like to add testing for this based on the reproduction steps in #2528, but that would be better done by building `youki` as a static binary using `musl` (since the `docker` image is based on `alpine`). I would like to wait until we merge https://github.com/containers/youki/pull/2498 to add `musl` support and add a test.
