### PR TITLE
Support namespace path or mount_label or rootfs_propagation empty in json

### DIFF
--- a/crates/libcontainer/src/container/init_builder.rs
+++ b/crates/libcontainer/src/container/init_builder.rs
@@ -164,14 +164,16 @@ impl InitContainerBuilder {
 
         if let Some(process) = spec.process() {
             if let Some(profile) = process.apparmor_profile() {
-                let apparmor_is_enabled = apparmor::is_enabled().map_err(|err| {
-                    tracing::error!(?err, "failed to check if apparmor is enabled");
-                    LibcontainerError::OtherIO(err)
-                })?;
-                if !apparmor_is_enabled {
-                    tracing::error!(?profile,
+                if profile != "" {
+                    let apparmor_is_enabled = apparmor::is_enabled().map_err(|err| {
+                        tracing::error!(?err, "failed to check if apparmor is enabled");
+                        LibcontainerError::OtherIO(err)
+                    })?;
+                    if !apparmor_is_enabled {
+                        tracing::error!(?profile,
                         "apparmor profile exists in the spec, but apparmor is not activated on this system");
-                    Err(ErrInvalidSpec::AppArmorNotEnabled)?;
+                        Err(ErrInvalidSpec::AppArmorNotEnabled)?;
+                    }
                 }
             }
 

--- a/crates/libcontainer/src/rootfs/rootfs.rs
+++ b/crates/libcontainer/src/rootfs/rootfs.rs
@@ -45,7 +45,7 @@ impl RootFS {
         match linux.rootfs_propagation().as_deref() {
             Some("shared") => flags |= MsFlags::MS_SHARED,
             Some("private") => flags |= MsFlags::MS_PRIVATE,
-            Some("slave" | "unbindable") | None => flags |= MsFlags::MS_SLAVE,
+            Some("slave" | "unbindable" | "") | None => flags |= MsFlags::MS_SLAVE,
             Some(unknown) => {
                 return Err(RootfsError::UnknownRootfsPropagation(unknown.to_string()));
             }


### PR DESCRIPTION
If we use youki as crate, config.json maybe created by upper container engine not youki self, namespace path, apparmor_profile, mount_label or rootfs_propagation may be set to Some("") not None in config.json, but it should be treated same as None.