### PR TITLE
New Releases needs approval from the maintainer

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -60,6 +60,8 @@ jobs:
 
   release:
     name: Create Draft Release
+    environment:
+      name: release
     runs-on: ubuntu-20.04
     permissions:
       contents: write
@@ -89,6 +91,8 @@ jobs:
   publish:
     name: Publish Packages
     needs: build
+    environment:
+      name: release
     runs-on: ubuntu-20.04
     if: ${{ github.repository == 'containers/youki' }}
     env:


### PR DESCRIPTION
We have already introduced an automatic release workflow. But it leads to accidents. Now we merge https://github.com/containers/youki/pull/2582 and will start our release workflow.

I'd like to prevent it by reviewing the deployment flow.
https://docs.github.com/en/actions/managing-workflow-runs/reviewing-deployments