### PR TITLE
Fix the missed naming changes in integration test validation CI

### DIFF
--- a/.github/workflows/integration_tests_validation.yaml
+++ b/.github/workflows/integration_tests_validation.yaml
@@ -45,12 +45,12 @@ jobs:
         uses: taiki-e/install-action@just
       - name: Install requirements
         run: sudo env PATH=$PATH just ci-prepare
-      - name: Install runc 1.1.0
+      - name: Install runc 1.1.11
         run: |
-          wget -q https://github.com/opencontainers/runc/releases/download/v1.1.0/runc.amd64
+          wget -q https://github.com/opencontainers/runc/releases/download/v1.1.11/runc.amd64
           sudo mv runc.amd64 /usr/bin/runc
           sudo chmod 755 /usr/bin/runc
       - name: Build
-        run: just runtimetest rust-oci-tests-bin
+        run: just runtimetest contest
       - name: Validate tests on runc
-        run: just validate-rust-oci-runc
+        run: just validate-contest-runc

--- a/docs/src/developer/e2e/rust_oci_test.md
+++ b/docs/src/developer/e2e/rust_oci_test.md
@@ -1,4 +1,4 @@
-# rust oci tests
+# Contest
 
 This is youki's original integration to verify the behavior of the low-level container runtime.
 
@@ -7,7 +7,7 @@ This is youki's original integration to verify the behavior of the low-level con
 # How to run
 
 ```console
-just rust-oci-tests
+just test-contest
 ```
 
 # How to write

--- a/justfile
+++ b/justfile
@@ -59,7 +59,7 @@ test-contest: youki-release contest
 
 # validate rust oci integration tests on runc
 validate-contest-runc: contest
-    {{ cwd }}/scripts/rust_integration_tests.sh runc
+    {{ cwd }}/scripts/contest.sh runc
 
 # test podman rootless works with youki
 test-rootless-podman:


### PR DESCRIPTION
The name changes were missed for the validate-integration-test CI, so it started failing. This fixes that.