### PR TITLE
Add docker-in-docker e2e test

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -182,3 +182,27 @@ jobs:
         run: chmod +x ./youki
       - name: Run tests
         run: just test-rootless-podman
+  
+  docker-in-docker:
+    runs-on: ${{ matrix.os }}
+    needs: [youki-build]
+    timeout-minutes: 5
+    strategy:
+      matrix:
+        # ubuntu 20.04 has cgroups-v1
+        # ubuntu 22.04 has cgroups-v2
+        os: [ "ubuntu-22.04", "ubuntu-20.04" ]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install just
+        uses: taiki-e/install-action@just
+      - name: Download youki binary
+        uses: actions/download-artifact@v3
+        with:
+          name: youki-x86_64-musl
+      - name: Add the permission to run
+        run: chmod +x ./youki
+      - name: Run tests
+        run: just test-dind
+
+    

--- a/justfile
+++ b/justfile
@@ -65,6 +65,9 @@ validate-contest-runc: contest
 test-rootless-podman:
     {{ cwd }}/tests/rootless-tests/run.sh {{ cwd }}/youki
 
+# test docker-in-docker works with youki
+test-dind:
+    {{ cwd }}/tests/dind/run.sh
 
 # run containerd integration tests
 containerd-test: youki-dev

--- a/tests/dind/daemon.json
+++ b/tests/dind/daemon.json
@@ -1,0 +1,7 @@
+{
+  "runtimes": {
+    "youki": {
+      "path": "/usr/bin/youki"
+    }
+  }
+}

--- a/tests/dind/run.sh
+++ b/tests/dind/run.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -e
+
+ROOT=$(git rev-parse --show-toplevel)
+
+docker run --privileged -dq \
+  --name youki-test-dind \
+  -v $ROOT/youki:/usr/bin/youki \
+  -v $ROOT/tests/dind/daemon.json:/etc/docker/daemon.json \
+  docker:dind > /dev/null
+
+trap "docker rm -f youki-test-dind > /dev/null" EXIT
+
+# wait for docker to start
+timeout 30s \
+  grep -q -m1 "/var/run/docker.sock" \
+    <(docker logs -f youki-test-dind 2>&1)
+
+docker exec -i youki-test-dind \
+  docker run -q --runtime=youki hello-world


### PR DESCRIPTION
This PR adds tests to lock the behavior introduced by #2532.
It tests that youki can be used in docker-in-docker with both cgroups v1 (through Ubuntu 20.04) and v2 (through Ubuntu 22.04).