### PR TITLE
Re enable skipped e2e tests

### DIFF
--- a/justfile
+++ b/justfile
@@ -55,11 +55,11 @@ test-oci:
 
 # run rust oci integration tests
 test-contest: youki-release contest
-    {{ cwd }}/scripts/contest.sh {{ cwd }}/youki
+    sudo {{ cwd }}/scripts/contest.sh {{ cwd }}/youki
 
 # validate rust oci integration tests on runc
 validate-contest-runc: contest
-    {{ cwd }}/scripts/contest.sh runc
+    sudo RUNTIME_KIND="runc" {{ cwd }}/scripts/contest.sh runc
 
 # test podman rootless works with youki
 test-rootless-podman:

--- a/scripts/contest.sh
+++ b/scripts/contest.sh
@@ -24,7 +24,7 @@ if [ ! -f ${ROOT}/bundle.tar.gz ]; then
 fi
 touch ${LOGFILE}
 
-sudo ${ROOT}/contest run --runtime "$RUNTIME" --runtimetest ${ROOT}/runtimetest > $LOGFILE
+${ROOT}/contest run --runtime "$RUNTIME" --runtimetest ${ROOT}/runtimetest > $LOGFILE
 
 if [ 0 -ne $(grep "not ok" $LOGFILE | wc -l ) ]; then
     cat $LOGFILE

--- a/tests/contest/contest/src/main.rs
+++ b/tests/contest/contest/src/main.rs
@@ -103,11 +103,9 @@ fn main() -> Result<()> {
     let ro_paths = get_ro_paths_test();
     let hostname = get_hostname_test();
     let mounts_recursive = get_mounts_recursive_test();
-    #[allow(unused_variables)]
     let domainname = get_domainname_tests();
     let intel_rdt = get_intel_rdt_test();
     let sysctl = get_sysctl_test();
-    #[allow(unused_variables)]
     let scheduler = get_scheduler_test();
 
     tm.add_test_group(Box::new(cl));
@@ -127,10 +125,10 @@ fn main() -> Result<()> {
     tm.add_test_group(Box::new(ro_paths));
     tm.add_test_group(Box::new(hostname));
     tm.add_test_group(Box::new(mounts_recursive));
-    // tm.add_test_group(Box::new(domainname)); // TODO (YJDoc2) fix in #2616
+    tm.add_test_group(Box::new(domainname));
     tm.add_test_group(Box::new(intel_rdt));
     tm.add_test_group(Box::new(sysctl));
-    // tm.add_test_group(Box::new(scheduler));
+    tm.add_test_group(Box::new(scheduler));
 
     tm.add_cleanup(Box::new(cgroups::cleanup_v1));
     tm.add_cleanup(Box::new(cgroups::cleanup_v2));

--- a/tests/contest/contest/src/tests/domainname/mod.rs
+++ b/tests/contest/contest/src/tests/domainname/mod.rs
@@ -1,4 +1,4 @@
-use crate::utils::test_inside_container;
+use crate::utils::{is_runtime_runc, test_inside_container};
 use oci_spec::runtime::{ProcessBuilder, Spec, SpecBuilder};
 use test_framework::{ConditionalTest, TestGroup, TestResult};
 
@@ -27,10 +27,7 @@ pub fn get_domainname_tests() -> TestGroup {
     let mut tg = TestGroup::new("domainname_test");
     let set_domainname_test = ConditionalTest::new(
         "set_domainname_test",
-        Box::new(|| match std::env::var("RUNTIME_KIND") {
-            Err(_) => true,
-            Ok(s) => s != "runc",
-        }),
+        Box::new(|| !is_runtime_runc()),
         Box::new(set_domainname_test),
     );
     tg.add(vec![Box::new(set_domainname_test)]);

--- a/tests/contest/contest/src/tests/domainname/mod.rs
+++ b/tests/contest/contest/src/tests/domainname/mod.rs
@@ -1,6 +1,6 @@
 use crate::utils::test_inside_container;
 use oci_spec::runtime::{ProcessBuilder, Spec, SpecBuilder};
-use test_framework::{Test, TestGroup, TestResult};
+use test_framework::{ConditionalTest, TestGroup, TestResult};
 
 fn get_spec(domainname: &str) -> Spec {
     SpecBuilder::default()
@@ -25,7 +25,14 @@ fn set_domainname_test() -> TestResult {
 
 pub fn get_domainname_tests() -> TestGroup {
     let mut tg = TestGroup::new("domainname_test");
-    let set_domainname_test = Test::new("set_domainname_test", Box::new(set_domainname_test));
+    let set_domainname_test = ConditionalTest::new(
+        "set_domainname_test",
+        Box::new(|| match std::env::var("RUNTIME_KIND") {
+            Err(_) => true,
+            Ok(s) => s != "runc",
+        }),
+        Box::new(set_domainname_test),
+    );
     tg.add(vec![Box::new(set_domainname_test)]);
 
     tg

--- a/tests/contest/contest/src/tests/scheduler/scheduler_policy.rs
+++ b/tests/contest/contest/src/tests/scheduler/scheduler_policy.rs
@@ -4,7 +4,7 @@ use oci_spec::runtime::{
 };
 use test_framework::{test_result, ConditionalTest, TestGroup, TestResult};
 
-use crate::utils::test_inside_container;
+use crate::utils::{is_runtime_runc, test_inside_container};
 
 fn create_spec(policy: LinuxSchedulerPolicy, execute_test: &str) -> Result<Spec> {
     let sc = SchedulerBuilder::default()
@@ -48,18 +48,12 @@ pub fn get_scheduler_test() -> TestGroup {
     let mut scheduler_policy_group = TestGroup::new("set_scheduler_policy");
     let policy_fifo_test = ConditionalTest::new(
         "policy_other",
-        Box::new(|| match std::env::var("RUNTIME_KIND") {
-            Err(_) => true,
-            Ok(s) => s != "runc",
-        }),
+        Box::new(|| !is_runtime_runc()),
         Box::new(scheduler_policy_other_test),
     );
     let policy_rr_test = ConditionalTest::new(
         "policy_batch",
-        Box::new(|| match std::env::var("RUNTIME_KIND") {
-            Err(_) => true,
-            Ok(s) => s != "runc",
-        }),
+        Box::new(|| !is_runtime_runc()),
         Box::new(scheduler_policy_batch_test),
     );
 

--- a/tests/contest/contest/src/utils/mod.rs
+++ b/tests/contest/contest/src/utils/mod.rs
@@ -1,8 +1,8 @@
 pub mod support;
 pub mod test_utils;
 pub use support::{
-    generate_uuid, get_project_path, get_runtime_path, get_runtimetest_path, prepare_bundle,
-    set_config, set_runtime_path,
+    generate_uuid, get_project_path, get_runtime_path, get_runtimetest_path, is_runtime_runc,
+    prepare_bundle, set_config, set_runtime_path,
 };
 pub use test_utils::{
     create_container, delete_container, get_state, kill_container, test_inside_container,

--- a/tests/contest/contest/src/utils/support.rs
+++ b/tests/contest/contest/src/utils/support.rs
@@ -91,3 +91,10 @@ pub fn set_config<P: AsRef<Path>>(project_path: P, config: &Spec) -> Result<()> 
     config.save(path)?;
     Ok(())
 }
+
+pub fn is_runtime_runc() -> bool {
+    match std::env::var("RUNTIME_KIND") {
+        Err(_) => false,
+        Ok(s) => s == "runc",
+    }
+}


### PR DESCRIPTION
closes #2616 

There are some tests which are (for now) only supported by youki, and not by the latest release of runc. Instead of not running those tests, we instead check an env var to see what runtime we are running, and skip those for runc.