### PR TITLE
Address GHSA-xr7r-f8xq-vfvv

### DIFF
--- a/crates/libcontainer/src/process/container_init_process.rs
+++ b/crates/libcontainer/src/process/container_init_process.rs
@@ -844,6 +844,8 @@ fn sync_seccomp(
 fn verify_cwd() -> Result<()> {
     let cwd = unistd::getcwd().map_err(|err| {
         if let nix::errno::Errno::ENOENT = err {
+            // https://man7.org/linux/man-pages/man2/getcwd.2.html
+            // ENOENT The current working directory has been unlinked.
             InitProcessError::InvalidCwd(err)
         } else {
             InitProcessError::NixOther(err)
@@ -855,7 +857,7 @@ fn verify_cwd() -> Result<()> {
         return Err(InitProcessError::InvalidCwd(nix::errno::Errno::ENOENT));
     }
 
-    return Ok(());
+    Ok(())
 }
 
 #[cfg(test)]

--- a/crates/libcontainer/src/process/container_init_process.rs
+++ b/crates/libcontainer/src/process/container_init_process.rs
@@ -81,6 +81,8 @@ pub enum InitProcessError {
     IoPriorityClass(String),
     #[error("call exec sched_setattr error: {0}")]
     SchedSetattr(String),
+    #[error("failed to verify if current working directory is safe")]
+    InvalidCwd(#[source] nix::Error),
 }
 
 type Result<T> = std::result::Result<T, InitProcessError>;
@@ -548,6 +550,12 @@ pub fn container_init_process(
         })?;
     }
 
+    // Ensure that the current working directory is actually inside the container.
+    verify_cwd().map_err(|err| {
+        tracing::error!(?err, "failed to verify cwd");
+        err
+    })?;
+
     // add HOME into envs if not exists
     let home_in_envs = envs.iter().any(|x| x.starts_with("HOME="));
     if !home_in_envs {
@@ -828,6 +836,26 @@ fn sync_seccomp(
     }
 
     Ok(())
+}
+
+// verifyCwd ensures that the current directory is actually inside the mount
+// namespace root of the current process.
+// Please refer to XXXXXXX(TODO(utam0k): fill in) for more details.
+fn verify_cwd() -> Result<()> {
+    let cwd = unistd::getcwd().map_err(|err| {
+        if let nix::errno::Errno::ENOENT = err {
+            InitProcessError::InvalidCwd(err)
+        } else {
+            InitProcessError::NixOther(err)
+        }
+    })?;
+
+    if !cwd.is_absolute() {
+        // This should never happen, but just in case.
+        return Err(InitProcessError::InvalidCwd(nix::errno::Errno::ENOENT));
+    }
+
+    return Ok(());
 }
 
 #[cfg(test)]


### PR DESCRIPTION
https://github.com/opencontainers/runc/security/advisories/GHSA-xr7r-f8xq-vfvv
> youki 0.3.1 does not leak any useful file descriptors into the runc init-equivalent process (so this attack is not exploitable as far as we can tell) however this appears to be pure luck. youki does leak a directory file descriptor from the host mount namespace, but it just so happens that the directory is the rootfs of the container (which then gets pivot_root'd into and so ends up as a in-root path thanks to chroot_fs_refs). In addition, no care is taken to make sure all non-stdio files are O_CLOEXEC and there is no check after chdir(2) to ensure the working directory is inside the container. If a file descriptor happened to be leaked in the future, this could be exploitable. In addition, any file descriptors passed to youki are not closed until the container process is executed, meaning that easily-overlooked programming errors by users of youki can lead to these attacks becoming exploitable.

This PR has already been approved by @jprendes @rumpl @yihuaf in private repository.