### PR TITLE
Set '--test-threads' option to 1 in unit tests

### DIFF
--- a/justfile
+++ b/justfile
@@ -39,11 +39,11 @@ test-basic: test-unit test-doc
 
 # run cargo unit tests
 test-unit:
-    {{ cwd }}/scripts/cargo.sh test --lib --bins --all --all-targets --all-features --no-fail-fast
+    {{ cwd }}/scripts/cargo.sh test --lib --bins --all --all-targets --all-features --no-fail-fast -- --test-threads=1
 
 # run cargo doc tests
 test-doc:
-    {{ cwd }}/scripts/cargo.sh test --doc
+    {{ cwd }}/scripts/cargo.sh test --doc -- --test-threads=1
 
 # run permutated feature compilation tests
 test-features:


### PR DESCRIPTION
Another try at https://github.com/containers/youki/pull/2615 and #2144 
 
done with ref https://github.com/containers/youki/pull/2615#issuecomment-1882697445

Instead of splitting the tests by configs, tried setting the number of test threads to 1, so the tests are always run one at a time. There is no considerable change in time, the basic check CI (whole) takes about 5-6 minutes now instead of 3 minutes previously. I ran it 10 times, and it didn't fail in any attempt : https://github.com/YJDoc2/youki/actions/workflows/basic.yml?query=branch%3Atests%2Ffix-for-2144-v2

This is a much simpler solution for the issue, and as mentioned in original problem, the root cause comes from tests running in multiple threads, and should not occur in actual use ; so doing this seems a better option than code changes, if this works.