### PR TITLE
(fix) podman e2e : Update workflow for new required deps, add vagrantfile

### DIFF
--- a/.github/workflows/podman_tests.yaml
+++ b/.github/workflows/podman_tests.yaml
@@ -9,18 +9,27 @@ jobs:
   podman-tests:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install just
         uses: taiki-e/install-action@just
       - name: Install requirements
         run: sudo env PATH=$PATH just ci-prepare
+      
       - name: Install skopeo and podman requirements
-        run: sudo apt-get install -y pkg-config libsystemd-dev libelf-dev libseccomp-dev libgpgme-dev libassuan-dev libbtrfs-dev libdevmapper-dev bats socat
+        run: |
+          sudo apt-get install -y pkg-config libsystemd-dev libelf-dev libseccomp-dev libgpgme-dev libassuan-dev libbtrfs-dev libdevmapper-dev bats socat protobuf-compiler jq conmon
+          cargo install netavark aardvark-dns
+      
+      - name: Copy binaries
+        run: |
+          sudo mkdir -p /usr/local/lib/podman
+          sudo cp $(which netavark) /usr/local/lib/podman && sudo cp $(which netavark)-dhcp-proxy-client /usr/local/lib/podman && sudo cp $(which aardvark-dns) /usr/local/lib/podman
       
       # setup go
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@v5
         with:
           go-version: '1.20'
+          cache: false
       
       # build skopeo
       # These build steps are taken from https://github.com/containers/skopeo/issues/1648#issuecomment-1132161659

--- a/Vagrantfile.podmane2e
+++ b/Vagrantfile.podmane2e
@@ -1,0 +1,69 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+GO_VERSION = "1.20.12"
+PODMAN_BRANCH = "main"
+SKOPEO_VERSION = "1.13.1"
+
+Vagrant.configure("2") do |config|
+    config.vm.box = "generic/ubuntu2204"
+    config.vm.synced_folder '.', '/vagrant/youki', disabled: false
+
+    config.vm.provider "virtualbox" do |v|
+      v.memory = 8192
+      v.cpus = 8
+    end
+
+    config.vm.provision "bootstrap", type: "shell" do |s|
+      s.inline = <<-SHELL
+        set -e -u -o pipefail
+        export DEBIAN_FRONTEND=noninteractive
+        apt-get update && apt-get install -y \
+          make \
+          pkg-config         \
+          libsystemd-dev     \
+          libdbus-glib-1-dev \
+          build-essential    \
+          libelf-dev \
+          libseccomp-dev \
+          libbtrfs-dev \
+          btrfs-progs \
+          libgpgme-dev \
+          libassuan-dev \
+          libdevmapper-dev \
+          bats \
+          socat \
+          jq \
+          conmon \
+          protobuf-compiler
+
+        wget --quiet https://go.dev/dl/go#{GO_VERSION}.linux-amd64.tar.gz -O /tmp/go#{GO_VERSION}.linux-amd64.tar.gz
+        rm -rf /usr/local/go && tar -C /usr/local -xzf /tmp/go#{GO_VERSION}.linux-amd64.tar.gz
+        echo "export PATH=$PATH:/usr/local/go/bin" >> ~/.bashrc
+        echo "export GOPATH=$HOME/go" >> ~/.bashrc
+        export PATH=$PATH:$HOME/.cargo/bin:/usr/local/go/bin
+        export GOPATH=$HOME/go
+
+        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+        source "$HOME/.cargo/env"
+        cargo install netavark aardvark-dns
+        mkdir -p /usr/local/lib/podman
+        sudo cp $(which netavark) /usr/local/lib/podman/
+        sudo cp $(which netavark)-dhcp-proxy-client /usr/local/lib/podman/
+        sudo cp $(which aardvark-dns) /usr/local/lib/podman/
+
+        mkdir /tmp/skopeo 
+        curl -fsSL "https://github.com/containers/skopeo/archive/v#{SKOPEO_VERSION}.tar.gz" | tar -xzf - -C /tmp/skopeo --strip-components=1
+        cd /tmp/skopeo && DISABLE_DOCS=1 make
+        sudo mkdir /etc/containers && sudo cp /tmp/skopeo/bin/skopeo /usr/local/bin/skopeo && sudo cp /tmp/skopeo/default-policy.json /etc/containers/policy.json
+
+        git clone https://github.com/containers/podman /vagrant/podman -b #{PODMAN_BRANCH}
+        
+        cd /vagrant/podman && make binaries install.tools
+
+        rm -rf /bin/runc /sbin/runc /usr/sbin/runc /usr/bin/runc
+
+        cp /vagrant/youki/youki /usr/bin/runc
+      SHELL
+    end
+end


### PR DESCRIPTION
With some recent changes in how podman repo runs its e2e, and deps that are needed by latest main branch, our podman e2e CI are failing all its tests due to missing deps from about a week.

This PR updates the CI to include the missing deps, and also adds a vagrant file that allows running those tests locally without having to change host system, like we have for containerd e2e.

Someone please also verify that vagrantfile works , as even though I have tested it, I had run it iteratively, so could have possibly missed some changes that I did manually. As long as the `VAGRANT_VAGRANTFILE=Vagrantfile.podmane2e vagrant up` command runs without any error, it should be ok. Note that the go download is expected to take some time, so there would not be any logs while that is running due to `--quiet` flag.

Thanks!

EDIT : I ran the podman e2e on this branch in my repo, and it shows the same number of failed test, as there were before all tests started failing : https://github.com/YJDoc2/youki/actions/runs/7942453846