### PR TITLE
config.vm.box changed to centos/7

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,7 +2,7 @@
 # vi: set ft=ruby :
 
 Vagrant.configure("2") do |config|
-    config.vm.box = "fedora/33-cloud-base"
+    config.vm.box = "centos/7"
     config.vm.synced_folder '.', '/vagrant', disabled: true
 
     config.vm.provider "virtualbox" do |v|


### PR DESCRIPTION
Issue link is https://github.com/containers/youki/issues/2693

changed config.vm.box from fedora/33-cloud-base to centos/7

It seems to worked.

![image](https://github.com/containers/youki/assets/68362169/b2c39f7d-74c6-4d41-af67-b37b19eec379)

![image](https://github.com/containers/youki/assets/68362169/2607a838-1094-4d88-98fd-233fe8701b69)

Please ignore if you don't need it.