### PR TITLE
Add missed test-threads=1 to coverage CI

### DIFF
--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -106,7 +106,7 @@ jobs:
       - name: Run Test Coverage for youki
         run: |
           cargo llvm-cov clean --workspace
-          cargo llvm-cov --no-report
+          cargo llvm-cov --no-report -- --test-threads=1
           cargo llvm-cov --no-run --lcov --output-path ./coverage.lcov
       - name: Upload Youki Code Coverage Results
         uses: codecov/codecov-action@v3

--- a/scripts/features_test.sh
+++ b/scripts/features_test.sh
@@ -23,7 +23,7 @@ test_package_features "libcgroups" "systemd cgroupsv2_devices"
 test_features() {
     echo "[feature test] testing features $1"
     "$CARGO_SH" build --no-default-features --features "$1"
-    "$CARGO_SH" test run --no-default-features --features "$1"
+    "$CARGO_SH" test run --no-default-features --features "$1" -- --test-threads=1
 }
 
 test_features "v1"


### PR DESCRIPTION
In #2685 I missed adding the test threads option to the coverage CI, due to which it still occasionally times out and fails. This adds that.

Also added in feature test script for uniformity, even though those are not failing