### PR TITLE
Improve error reporting and logging

### DIFF
--- a/crates/libcgroups/src/common.rs
+++ b/crates/libcgroups/src/common.rs
@@ -27,14 +27,16 @@ pub const DEFAULT_CGROUP_ROOT: &str = "/sys/fs/cgroup";
 
 #[cfg(feature = "systemd")]
 #[inline]
-fn is_true_root() -> bool {
+fn is_true_root() -> Result<bool, WrappedIoError> {
     if !nix::unistd::geteuid().is_root() {
-        return false;
+        return Ok(false);
     }
     let uid_map_path = "/proc/self/uid_map";
-    let content = std::fs::read_to_string(uid_map_path)
-        .unwrap_or_else(|_| panic!("failed to read {}", uid_map_path));
-    content.contains("4294967295")
+    let content = std::fs::read_to_string(uid_map_path).map_err(|e| WrappedIoError::Read {
+        err: e,
+        path: uid_map_path.into(),
+    })?;
+    Ok(content.contains("4294967295"))
 }
 pub trait CgroupManager {
     type Error;
@@ -423,7 +425,7 @@ fn create_systemd_cgroup_manager(
         );
     }
 
-    let use_system = is_true_root();
+    let use_system = is_true_root().map_err(systemd::manager::SystemdManagerError::WrappedIo)?;
 
     tracing::info!(
         "systemd cgroup manager with system bus {} will be used",

--- a/crates/libcgroups/src/stats.rs
+++ b/crates/libcgroups/src/stats.rs
@@ -216,6 +216,8 @@ pub fn supported_page_sizes() -> Result<Vec<String>, SupportedPageSizesError> {
         }
 
         let dir_name = hugetlb_entry.file_name();
+        // this name should always be valid utf-8,
+        // so can unwrap without any checks
         let dir_name = dir_name.to_str().unwrap();
 
         sizes.push(extract_page_size(dir_name)?);

--- a/crates/libcgroups/src/systemd/dbus_native/message.rs
+++ b/crates/libcgroups/src/systemd/dbus_native/message.rs
@@ -188,7 +188,7 @@ impl Header {
                     .into());
                 }
                 let ret = HeaderValue::U32(u32::from_le_bytes(
-                    buf[*ctr..*ctr + 4].try_into().unwrap(), // we ca unwrap here as we know 4 byte buffer will satisfy [u8;4]
+                    buf[*ctr..*ctr + 4].try_into().unwrap(), // we can unwrap here as we know 4 byte buffer will satisfy [u8;4]
                 ));
                 *ctr += 4;
                 ret

--- a/crates/libcgroups/src/systemd/dbus_native/utils.rs
+++ b/crates/libcgroups/src/systemd/dbus_native/utils.rs
@@ -40,6 +40,8 @@ pub enum DbusError {
     MethodCallErr(String),
     #[error("dbus bus address error: {0}")]
     BusAddressError(String),
+    #[error("dbus busctl error")]
+    BusctlError(String),
     #[error("could not parse uid from busctl: {0}")]
     UidError(ParseIntError),
 }

--- a/crates/libcgroups/src/v1/manager.rs
+++ b/crates/libcgroups/src/v1/manager.rs
@@ -105,7 +105,7 @@ impl Manager {
             .cgroups()?
             .into_iter()
             .find(|c| c.controllers.contains(&subsystem.to_string()))
-            .unwrap();
+            .ok_or(V1ManagerError::SubsystemDoesNotExist)?;
 
         let p = if cgroup_path.as_os_str().is_empty() {
             mount_point.join_safely(Path::new(&cgroup.pathname))?
@@ -246,7 +246,9 @@ impl CgroupManager for Manager {
         };
         Ok(Freezer::apply(
             &controller_opt,
-            self.subsystems.get(&CtrlType::Freezer).unwrap(),
+            self.subsystems
+                .get(&CtrlType::Freezer)
+                .ok_or(V1ManagerError::SubsystemDoesNotExist)?,
         )?)
     }
 

--- a/crates/libcgroups/src/v2/io.rs
+++ b/crates/libcgroups/src/v2/io.rs
@@ -127,10 +127,12 @@ impl Io {
     fn apply(root_path: &Path, blkio: &LinuxBlockIo) -> Result<(), V2IoControllerError> {
         if let Some(weight_device) = blkio.weight_device() {
             for wd in weight_device {
-                common::write_cgroup_file(
-                    root_path.join(CGROUP_BFQ_IO_WEIGHT),
-                    format!("{}:{} {}", wd.major(), wd.minor(), wd.weight().unwrap()),
-                )?;
+                if let Some(weight) = wd.weight() {
+                    common::write_cgroup_file(
+                        root_path.join(CGROUP_BFQ_IO_WEIGHT),
+                        format!("{}:{} {}", wd.major(), wd.minor(), weight),
+                    )?;
+                }
             }
         }
         if let Some(leaf_weight) = blkio.leaf_weight() {

--- a/crates/libcontainer/src/container/builder_impl.rs
+++ b/crates/libcontainer/src/container/builder_impl.rs
@@ -129,7 +129,12 @@ impl ContainerBuilderImpl {
         // ourselves to be non-dumpable only breaks things (like rootless
         // containers), which is the recommendation from the kernel folks.
         if linux.namespaces().is_some() {
-            prctl::set_dumpable(false).unwrap();
+            prctl::set_dumpable(false).map_err(|e| {
+                LibcontainerError::Other(format!(
+                    "error in setting dumpable to false : {}",
+                    nix::errno::from_i32(e)
+                ))
+            })?;
         }
 
         // This container_args will be passed to the container processes,

--- a/crates/libcontainer/src/container/container_kill.rs
+++ b/crates/libcontainer/src/container/container_kill.rs
@@ -57,7 +57,9 @@ impl Container {
 
     fn kill_one_process<S: Into<Signal>>(&self, signal: S) -> Result<(), LibcontainerError> {
         let signal = signal.into().into_raw();
-        let pid = self.pid().unwrap();
+        let pid = self.pid().ok_or(LibcontainerError::Other(
+            "container process pid not found in state".into(),
+        ))?;
 
         tracing::debug!("kill signal {} to {}", signal, pid);
 

--- a/crates/libcontainer/src/container/mod.rs
+++ b/crates/libcontainer/src/container/mod.rs
@@ -20,4 +20,5 @@ pub mod state;
 pub mod tenant_builder;
 pub use container::CheckpointOptions;
 pub use container::Container;
+pub use container_checkpoint::CheckpointError;
 pub use state::{ContainerProcessState, ContainerStatus, State};

--- a/crates/libcontainer/src/container/tenant_builder.rs
+++ b/crates/libcontainer/src/container/tenant_builder.rs
@@ -321,13 +321,11 @@ impl TenantContainerBuilder {
             process_builder.build()?
         };
 
-        if container.pid().is_none() {
-            return Err(LibcontainerError::Other(
-                "could not retrieve container init pid".into(),
-            ));
-        }
+        let container_pid = container.pid().ok_or(LibcontainerError::Other(
+            "could not retrieve container init pid".into(),
+        ))?;
 
-        let init_process = procfs::process::Process::new(container.pid().unwrap().as_raw())?;
+        let init_process = procfs::process::Process::new(container_pid.as_raw())?;
         let ns = self.get_namespaces(init_process.namespaces()?.0)?;
         let linux = LinuxBuilder::default().namespaces(ns).build()?;
 

--- a/crates/libcontainer/src/error.rs
+++ b/crates/libcontainer/src/error.rs
@@ -60,6 +60,8 @@ pub enum LibcontainerError {
     CgroupCreate(#[from] libcgroups::common::CreateCgroupSetupError),
     #[error(transparent)]
     CgroupGet(#[from] libcgroups::common::GetCgroupSetupError),
+    #[error[transparent]]
+    Checkpoint(#[from] crate::container::CheckpointError),
 
     // Catch all errors that are not covered by the above
     #[error("syscall error")]

--- a/crates/libcontainer/src/notify_socket.rs
+++ b/crates/libcontainer/src/notify_socket.rs
@@ -65,6 +65,7 @@ impl NotifyListener {
         })?;
         let stream = UnixListener::bind(socket_name).map_err(|e| NotifyListenerError::Bind {
             source: e,
+            // ok to unwrap here as OsStr should always be utf-8 compatible
             name: socket_name.to_str().unwrap().to_owned(),
         })?;
         unistd::chdir(&cwd).map_err(|e| NotifyListenerError::Chdir {
@@ -142,6 +143,7 @@ impl NotifySocket {
         let mut stream =
             UnixStream::connect(socket_name).map_err(|e| NotifyListenerError::Connect {
                 source: e,
+                // ok to unwrap as OsStr should always be utf-8 compatible
                 name: socket_name.to_str().unwrap().to_owned(),
             })?;
         stream

--- a/crates/libcontainer/src/process/channel.rs
+++ b/crates/libcontainer/src/process/channel.rs
@@ -173,6 +173,10 @@ impl MainReceiver {
             })?;
         match msg {
             Message::InitReady => Ok(()),
+            // this case in unique and known enough to have a special error format
+            Message::ExecFailed(err) => Err(ChannelError::ExecError(format!(
+                "error in executing process : {err}"
+            ))),
             msg => Err(ChannelError::UnexpectedMessage {
                 expected: Message::InitReady,
                 received: msg,

--- a/crates/libcontainer/src/process/container_init_process.rs
+++ b/crates/libcontainer/src/process/container_init_process.rs
@@ -323,8 +323,8 @@ pub fn container_init_process(
             })?;
         }
 
-        let bind_service =
-            namespaces.get(LinuxNamespaceType::User)?.is_some() || utils::is_in_new_userns();
+        let in_user_ns = utils::is_in_new_userns().map_err(InitProcessError::Io)?;
+        let bind_service = namespaces.get(LinuxNamespaceType::User)?.is_some() || in_user_ns;
         let rootfs = RootFS::new();
         rootfs
             .prepare_rootfs(
@@ -355,11 +355,10 @@ pub fn container_init_process(
             })?;
         }
 
-        // As we have chagned the root mount, from here on
+        // As we have changed the root mount, from here on
         // logs are no longer visible in journalctl
         // so make sure that you bubble up any errors
-        // and do not call unwrap as any panics would not be correctly logged
-
+        // and do not call unwrap() as any panics would not be correctly logged
 
         rootfs.adjust_root_mount_propagation(linux).map_err(|err| {
             tracing::error!(?err, "failed to adjust root mount propagation");
@@ -791,6 +790,8 @@ fn setup_scheduler(sc_op: &Option<Scheduler>) -> Result<()> {
             }
         }
         let mut a = nc::sched_attr_t {
+            // size of the structure should always be within u32 bounds,
+            // so this unwrap should never fail
             size: mem::size_of::<nc::sched_attr_t>().try_into().unwrap(),
             sched_policy: policy,
             sched_flags: flags_value,

--- a/crates/libcontainer/src/process/container_init_process.rs
+++ b/crates/libcontainer/src/process/container_init_process.rs
@@ -355,6 +355,12 @@ pub fn container_init_process(
             })?;
         }
 
+        // As we have chagned the root mount, from here on
+        // logs are no longer visible in journalctl
+        // so make sure that you bubble up any errors
+        // and do not call unwrap as any panics would not be correctly logged
+
+
         rootfs.adjust_root_mount_propagation(linux).map_err(|err| {
             tracing::error!(?err, "failed to adjust root mount propagation");
             InitProcessError::RootFS(err)

--- a/crates/libcontainer/src/process/container_intermediate_process.rs
+++ b/crates/libcontainer/src/process/container_intermediate_process.rs
@@ -29,6 +29,8 @@ pub enum IntermediateProcessError {
     ExecNotify(#[source] nix::Error),
     #[error(transparent)]
     MissingSpec(#[from] crate::error::MissingSpecError),
+    #[error("other error")]
+    Other(String),
 }
 
 type Result<T> = std::result::Result<T, IntermediateProcessError>;
@@ -45,8 +47,8 @@ pub fn container_intermediate_process(
     let spec = &args.spec;
     let linux = spec.linux().as_ref().ok_or(MissingSpecError::Linux)?;
     let namespaces = Namespaces::try_from(linux.namespaces().as_ref())?;
-    let cgroup_manager =
-        libcgroups::common::create_cgroup_manager(args.cgroup_config.to_owned()).unwrap();
+    let cgroup_manager = libcgroups::common::create_cgroup_manager(args.cgroup_config.to_owned())
+        .map_err(|e| IntermediateProcessError::Cgroup(e.to_string()))?;
 
     // this needs to be done before we create the init process, so that the init
     // process will already be captured by the cgroup. It also needs to be done
@@ -201,7 +203,12 @@ fn setup_userns(
     tracing::debug!("creating new user namespace");
     // child needs to be dumpable, otherwise the non root parent is not
     // allowed to write the uid/gid maps
-    prctl::set_dumpable(true).unwrap();
+    prctl::set_dumpable(true).map_err(|e| {
+        IntermediateProcessError::Other(format!(
+            "error in setting dumpable to true : {}",
+            nix::errno::from_i32(e)
+        ))
+    })?;
     sender.identifier_mapping_request().map_err(|err| {
         tracing::error!("failed to send id mapping request: {}", err);
         err
@@ -210,7 +217,12 @@ fn setup_userns(
         tracing::error!("failed to receive id mapping ack: {}", err);
         err
     })?;
-    prctl::set_dumpable(false).unwrap();
+    prctl::set_dumpable(false).map_err(|e| {
+        IntermediateProcessError::Other(format!(
+            "error in setting dumplable to false : {}",
+            nix::errno::from_i32(e)
+        ))
+    })?;
     Ok(())
 }
 

--- a/crates/libcontainer/src/process/intel_rdt.rs
+++ b/crates/libcontainer/src/process/intel_rdt.rs
@@ -161,27 +161,27 @@ fn combine_l3_cache_and_mem_bw_schemas(
     l3_cache_schema: &Option<String>,
     mem_bw_schema: &Option<String>,
 ) -> Option<String> {
-    if l3_cache_schema.is_some() && mem_bw_schema.is_some() {
-        // Combine the results. Filter out "MB:"-lines from l3_cache_schema
-        let real_l3_cache_schema = l3_cache_schema.as_ref().unwrap();
-        let real_mem_bw_schema = mem_bw_schema.as_ref().unwrap();
-        let mut output: Vec<&str> = vec![];
+    match (l3_cache_schema, mem_bw_schema) {
+        (Some(ref real_l3_cache_schema), Some(ref real_mem_bw_schema)) => {
+            // Combine the results. Filter out "MB:"-lines from l3_cache_schema
+            let mut output: Vec<&str> = vec![];
 
-        for line in real_l3_cache_schema.lines() {
-            if line.starts_with("MB:") {
-                continue;
+            for line in real_l3_cache_schema.lines() {
+                if line.starts_with("MB:") {
+                    continue;
+                }
+                output.push(line);
             }
-            output.push(line);
+            output.push(real_mem_bw_schema);
+            Some(output.join("\n"))
         }
-        output.push(real_mem_bw_schema);
-        return Some(output.join("\n"));
-    } else if l3_cache_schema.is_some() {
-        // Apprarently the "MB:"-lines don't need to be removed in this case?
-        return l3_cache_schema.to_owned();
-    } else if mem_bw_schema.is_some() {
-        return mem_bw_schema.to_owned();
+        (Some(_), None) => {
+            // Apprarently the "MB:"-lines don't need to be removed in this case?
+            l3_cache_schema.to_owned()
+        }
+        (None, Some(_)) => mem_bw_schema.to_owned(),
+        (None, None) => None,
     }
-    None
 }
 
 #[derive(PartialEq)]

--- a/crates/libcontainer/src/workload/mod.rs
+++ b/crates/libcontainer/src/workload/mod.rs
@@ -20,8 +20,8 @@ pub enum ExecutorError {
 pub enum ExecutorValidationError {
     #[error("{0} executor can't handle spec")]
     CantHandle(&'static str),
-    #[error("invalid argument")]
-    InvalidArg,
+    #[error("{0}")]
+    ArgValidationError(String),
 }
 
 // Here is an explanation about the complexity below regarding to

--- a/crates/youki/src/main.rs
+++ b/crates/youki/src/main.rs
@@ -123,6 +123,7 @@ fn main() -> Result<()> {
             CommonCmd::Exec(exec) => match commands::exec::exec(exec, root_path) {
                 Ok(exit_code) => std::process::exit(exit_code),
                 Err(e) => {
+                    tracing::error!("error in executing command: {:?}", e);
                     eprintln!("exec failed : {e}");
                     std::process::exit(-1);
                 }
@@ -135,6 +136,7 @@ fn main() -> Result<()> {
             CommonCmd::Run(run) => match commands::run::run(run, root_path, systemd_cgroup) {
                 Ok(exit_code) => std::process::exit(exit_code),
                 Err(e) => {
+                    tracing::error!("error in executing command: {:?}", e);
                     eprintln!("run failed : {e}");
                     std::process::exit(-1);
                 }
@@ -151,6 +153,7 @@ fn main() -> Result<()> {
 
     if let Err(ref e) = cmd_result {
         tracing::error!("error in executing command: {:?}", e);
+        eprintln!("error in executing command: {:?}", e);
     }
     cmd_result
 }

--- a/crates/youki/src/rootpath.rs
+++ b/crates/youki/src/rootpath.rs
@@ -18,7 +18,7 @@ pub fn determine(root_path: Option<PathBuf>) -> Result<PathBuf> {
         return Ok(path);
     }
 
-    if !rootless_required() {
+    if !rootless_required()? {
         let path = get_default_not_rootless_path();
         create_dir_all_with_mode(&path, uid, Mode::S_IRWXU)?;
         return Ok(path);

--- a/crates/youki/src/workload/wasmedge.rs
+++ b/crates/youki/src/workload/wasmedge.rs
@@ -104,6 +104,8 @@ fn get_args(spec: &Spec) -> &[String] {
 
 fn env_to_wasi(spec: &Spec) -> Vec<String> {
     let default = vec![];
+    // below we can be sure that process exists, as otherwise container init process
+    // function would have returned error at the very start
     let env = spec
         .process()
         .as_ref()


### PR DESCRIPTION
ref : #2695 

This converts a lot of `.unwrap` calls to propagated errors, and also improves general error reporting that is seen by users of youki.

I'll suggest to review both of the commits separately,  as they focus on two different aspects of this :

- 7f8422f2ef1babbe4b65d86152ade37f74f605bd deals with the issue that when init process fails to exec, it does not report back to main process, thus the error gets reported as `channel broken` which is not at all useful. This now sends the error back via the channel. This also changes the `InvalidArg` error that is given by validation of executable to `ArgValdationError` . I feel the latter is better suited, and does not collide with another error of the same name that we have. This might be a breaking change for runwasi If they are match-ing on the enum values.

- 62431aa0cb8da9814029785784ba39bb305de58f : This converts various `.unwrap` s we have into error propagation so that users of the libraries can decide how they want to deal with it. I have left some unwraps where we first check that it cannot fail, and then call unwrap, as in those places, converting it to more idiomatic ways is either not possible to too complex code. I have also left out unwraps in all the tests, as it does not make sense to convert them. While the error propagation behavior is changed, otherwise the behavior should not change.

I also have some other comments, which I'm leaving as review comments below.

Thanks :)