### PR TITLE
Fix integration test validation CI, make io_priority test conditional

### DIFF
--- a/.github/workflows/integration_tests_validation.yaml
+++ b/.github/workflows/integration_tests_validation.yaml
@@ -22,9 +22,7 @@ jobs:
         with:
           files: |
             .github/workflows/integration_tests_validation.yaml
-            tests/runtimetest/**
-            tests/test_framework/**
-            tests/integration_test/**
+            tests/contest/**
           files_ignore: |
             **.md
       - name: List all changed files

--- a/tests/contest/contest/src/tests/io_priority/io_priority_test.rs
+++ b/tests/contest/contest/src/tests/io_priority/io_priority_test.rs
@@ -1,9 +1,9 @@
-use crate::utils::test_inside_container;
+use crate::utils::{is_runtime_runc, test_inside_container};
 use anyhow::{Context, Result};
 use oci_spec::runtime::{
     IOPriorityClass, LinuxIOPriorityBuilder, ProcessBuilder, Spec, SpecBuilder,
 };
-use test_framework::{test_result, Test, TestGroup, TestResult};
+use test_framework::{test_result, ConditionalTest, TestGroup, TestResult};
 
 fn create_spec(
     io_priority_class: IOPriorityClass,
@@ -60,12 +60,19 @@ fn io_priority_class_idle_test() -> TestResult {
 
 pub fn get_io_priority_test() -> TestGroup {
     let mut io_priority_group = TestGroup::new("set_io_priority");
-    let io_priority_class_rt =
-        Test::new("io_priority_class_rt", Box::new(io_priority_class_rt_test));
-    let io_priority_class_be =
-        Test::new("io_priority_class_be", Box::new(io_priority_class_be_test));
-    let io_priority_class_idle = Test::new(
+    let io_priority_class_rt = ConditionalTest::new(
+        "io_priority_class_rt",
+        Box::new(|| !is_runtime_runc()),
+        Box::new(io_priority_class_rt_test),
+    );
+    let io_priority_class_be = ConditionalTest::new(
+        "io_priority_class_be",
+        Box::new(|| !is_runtime_runc()),
+        Box::new(io_priority_class_be_test),
+    );
+    let io_priority_class_idle = ConditionalTest::new(
         "io_priority_class_idle",
+        Box::new(|| !is_runtime_runc()),
         Box::new(io_priority_class_idle_test),
     );
 


### PR DESCRIPTION
After the name change of integration test to contest, this CI file was missed, and as a result we didn't validate the tests even when there was a change in them.

I think implementation of io_priority in runc is still pending on https://github.com/opencontainers/runc/pull/3783 , so made them condition with runc check.