### PR TITLE
Add support for rsvd hugetlb cgroup

### DIFF
--- a/crates/libcgroups/src/v1/hugetlb.rs
+++ b/crates/libcgroups/src/v1/hugetlb.rs
@@ -1,10 +1,10 @@
-use std::{collections::HashMap, num::ParseIntError, path::Path};
-
 use crate::{
     common::{self, ControllerOpt, EitherError, MustBePowerOfTwo, WrappedIoError},
     stats::{supported_page_sizes, HugeTlbStats, StatsProvider, SupportedPageSizesError},
 };
+use std::{collections::HashMap, num::ParseIntError, path::Path};
 
+use crate::common::read_cgroup_file;
 use oci_spec::runtime::LinuxHugepageLimit;
 
 use super::controller::Controller;
@@ -109,6 +109,15 @@ impl HugeTlb {
             root_path.join(format!("hugetlb.{}.limit_in_bytes", hugetlb.page_size())),
             hugetlb.limit(),
         )?;
+
+        let rsvd_file_path = root_path.join(format!(
+            "hugetlb.{}.rsvd.limit_in_bytes",
+            hugetlb.page_size()
+        ));
+        if rsvd_file_path.exists() {
+            common::write_cgroup_file(rsvd_file_path, hugetlb.limit())?;
+        }
+
         Ok(())
     }
 
@@ -121,16 +130,20 @@ impl HugeTlb {
         page_size: &str,
     ) -> Result<HugeTlbStats, V1HugeTlbStatsError> {
         let mut stats = HugeTlbStats::default();
-
-        let usage_file = format!("hugetlb.{page_size}.usage_in_bytes");
-        let usage_content = common::read_cgroup_file(cgroup_path.join(usage_file))?;
+        let mut file_prefix = format!("hugetlb.{page_size}.rsvd");
+        let mut usage_file = format!("{file_prefix}.usage_in_bytes");
+        let usage_content = read_cgroup_file(cgroup_path.join(&usage_file)).or_else(|_| {
+            file_prefix = format!("hugetlb.{page_size}");
+            usage_file = format!("{file_prefix}.usage_in_bytes");
+            read_cgroup_file(cgroup_path.join(&usage_file))
+        })?;
         stats.usage = usage_content.trim().parse()?;
 
-        let max_file = format!("hugetlb.{page_size}.max_usage_in_bytes");
+        let max_file = format!("{file_prefix}.max_usage_in_bytes");
         let max_content = common::read_cgroup_file(cgroup_path.join(max_file))?;
         stats.max_usage = max_content.trim().parse()?;
 
-        let failcnt_file = format!("hugetlb.{page_size}.failcnt");
+        let failcnt_file = format!("{file_prefix}.failcnt");
         let failcnt_content = common::read_cgroup_file(cgroup_path.join(failcnt_file))?;
         stats.fail_count = failcnt_content.trim().parse()?;
 
@@ -161,6 +174,32 @@ mod tests {
         let content =
             read_to_string(tmp.path().join(page_file_name)).expect("Read hugetlb file content");
         assert_eq!(hugetlb.limit().to_string(), content);
+    }
+
+    #[test]
+    fn test_set_rsvd_hugetlb() {
+        let page_file_name = "hugetlb.2MB.limit_in_bytes";
+        let rsvd_page_file_name = "hugetlb.2MB.rsvd.limit_in_bytes";
+        let tmp = tempfile::tempdir().unwrap();
+        set_fixture(tmp.path(), page_file_name, "0").expect("Set fixture for 2 MB page size");
+        set_fixture(tmp.path(), rsvd_page_file_name, "0")
+            .expect("Set fixture for 2 MB rsvd page size");
+
+        let hugetlb = LinuxHugepageLimitBuilder::default()
+            .page_size("2MB")
+            .limit(16384)
+            .build()
+            .unwrap();
+
+        HugeTlb::apply(tmp.path(), &hugetlb).expect("apply hugetlb");
+        let content =
+            read_to_string(tmp.path().join(page_file_name)).expect("Read hugetlb file content");
+        let rsvd_content = read_to_string(tmp.path().join(rsvd_page_file_name))
+            .expect("Read rsvd hugetlb file content");
+
+        // Both files should have been written to
+        assert_eq!(hugetlb.limit().to_string(), content);
+        assert_eq!(hugetlb.limit().to_string(), rsvd_content);
     }
 
     #[test]
@@ -215,6 +254,32 @@ mod tests {
 
         let actual = HugeTlb::stats_for_page_size(tmp.path(), "2MB").expect("get cgroup stats");
 
+        let expected = HugeTlbStats {
+            usage: 1024,
+            max_usage: 4096,
+            fail_count: 5,
+        };
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_stat_rsvd_hugetlb() {
+        let tmp = tempfile::tempdir().unwrap();
+
+        set_fixture(tmp.path(), "hugetlb.2MB.rsvd.usage_in_bytes", "1024\n")
+            .expect("set hugetlb usage");
+        set_fixture(tmp.path(), "hugetlb.2MB.rsvd.max_usage_in_bytes", "4096\n")
+            .expect("set hugetlb max usage");
+        set_fixture(tmp.path(), "hugetlb.2MB.rsvd.failcnt", "5").expect("set hugetlb fail count");
+
+        set_fixture(tmp.path(), "hugetlb.2MB.usage_in_bytes", "2048\n").expect("set hugetlb usage");
+        set_fixture(tmp.path(), "hugetlb.2MB.max_usage_in_bytes", "8192\n")
+            .expect("set hugetlb max usage");
+        set_fixture(tmp.path(), "hugetlb.2MB.failcnt", "10").expect("set hugetlb fail count");
+
+        let actual = HugeTlb::stats_for_page_size(tmp.path(), "2MB").expect("get cgroup stats");
+
+        // Should prefer rsvd stats over non-rsvd stats
         let expected = HugeTlbStats {
             usage: 1024,
             max_usage: 4096,


### PR DESCRIPTION
Adds support for rsvg hugetlb cgroup. More Info on why this is necessary: https://github.com/opencontainers/runtime-spec/pull/1116. Should fix #1707.