### PR TITLE
Fix cgroups determination in exec implementation

### DIFF
--- a/Cross.toml
+++ b/Cross.toml
@@ -1,5 +1,6 @@
 [build]
 default-target = "x86_64-unknown-linux-gnu"
+env.passthrough = ["XDG_RUNTIME_DIR"]
 
 [target.aarch64-unknown-linux-gnu]
 dockerfile = "cross/Dockerfile.gnu"

--- a/crates/libcgroups/src/systemd/dbus_native/client.rs
+++ b/crates/libcgroups/src/systemd/dbus_native/client.rs
@@ -26,4 +26,11 @@ pub trait SystemdClient {
     fn systemd_version(&self) -> Result<u32, SystemdClientError>;
 
     fn control_cgroup_root(&self) -> Result<PathBuf, SystemdClientError>;
+
+    fn add_process_to_unit(
+        &self,
+        unit_name: &str,
+        subcgroup: &str,
+        pid: u32,
+    ) -> Result<(), SystemdClientError>;
 }

--- a/crates/libcgroups/src/systemd/dbus_native/dbus.rs
+++ b/crates/libcgroups/src/systemd/dbus_native/dbus.rs
@@ -453,6 +453,10 @@ impl SystemdClient for DbusConnection {
         let cgroup_root = proxy.control_group()?;
         Ok(PathBuf::from(&cgroup_root))
     }
+    fn add_process_to_unit(&self, unit_name: &str, subcgroup: &str, pid: u32) -> Result<()> {
+        let proxy = self.create_proxy();
+        proxy.attach_process(unit_name, subcgroup, pid)
+    }
 }
 
 #[cfg(test)]

--- a/crates/libcgroups/src/systemd/dbus_native/proxy.rs
+++ b/crates/libcgroups/src/systemd/dbus_native/proxy.rs
@@ -239,4 +239,11 @@ impl<'conn> Proxy<'conn> {
             v => panic!("control group expected string variant, got {:?} instead", v),
         }
     }
+    pub fn attach_process(&self, name: &str, cgroup: &str, pid: u32) -> Result<()> {
+        self.method_call::<_, ()>(
+            "org.freedesktop.systemd1.Manager",
+            "AttachProcessesToUnit",
+            Some((name, cgroup, vec![pid])),
+        )
+    }
 }

--- a/crates/libcgroups/src/systemd/manager.rs
+++ b/crates/libcgroups/src/systemd/manager.rs
@@ -21,7 +21,7 @@ use super::{
 use crate::{
     common::{
         self, AnyCgroupManager, CgroupManager, ControllerOpt, FreezerState, JoinSafelyError,
-        PathBufExt, WrapIoResult, WrappedIoError,
+        PathBufExt, WrapIoResult, WrappedIoError, CGROUP_PROCS,
     },
     systemd::{dbus_native::serialize::Variant, unified::Unified},
     v2::manager::V2ManagerError,
@@ -355,6 +355,7 @@ impl CgroupManager for Manager {
         }
         if self.client.transient_unit_exists(&self.unit_name) {
             tracing::debug!("Transient unit {:?} already exists", self.unit_name);
+            common::write_cgroup_file(self.full_path.join(CGROUP_PROCS), pid)?;
             return Ok(());
         }
 

--- a/crates/libcgroups/src/systemd/manager.rs
+++ b/crates/libcgroups/src/systemd/manager.rs
@@ -353,6 +353,10 @@ impl CgroupManager for Manager {
         if pid.as_raw() == -1 {
             return Ok(());
         }
+        if self.client.transient_unit_exists(&self.unit_name) {
+            tracing::debug!("Transient unit {:?} already exists", self.unit_name);
+            return Ok(());
+        }
 
         tracing::debug!("Starting {:?}", self.unit_name);
         self.client.start_transient_unit(

--- a/crates/libcgroups/src/v2/manager.rs
+++ b/crates/libcgroups/src/v2/manager.rs
@@ -151,6 +151,10 @@ impl CgroupManager for Manager {
     type Error = V2ManagerError;
 
     fn add_task(&self, pid: Pid) -> Result<(), Self::Error> {
+        if self.full_path.exists() {
+            common::write_cgroup_file(self.full_path.join(CGROUP_PROCS), pid)?;
+            return Ok(());
+        }
         self.create_unified_cgroup(pid)?;
         Ok(())
     }

--- a/crates/libcontainer/src/config.rs
+++ b/crates/libcontainer/src/config.rs
@@ -109,7 +109,10 @@ mod tests {
         let config = YoukiConfig::from_spec(&spec, container_id, false)?;
         assert_eq!(&config.hooks, spec.hooks());
         dbg!(&config.cgroup_path);
-        assert_eq!(config.cgroup_path, PathBuf::from(container_id));
+        assert_eq!(
+            config.cgroup_path,
+            PathBuf::from(format!(":youki:{container_id}"))
+        );
         Ok(())
     }
 

--- a/crates/libcontainer/src/config.rs
+++ b/crates/libcontainer/src/config.rs
@@ -47,7 +47,7 @@ pub struct YoukiConfig {
 }
 
 impl<'a> YoukiConfig {
-    pub fn from_spec(spec: &'a Spec, container_id: &str, new_user_ns: bool) -> Result<Self> {
+    pub fn from_spec(spec: &'a Spec, container_id: &str) -> Result<Self> {
         Ok(YoukiConfig {
             hooks: spec.hooks().clone(),
             cgroup_path: utils::get_cgroup_path(
@@ -56,7 +56,6 @@ impl<'a> YoukiConfig {
                     .ok_or(ConfigError::MissingLinux)?
                     .cgroups_path(),
                 container_id,
-                new_user_ns,
             ),
         })
     }
@@ -106,7 +105,7 @@ mod tests {
     fn test_config_from_spec() -> Result<()> {
         let container_id = "sample";
         let spec = Spec::default();
-        let config = YoukiConfig::from_spec(&spec, container_id, false)?;
+        let config = YoukiConfig::from_spec(&spec, container_id)?;
         assert_eq!(&config.hooks, spec.hooks());
         dbg!(&config.cgroup_path);
         assert_eq!(
@@ -121,7 +120,7 @@ mod tests {
         let container_id = "sample";
         let tmp = tempfile::tempdir().expect("create temp dir");
         let spec = Spec::default();
-        let config = YoukiConfig::from_spec(&spec, container_id, false)?;
+        let config = YoukiConfig::from_spec(&spec, container_id)?;
         config.save(&tmp)?;
         let act = YoukiConfig::load(&tmp)?;
         assert_eq!(act, config);

--- a/crates/libcontainer/src/container/builder_impl.rs
+++ b/crates/libcontainer/src/container/builder_impl.rs
@@ -68,11 +68,7 @@ impl ContainerBuilderImpl {
 
     fn run_container(&mut self) -> Result<Pid, LibcontainerError> {
         let linux = self.spec.linux().as_ref().ok_or(MissingSpecError::Linux)?;
-        let cgroups_path = utils::get_cgroup_path(
-            linux.cgroups_path(),
-            &self.container_id,
-            self.user_ns_config.is_some(),
-        );
+        let cgroups_path = utils::get_cgroup_path(linux.cgroups_path(), &self.container_id);
         let cgroup_config = libcgroups::common::CgroupConfig {
             cgroup_path: cgroups_path,
             systemd_cgroup: self.use_systemd || self.user_ns_config.is_some(),
@@ -186,11 +182,7 @@ impl ContainerBuilderImpl {
 
     fn cleanup_container(&self) -> Result<(), LibcontainerError> {
         let linux = self.spec.linux().as_ref().ok_or(MissingSpecError::Linux)?;
-        let cgroups_path = utils::get_cgroup_path(
-            linux.cgroups_path(),
-            &self.container_id,
-            self.user_ns_config.is_some(),
-        );
+        let cgroups_path = utils::get_cgroup_path(linux.cgroups_path(), &self.container_id);
         let cmanager =
             libcgroups::common::create_cgroup_manager(libcgroups::common::CgroupConfig {
                 cgroup_path: cgroups_path,

--- a/crates/libcontainer/src/container/container.rs
+++ b/crates/libcontainer/src/container/container.rs
@@ -332,8 +332,7 @@ mod tests {
         let tmp_dir = tempfile::tempdir().unwrap();
         use oci_spec::runtime::Spec;
         let spec = Spec::default();
-        let config =
-            YoukiConfig::from_spec(&spec, "123", false).context("convert spec to config")?;
+        let config = YoukiConfig::from_spec(&spec, "123").context("convert spec to config")?;
         config.save(tmp_dir.path()).context("save config")?;
 
         let container = Container {

--- a/crates/libcontainer/src/container/init_builder.rs
+++ b/crates/libcontainer/src/container/init_builder.rs
@@ -88,7 +88,7 @@ impl InitContainerBuilder {
 
         let user_ns_config = UserNamespaceConfig::new(&spec)?;
 
-        let config = YoukiConfig::from_spec(&spec, container.id(), user_ns_config.is_some())?;
+        let config = YoukiConfig::from_spec(&spec, container.id())?;
         config.save(&container_dir).map_err(|err| {
             tracing::error!(?container_dir, "failed to save config: {}", err);
             err

--- a/crates/libcontainer/src/container/tenant_builder.rs
+++ b/crates/libcontainer/src/container/tenant_builder.rs
@@ -332,7 +332,7 @@ impl TenantContainerBuilder {
         let spec_linux = spec.linux().as_ref().unwrap();
         let mut linux_builder = LinuxBuilder::default().namespaces(ns);
 
-        if let Some(ref cgroup_path) = spec_linux.cgroups_path(){
+        if let Some(ref cgroup_path) = spec_linux.cgroups_path() {
             linux_builder = linux_builder.cgroups_path(cgroup_path.clone());
         }
         let linux = linux_builder.build()?;

--- a/crates/libcontainer/src/container/tenant_builder.rs
+++ b/crates/libcontainer/src/container/tenant_builder.rs
@@ -327,8 +327,16 @@ impl TenantContainerBuilder {
 
         let init_process = procfs::process::Process::new(container_pid.as_raw())?;
         let ns = self.get_namespaces(init_process.namespaces()?.0)?;
-        let linux = LinuxBuilder::default().namespaces(ns).build()?;
 
+        let linux = spec.linux().as_ref().unwrap();
+        let linux = if linux.cgroups_path().is_some() {
+            LinuxBuilder::default()
+                .namespaces(ns)
+                .cgroups_path(linux.cgroups_path().as_ref().unwrap().clone())
+                .build()?
+        } else {
+            LinuxBuilder::default().namespaces(ns).build()?
+        };
         spec.set_process(Some(process)).set_linux(Some(linux));
         Ok(())
     }

--- a/crates/libcontainer/src/utils.rs
+++ b/crates/libcontainer/src/utils.rs
@@ -147,11 +147,7 @@ pub fn get_user_home(uid: u32) -> Option<PathBuf> {
 }
 
 /// If None, it will generate a default path for cgroups.
-pub fn get_cgroup_path(
-    cgroups_path: &Option<PathBuf>,
-    container_id: &str,
-    new_user_ns: bool,
-) -> PathBuf {
+pub fn get_cgroup_path(cgroups_path: &Option<PathBuf>, container_id: &str) -> PathBuf {
     match cgroups_path {
         Some(cpath) => cpath.clone(),
         None => PathBuf::from(format!(":youki:{container_id}")),
@@ -320,11 +316,11 @@ mod tests {
     fn test_get_cgroup_path() {
         let cid = "sample_container_id";
         assert_eq!(
-            get_cgroup_path(&None, cid, false),
+            get_cgroup_path(&None, cid),
             PathBuf::from(":youki:sample_container_id")
         );
         assert_eq!(
-            get_cgroup_path(&Some(PathBuf::from("/youki")), cid, false),
+            get_cgroup_path(&Some(PathBuf::from("/youki")), cid),
             PathBuf::from("/youki")
         );
     }

--- a/crates/libcontainer/src/utils.rs
+++ b/crates/libcontainer/src/utils.rs
@@ -154,10 +154,7 @@ pub fn get_cgroup_path(
 ) -> PathBuf {
     match cgroups_path {
         Some(cpath) => cpath.clone(),
-        None => match new_user_ns {
-            false => PathBuf::from(container_id),
-            true => PathBuf::from(format!(":youki:{container_id}")),
-        },
+        None => PathBuf::from(format!(":youki:{container_id}")),
     }
 }
 
@@ -324,7 +321,7 @@ mod tests {
         let cid = "sample_container_id";
         assert_eq!(
             get_cgroup_path(&None, cid, false),
-            PathBuf::from("sample_container_id")
+            PathBuf::from(":youki:sample_container_id")
         );
         assert_eq!(
             get_cgroup_path(&Some(PathBuf::from("/youki")), cid, false),

--- a/cross/Dockerfile.gnu
+++ b/cross/Dockerfile.gnu
@@ -13,3 +13,6 @@ RUN dpkg --add-architecture ${CROSS_DEB_ARCH} && \
     zlib1g-dev:${CROSS_DEB_ARCH} \
     # dependencies to build wasmedge-sys
     libzstd-dev:${CROSS_DEB_ARCH}
+
+COPY hack/busctl.sh /bin/busctl
+RUN chmod +x /bin/busctl

--- a/cross/Dockerfile.musl
+++ b/cross/Dockerfile.musl
@@ -22,6 +22,9 @@ ENV LIBSECCOMP_LIB_PATH="${CROSS_SYSROOT}/lib"
 ENV WASMEDGE_DEP_STDCXX_LINK_TYPE="static"
 ENV WASMEDGE_DEP_STDCXX_LIB_PATH="${CROSS_SYSROOT}/lib"
 
+COPY hack/busctl.sh /bin/busctl
+RUN chmod +x /bin/busctl
+
 # wasmedge-sys (through llvm) needs some symbols defined in libgcc
 RUN mkdir /.cargo && cat <<'EOF' > /.cargo/config.toml
 [target.'cfg(target_env = "musl")']

--- a/hack/busctl.sh
+++ b/hack/busctl.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+# This hack script is the dummy busctl command used when running tests with cross containers.
+
+# The issue is that we cannot run systemd or dbus inside the test container without a lot 
+# of hacks. For one specific test - test_task_addition, we need to check that the task
+# addition via systemd manager works. We mount the host dbus socket in the test container, so 
+# dbus calls work, but for the initial authentication, we use busctl which needs dbus and systemd
+# to be present and running. So instead of doing all that, we simply run the container with the 
+# actual test running user's uid/gid and here we echo the only relevant line from busctl's 
+# output, using id to get the uid. This is a hack, but less complex than actually setting up
+# and running the systemd+dbus inside the container.
+
+echo "OwnerUID=$(id -u)"

--- a/scripts/cargo.sh
+++ b/scripts/cargo.sh
@@ -56,7 +56,11 @@ if [ "$CARGO" == "cross" ]; then
 
     # mount run to have access to dbus socket.
     # mount /tmp so as shared for test_make_parent_mount_private
-    export CROSS_CONTAINER_OPTS="--privileged -v/run:/run --mount=type=bind,source=/tmp,destination=/tmp,bind-propagation=shared"
+    # Then there are few "hacks" specificallt for test_task_addition
+    # run with user same as the invoking user, so that the dbus is connected with correct user
+    # we want pid ns of host, because we will be connecting to the host dbus, and it needs task pid from host
+    # finally we need to mount the cgroup as read-only, as we need that to check if the tasks are correctly added
+    export CROSS_CONTAINER_OPTS="--privileged --user `id -u`:`id -g` --pid=host -v /sys/fs/cgroup:/sys/fs/cgroup:ro -v/run:/run --mount=type=bind,source=/tmp,destination=/tmp,bind-propagation=shared"
 fi
 
 if [ "$1" == "--print-target-dir" ]; then

--- a/tests/rootless-tests/run.sh
+++ b/tests/rootless-tests/run.sh
@@ -10,9 +10,20 @@ podman rm --force --ignore create-test # remove if existing
 podman create --runtime $runtime --name create-test hello-world
 log=$(podman start -a create-test)
 echo $log | grep "This message shows that your installation appears to be working correctly"
-podman rm create-test
+podman rm --force --ignore create-test
 
 rand=$(head -c 10 /dev/random | base64)
 
 log=$(podman run --runtime $runtime fedora echo "$rand")
 echo $log | grep $rand
+
+podman rm --force --ignore exec-test
+podman run -d --runtime $runtime --name exec-test busybox sleep 10m
+
+rand=$(head -c 10 /dev/random | base64)
+
+log=$(podman exec --runtime $runtime exec-test echo "$rand")
+echo $log | grep $rand
+
+podman kill exec-test
+podman rm --force --ignore exec-test

--- a/tests/rootless-tests/run.sh
+++ b/tests/rootless-tests/run.sh
@@ -17,6 +17,7 @@ rand=$(head -c 10 /dev/random | base64)
 log=$(podman run --runtime $runtime fedora echo "$rand")
 echo $log | grep $rand
 
+podman kill exec-test || true # ignore failure for killing
 podman rm --force --ignore exec-test
 podman run -d --runtime $runtime --name exec-test busybox sleep 10m
 
@@ -24,6 +25,20 @@ rand=$(head -c 10 /dev/random | base64)
 
 log=$(podman exec --runtime $runtime exec-test echo "$rand")
 echo $log | grep $rand
+
+CGROUP_SUB_PATH=$(podman inspect exec-test | jq .[0].State.CgroupPath | tr -d "\"")
+CGROUP_PATH="/sys/fs/cgroup$CGROUP_SUB_PATH/cgroup.procs"
+
+# assert we have exactly one process in the cgroup
+test $(cat $CGROUP_PATH | wc -l) -eq 1
+# assert pid match
+test $(cat $CGROUP_PATH) -eq $(podman inspect exec-test | jq .[0].State.Pid)
+
+podman exec -d --runtime $runtime exec-test sleep 5m
+
+# we cannot exactly check the pid of tenant here, instead just check that there are
+# two processes in the same cgroup now
+test $(cat $CGROUP_PATH | wc -l) -eq 2
 
 podman kill exec-test
 podman rm --force --ignore exec-test


### PR DESCRIPTION
This fixes the way we determine cgroup name as well as the way we set the cgroup in case of exec. Right now on the main, following would fail even though they should succeed

```
podman run -d --runtime /path/to/youki busybox sleep 10m
podman exec -it --runtime /path/to/youki SHA-HERE /bin/sh
```
This is because 
1. we copy over the namespaces from "main" container to tenant, but not the cgroups
2. In case of rootless, we directly use container id as cgroup name, but that fails when trying to decode the cgroup path

Thus, we fix it here by also copying over the cgroup config from init to tenant, and if cgroup path is not present using `:youki:id` instead .

I have also added a test for exec in the rootless tests we have.

~NOT READY FOR MERGE YET.~