### PR TITLE
Limt dependabot updates to only direct dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,6 @@ updates:
     open-pull-requests-limit: 10
     allow:
       - dependency-type: direct
-      - dependency-type: indirect
     groups:
       patch:
         update-types: 


### PR DESCRIPTION
The `indirect` type creates PR too much.