### PR TITLE
Update nix to 0.28.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -527,7 +527,7 @@ dependencies = [
  "flate2",
  "libcgroups",
  "libcontainer",
- "nix 0.27.1",
+ "nix 0.28.0",
  "num_cpus",
  "oci-spec",
  "once_cell",
@@ -1925,7 +1925,7 @@ dependencies = [
  "libbpf-sys",
  "libc",
  "mockall",
- "nix 0.27.1",
+ "nix 0.28.0",
  "oci-spec",
  "procfs",
  "quickcheck",
@@ -1952,7 +1952,7 @@ dependencies = [
  "libcgroups",
  "libseccomp",
  "nc",
- "nix 0.27.1",
+ "nix 0.28.0",
  "oci-spec",
  "once_cell",
  "prctl",
@@ -2238,7 +2238,6 @@ dependencies = [
  "bitflags 2.5.0",
  "cfg-if",
  "libc",
- "memoffset 0.9.1",
 ]
 
 [[package]]
@@ -2251,6 +2250,7 @@ dependencies = [
  "cfg-if",
  "cfg_aliases",
  "libc",
+ "memoffset 0.9.1",
 ]
 
 [[package]]
@@ -3123,7 +3123,7 @@ dependencies = [
  "anyhow",
  "libc",
  "nc",
- "nix 0.27.1",
+ "nix 0.28.0",
  "oci-spec",
 ]
 
@@ -5688,7 +5688,7 @@ dependencies = [
  "libcgroups",
  "libcontainer",
  "liboci-cli",
- "nix 0.27.1",
+ "nix 0.28.0",
  "once_cell",
  "pentacle",
  "procfs",

--- a/crates/libcgroups/Cargo.toml
+++ b/crates/libcgroups/Cargo.toml
@@ -20,7 +20,7 @@ systemd = ["v2", "nix/socket", "nix/uio"]
 cgroupsv2_devices = ["rbpf", "libbpf-sys", "errno", "libc", "nix/dir"]
 
 [dependencies]
-nix = { version = "0.27.1", features = ["signal", "user", "fs"] }
+nix = { version = "0.28.0", features = ["signal", "user", "fs"] }
 procfs = "0.16.0"
 oci-spec = { version = "~0.6.4", features = ["runtime"] }
 fixedbitset = "0.5.7"

--- a/crates/libcgroups/src/v1/memory.rs
+++ b/crates/libcgroups/src/v1/memory.rs
@@ -331,7 +331,7 @@ impl Memory {
             Err(e) => {
                 // we need to look into the raw OS error for an EBUSY status
                 match e.inner().raw_os_error() {
-                    Some(code) => match Errno::from_i32(code) {
+                    Some(code) => match Errno::from_raw(code) {
                         Errno::EBUSY => {
                             let usage = Self::get_memory_usage(cgroup_root)?;
                             let max_usage = Self::get_memory_max_usage(cgroup_root)?;

--- a/crates/libcontainer/Cargo.toml
+++ b/crates/libcontainer/Cargo.toml
@@ -29,7 +29,7 @@ chrono = { version = "0.4", default-features = false, features = [
 fastrand = "^2.1.0"
 futures = { version = "0.3", features = ["thread-pool"] }
 libc = "0.2.155"
-nix = { version = "0.27.1", features = [
+nix = { version = "0.28.0", features = [
     "socket",
     "sched",
     "mount",

--- a/crates/libcontainer/src/container/builder_impl.rs
+++ b/crates/libcontainer/src/container/builder_impl.rs
@@ -133,7 +133,7 @@ impl ContainerBuilderImpl {
             prctl::set_dumpable(false).map_err(|e| {
                 LibcontainerError::Other(format!(
                     "error in setting dumpable to false : {}",
-                    nix::errno::from_i32(e)
+                    nix::errno::Errno::from_raw(e)
                 ))
             })?;
         }

--- a/crates/libcontainer/src/seccomp/mod.rs
+++ b/crates/libcontainer/src/seccomp/mod.rs
@@ -329,7 +329,7 @@ mod tests {
             }
 
             if let Some(errno) = ret.err() {
-                if errno != nix::errno::from_i32(expect_error) {
+                if errno != nix::errno::Errno::from_raw(expect_error) {
                     Err(TestCallbackError::Custom(format!(
                         "getcwd failed but we didn't get the expected error from seccomp profile: {}",
                         errno

--- a/crates/libcontainer/src/syscall/linux.rs
+++ b/crates/libcontainer/src/syscall/linux.rs
@@ -314,7 +314,7 @@ impl Syscall for LinuxSyscall {
     fn set_id(&self, uid: Uid, gid: Gid) -> Result<()> {
         prctl::set_keep_capabilities(true).map_err(|errno| {
             tracing::error!(?errno, "failed to set keep capabilities to true");
-            nix::errno::from_i32(errno)
+            nix::errno::Errno::from_raw(errno)
         })?;
         // args : real *id, effective *id, saved set *id respectively
 
@@ -350,7 +350,7 @@ impl Syscall for LinuxSyscall {
         }
         prctl::set_keep_capabilities(false).map_err(|errno| {
             tracing::error!(?errno, "failed to set keep capabilities to false");
-            nix::errno::from_i32(errno)
+            nix::errno::Errno::from_raw(errno)
         })?;
         Ok(())
     }

--- a/crates/youki/Cargo.toml
+++ b/crates/youki/Cargo.toml
@@ -32,7 +32,7 @@ chrono = { version = "0.4", default-features = false, features = ["clock", "serd
 libcgroups = { path = "../libcgroups", default-features = false, version = "0.3.2" } # MARK: Version
 libcontainer = { path = "../libcontainer", default-features = false, version = "0.3.2" } # MARK: Version
 liboci-cli = { path = "../liboci-cli", version = "0.3.2" } # MARK: Version
-nix = "0.27.1"
+nix = "0.28.0"
 once_cell = "1.19.0"
 pentacle = "1.0.0"
 procfs = "0.16.0"

--- a/tests/contest/contest/Cargo.toml
+++ b/tests/contest/contest/Cargo.toml
@@ -9,7 +9,7 @@ chrono = { version = "0.4", default-features = false, features = ["clock"] }
 flate2 = "1.0"
 libcgroups = { path = "../../../crates/libcgroups" }
 libcontainer = { path = "../../../crates/libcontainer" }
-nix = "0.27.1"
+nix = "0.28.0"
 num_cpus = "1.16"
 oci-spec = { version = "0.6.4", features = ["runtime"] }
 once_cell = "1.19.0"

--- a/tests/contest/contest/src/tests/seccomp_notify/seccomp_agent.rs
+++ b/tests/contest/contest/src/tests/seccomp_notify/seccomp_agent.rs
@@ -5,7 +5,7 @@ use std::path::Path;
 
 use anyhow::{bail, Context, Result};
 use libcontainer::container::ContainerProcessState;
-use nix::sys::socket::{self, UnixAddr};
+use nix::sys::socket::{self, Backlog, UnixAddr};
 use nix::unistd;
 
 const DEFAULT_BUFFER_SIZE: usize = 4096;
@@ -30,7 +30,8 @@ pub fn recv_seccomp_listener(seccomp_listener: &Path) -> SeccompAgentResult {
     socket::bind(socket.as_raw_fd(), &addr).context("failed to bind to seccomp listener socket")?;
     // Force the backlog to be 1 so in the case of an error, only one connection
     // from clients will be waiting.
-    socket::listen(&socket.as_fd(), 1).context("failed to listen on seccomp listener")?;
+    socket::listen(&socket.as_fd(), Backlog::new(1)?)
+        .context("failed to listen on seccomp listener")?;
     let conn = match socket::accept(socket.as_raw_fd()) {
         Ok(conn) => conn,
         Err(e) => {

--- a/tests/contest/runtimetest/Cargo.toml
+++ b/tests/contest/runtimetest/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 oci-spec = { version = "0.6.4", features = ["runtime"] }
-nix = "0.27.1"
+nix = "0.28.0"
 anyhow = "1.0"
 libc = "0.2.155" # TODO (YJDoc2) upgrade to latest
 nc = "0.8.20"

--- a/tests/contest/runtimetest/src/tests.rs
+++ b/tests/contest/runtimetest/src/tests.rs
@@ -38,7 +38,7 @@ pub fn validate_readonly_paths(spec: &Spec) {
     // change manual matching of i32 to e.kind() and match statement
     for path in ro_paths {
         if let std::io::Result::Err(e) = test_read_access(path) {
-            let errno = Errno::from_i32(e.raw_os_error().unwrap());
+            let errno = Errno::from_raw(e.raw_os_error().unwrap());
             // In the integration tests we test for both existing and non-existing readonly paths
             // to be specified in the spec, so we allow ENOENT here
             if errno == Errno::ENOENT {
@@ -54,7 +54,7 @@ pub fn validate_readonly_paths(spec: &Spec) {
         }
 
         if let std::io::Result::Err(e) = test_write_access(path) {
-            let errno = Errno::from_i32(e.raw_os_error().unwrap());
+            let errno = Errno::from_raw(e.raw_os_error().unwrap());
             // In the integration tests we test for both existing and non-existing readonly paths
             // being specified in the spec, so we allow ENOENT, and we expect EROFS as the paths
             // should be read-only


### PR DESCRIPTION
Updates nix to 0.28.0. Changed the deprecated functions to new recommended ones. Another noticeable change was the write() ~and close()~ function~s~ in nix now take in `OwnedFd` instead of `RawFd`. Included changes for them as well.