### PR TITLE
Remove `chdir` in container `init` and `start`

### DIFF
--- a/crates/libcontainer/src/container/container_start.rs
+++ b/crates/libcontainer/src/container/container_start.rs
@@ -6,7 +6,7 @@ use crate::{
 };
 
 use super::{Container, ContainerStatus};
-use nix::{sys::signal, unistd};
+use nix::sys::signal;
 
 impl Container {
     /// Starts a previously created container

--- a/crates/libcontainer/src/container/container_start.rs
+++ b/crates/libcontainer/src/container/container_start.rs
@@ -59,11 +59,6 @@ impl Container {
             })?;
         }
 
-        unistd::chdir(self.root.as_os_str()).map_err(|err| {
-            tracing::error!("failed to change directory to container root: {}", err);
-            LibcontainerError::OtherSyscall(err)
-        })?;
-
         let mut notify_socket = NotifySocket::new(self.root.join(NOTIFY_FILE));
         notify_socket.notify_container_start()?;
         self.set_status(ContainerStatus::Running)

--- a/crates/libcontainer/src/container/init_builder.rs
+++ b/crates/libcontainer/src/container/init_builder.rs
@@ -1,4 +1,3 @@
-use nix::unistd;
 use oci_spec::runtime::Spec;
 use std::{
     fs,

--- a/crates/libcontainer/src/container/init_builder.rs
+++ b/crates/libcontainer/src/container/init_builder.rs
@@ -61,14 +61,6 @@ impl InitContainerBuilder {
             .set_systemd(self.use_systemd)
             .set_annotations(spec.annotations().clone());
 
-        unistd::chdir(&container_dir).map_err(|err| {
-            tracing::error!(
-                ?container_dir,
-                ?err,
-                "failed to chdir into the container directory"
-            );
-            LibcontainerError::OtherSyscall(err)
-        })?;
         let notify_path = container_dir.join(NOTIFY_FILE);
         // convert path of root file system of the container to absolute path
         let rootfs = fs::canonicalize(spec.root().as_ref().ok_or(MissingSpecError::Root)?.path())

--- a/crates/libcontainer/src/container/tenant_builder.rs
+++ b/crates/libcontainer/src/container/tenant_builder.rs
@@ -108,7 +108,6 @@ impl TenantContainerBuilder {
 
         tracing::debug!("{:#?}", spec);
 
-        unistd::chdir(&container_dir).map_err(LibcontainerError::OtherSyscall)?;
         let notify_path = Self::setup_notify_listener(&container_dir)?;
         // convert path of root file system of the container to absolute path
         let rootfs = fs::canonicalize(spec.root().as_ref().ok_or(MissingSpecError::Root)?.path())

--- a/crates/libcontainer/src/container/tenant_builder.rs
+++ b/crates/libcontainer/src/container/tenant_builder.rs
@@ -1,6 +1,6 @@
 use caps::Capability;
 use nix::fcntl::OFlag;
-use nix::unistd::{self, close, pipe2, read, Pid};
+use nix::unistd::{close, pipe2, read, Pid};
 use oci_spec::runtime::{
     Capabilities as SpecCapabilities, Capability as SpecCapability, LinuxBuilder,
     LinuxCapabilities, LinuxCapabilitiesBuilder, LinuxNamespace, LinuxNamespaceBuilder,


### PR DESCRIPTION
Remove unnecessary `chdir` in container `init` and `start`, the invokes seem not necessary.

Pending comments from https://github.com/containers/youki/issues/2772#issuecomment-2088446225 and will close issue #2772 