### PR TITLE
Update rust version to 1.77.2

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
 profile="default"
-channel="1.77.1"
+channel="1.77.2"


### PR DESCRIPTION
Cross updated its msrv to 1.77.2 in https://github.com/cross-rs/cross/commit/7129d5ab15c5b293cfeb439a0d41e116988edcc2 , so we need to update ours too, as otherwise CI fails to install cross.

Alternatively we can pin cross version, but this is not a big change, and we would be updating rust version eventually anyways.