### PR TITLE
deps: Disable unused/unnecessary regex features in libcontainer

### DIFF
--- a/crates/libcontainer/Cargo.toml
+++ b/crates/libcontainer/Cargo.toml
@@ -49,7 +49,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 rust-criu = "0.4.0"
 protobuf = "= 3.2.0" # https://github.com/checkpoint-restore/rust-criu/issues/19
-regex = "1.10.4"
+regex = { version = "1.10.4", default-features = false, features = ["std", "unicode-perl"] }
 thiserror = "1.0.59"
 tracing = { version = "0.1.40", features = ["attributes"] }
 safe-path = "0.1.0"


### PR DESCRIPTION
To reduce binary size and dependency bloat in projects using libcontainer.