### PR TITLE
Add `rustfmt.toml` to standardize formatting

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,6 @@
+# Ignore commits in the blame view
+# see:
+#   https://docs.github.com/en/repositories/working-with-files/using-files/viewing-a-file#ignore-commits-in-the-blame-view
+
+# Bulk apply formatting
+13a3fd516e9904d5cd7ef20ead76dd70cd172fe7

--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -44,7 +44,9 @@ jobs:
       - name: Setup Rust toolchain and cache
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          components: rustfmt, clippy
+          components: clippy
+      - name: Install nightly rustfmt
+        run: rustup toolchain install nightly --component rustfmt --profile minimal --no-self-update
       - name: typos-action
         uses: crate-ci/typos@v1.14.12
       - name: Install just

--- a/crates/libcgroups/examples/bpf.rs
+++ b/crates/libcgroups/examples/bpf.rs
@@ -2,19 +2,15 @@ use anyhow::Result;
 
 #[cfg(feature = "cgroupsv2_devices")]
 mod bpf {
-    use anyhow::{bail, Result};
-    use clap::Arg;
-    use clap::Command;
-    use oci_spec::runtime::LinuxDeviceCgroup;
     use std::os::unix::io::AsRawFd;
     use std::path::Path;
 
+    use anyhow::{bail, Result};
+    use clap::{Arg, Command};
+    use libcgroups::v2::devices::{bpf, emulator, program};
     use nix::fcntl::OFlag;
     use nix::sys::stat::Mode;
-
-    use libcgroups::v2::devices::bpf;
-    use libcgroups::v2::devices::emulator;
-    use libcgroups::v2::devices::program;
+    use oci_spec::runtime::LinuxDeviceCgroup;
 
     const LICENSE: &str = "Apache";
     fn cli() -> Command {

--- a/crates/libcgroups/src/common.rs
+++ b/crates/libcgroups/src/common.rs
@@ -1,26 +1,19 @@
-use std::{
-    fmt::{Debug, Display},
-    fs::{self, File},
-    io::{BufRead, BufReader, Write},
-    path::{Path, PathBuf, StripPrefixError},
-    time::Duration,
-};
+use std::fmt::{Debug, Display};
+use std::fs::{self, File};
+use std::io::{BufRead, BufReader, Write};
+use std::path::{Path, PathBuf, StripPrefixError};
+use std::time::Duration;
 
-use nix::{
-    sys::statfs::{statfs, CGROUP2_SUPER_MAGIC, TMPFS_MAGIC},
-    unistd::Pid,
-};
+use nix::sys::statfs::{statfs, CGROUP2_SUPER_MAGIC, TMPFS_MAGIC};
+use nix::unistd::Pid;
 use oci_spec::runtime::LinuxResources;
 #[cfg(any(feature = "cgroupsv2_devices", feature = "v1"))]
 use oci_spec::runtime::{
     LinuxDevice, LinuxDeviceBuilder, LinuxDeviceCgroup, LinuxDeviceCgroupBuilder, LinuxDeviceType,
 };
 
-use super::systemd;
-use super::v1;
-use super::v2;
-
 use super::stats::Stats;
+use super::{systemd, v1, v2};
 
 pub const CGROUP_PROCS: &str = "cgroup.procs";
 pub const DEFAULT_CGROUP_ROOT: &str = "/sys/fs/cgroup";

--- a/crates/libcgroups/src/stats.rs
+++ b/crates/libcgroups/src/stats.rs
@@ -1,15 +1,13 @@
-use serde::Serialize;
-use std::{
-    collections::HashMap,
-    fmt::Display,
-    fs,
-    num::ParseIntError,
-    path::{Path, PathBuf},
-};
+use std::collections::HashMap;
+use std::fmt::Display;
+use std::fs;
+use std::num::ParseIntError;
+use std::path::{Path, PathBuf};
 
-use crate::common::{WrapIoResult, WrappedIoError};
+use serde::Serialize;
 
 use super::common;
+use crate::common::{WrapIoResult, WrappedIoError};
 
 pub(crate) trait StatsProvider {
     type Error;
@@ -475,9 +473,8 @@ fn parse_psi(stat_line: &str, path: &Path) -> Result<PSIData, WrappedIoError> {
 
 #[cfg(test)]
 mod tests {
-    use crate::test::set_fixture;
-
     use super::*;
+    use crate::test::set_fixture;
 
     #[test]
     fn test_supported_page_sizes_gigabyte() {

--- a/crates/libcgroups/src/systemd/controller.rs
+++ b/crates/libcgroups/src/systemd/controller.rs
@@ -1,7 +1,6 @@
 use std::collections::HashMap;
 
 use super::dbus_native::serialize::Variant;
-
 use crate::common::ControllerOpt;
 
 pub(super) trait Controller {

--- a/crates/libcgroups/src/systemd/cpu.rs
+++ b/crates/libcgroups/src/systemd/cpu.rs
@@ -1,9 +1,9 @@
 use std::collections::HashMap;
 
-use super::dbus_native::serialize::Variant;
 use oci_spec::runtime::LinuxCpu;
 
 use super::controller::Controller;
+use super::dbus_native::serialize::Variant;
 use crate::common::ControllerOpt;
 
 pub const CPU_WEIGHT: &str = "CPUWeight";
@@ -95,9 +95,8 @@ mod tests {
     use oci_spec::runtime::LinuxCpuBuilder;
 
     use super::super::dbus_native::serialize::DbusSerialize;
-    use crate::recast;
-
     use super::*;
+    use crate::recast;
 
     #[test]
     fn test_set_shares() -> Result<()> {

--- a/crates/libcgroups/src/systemd/cpuset.rs
+++ b/crates/libcgroups/src/systemd/cpuset.rs
@@ -1,12 +1,11 @@
 use std::collections::HashMap;
 
-use super::dbus_native::serialize::Variant;
 use fixedbitset::FixedBitSet;
 use oci_spec::runtime::LinuxCpu;
 
-use crate::common::ControllerOpt;
-
 use super::controller::Controller;
+use super::dbus_native::serialize::Variant;
+use crate::common::ControllerOpt;
 
 pub const ALLOWED_CPUS: &str = "AllowedCPUs";
 pub const ALLOWED_NODES: &str = "AllowedMemoryNodes";
@@ -139,9 +138,8 @@ mod tests {
     use oci_spec::runtime::LinuxCpuBuilder;
 
     use super::super::dbus_native::serialize::DbusSerialize;
-    use crate::recast;
-
     use super::*;
+    use crate::recast;
 
     #[test]
     fn to_bitmask_single_value() -> Result<()> {

--- a/crates/libcgroups/src/systemd/dbus_native/client.rs
+++ b/crates/libcgroups/src/systemd/dbus_native/client.rs
@@ -1,6 +1,8 @@
-use super::{serialize::Variant, utils::SystemdClientError};
 use std::collections::HashMap;
 use std::path::PathBuf;
+
+use super::serialize::Variant;
+use super::utils::SystemdClientError;
 
 pub trait SystemdClient {
     fn is_system(&self) -> bool;

--- a/crates/libcgroups/src/systemd/dbus_native/dbus.rs
+++ b/crates/libcgroups/src/systemd/dbus_native/dbus.rs
@@ -1,15 +1,16 @@
-use crate::systemd::dbus_native::serialize::{DbusSerialize, Structure, Variant};
-
-use super::client::SystemdClient;
-use super::message::*;
-use super::proxy::Proxy;
-use super::utils::{DbusError, Result, SystemdClientError};
-use nix::sys::socket;
 use std::collections::HashMap;
 use std::io::{IoSlice, IoSliceMut};
 use std::os::fd::AsRawFd;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicU32, Ordering};
+
+use nix::sys::socket;
+
+use super::client::SystemdClient;
+use super::message::*;
+use super::proxy::Proxy;
+use super::utils::{DbusError, Result, SystemdClientError};
+use crate::systemd::dbus_native::serialize::{DbusSerialize, Structure, Variant};
 
 const REPLY_BUF_SIZE: usize = 128; // seems good enough tradeoff between extra size and repeated calls
 
@@ -461,9 +462,10 @@ impl SystemdClient for DbusConnection {
 
 #[cfg(test)]
 mod tests {
+    use nix::unistd::getuid;
+
     use super::super::utils::Result;
     use super::{uid_to_hex_str, DbusConnection, SystemdClientError};
-    use nix::unistd::getuid;
 
     #[test]
     fn test_uid_to_hex_str() {

--- a/crates/libcgroups/src/systemd/dbus_native/message.rs
+++ b/crates/libcgroups/src/systemd/dbus_native/message.rs
@@ -489,11 +489,9 @@ impl Message {
 
 #[cfg(test)]
 mod tests {
-    use crate::systemd::dbus_native::serialize::{Structure, Variant};
-
     use super::super::serialize::DbusSerialize;
-    use super::{Header, HeaderKind, HeaderValue, MessageType};
-    use super::{Message, Result};
+    use super::{Header, HeaderKind, HeaderValue, Message, MessageType, Result};
+    use crate::systemd::dbus_native::serialize::{Structure, Variant};
     // The hardcoded serialized values are captured from
     // original dbus library communication
     // and manually decoded.

--- a/crates/libcgroups/src/systemd/manager.rs
+++ b/crates/libcgroups/src/systemd/manager.rs
@@ -1,32 +1,30 @@
-use std::{
-    collections::HashMap,
-    convert::Infallible,
-    fmt::{Debug, Display},
-    fs::{self},
-    path::Component::RootDir,
-};
-
-use nix::{unistd::Pid, NixPath};
+use std::collections::HashMap;
+use std::convert::Infallible;
+use std::fmt::{Debug, Display};
+use std::fs::{self};
+use std::path::Component::RootDir;
 use std::path::{Path, PathBuf};
 
-use super::{
-    controller::Controller,
-    controller_type::{ControllerType, CONTROLLER_TYPES},
-    cpu::Cpu,
-    cpuset::CpuSet,
-    dbus_native::{client::SystemdClient, dbus::DbusConnection, utils::SystemdClientError},
-    memory::Memory,
-    pids::Pids,
+use nix::unistd::Pid;
+use nix::NixPath;
+
+use super::controller::Controller;
+use super::controller_type::{ControllerType, CONTROLLER_TYPES};
+use super::cpu::Cpu;
+use super::cpuset::CpuSet;
+use super::dbus_native::client::SystemdClient;
+use super::dbus_native::dbus::DbusConnection;
+use super::dbus_native::utils::SystemdClientError;
+use super::memory::Memory;
+use super::pids::Pids;
+use crate::common::{
+    self, AnyCgroupManager, CgroupManager, ControllerOpt, FreezerState, JoinSafelyError,
+    PathBufExt, WrapIoResult, WrappedIoError,
 };
-use crate::{
-    common::{
-        self, AnyCgroupManager, CgroupManager, ControllerOpt, FreezerState, JoinSafelyError,
-        PathBufExt, WrapIoResult, WrappedIoError,
-    },
-    systemd::{dbus_native::serialize::Variant, unified::Unified},
-    v2::manager::V2ManagerError,
-};
-use crate::{stats::Stats, v2::manager::Manager as FsManager};
+use crate::stats::Stats;
+use crate::systemd::dbus_native::serialize::Variant;
+use crate::systemd::unified::Unified;
+use crate::v2::manager::{Manager as FsManager, V2ManagerError};
 
 const CGROUP_CONTROLLERS: &str = "cgroup.controllers";
 const CGROUP_SUBTREE_CONTROL: &str = "cgroup.subtree_control";
@@ -436,12 +434,10 @@ mod tests {
     use anyhow::{Context, Result};
 
     use super::*;
-    use crate::{
-        common::DEFAULT_CGROUP_ROOT,
-        systemd::dbus_native::{
-            client::SystemdClient, serialize::Variant, utils::SystemdClientError,
-        },
-    };
+    use crate::common::DEFAULT_CGROUP_ROOT;
+    use crate::systemd::dbus_native::client::SystemdClient;
+    use crate::systemd::dbus_native::serialize::Variant;
+    use crate::systemd::dbus_native::utils::SystemdClientError;
 
     struct TestSystemdClient {}
 

--- a/crates/libcgroups/src/systemd/memory.rs
+++ b/crates/libcgroups/src/systemd/memory.rs
@@ -1,11 +1,10 @@
 use std::collections::HashMap;
 
-use super::dbus_native::serialize::Variant;
 use oci_spec::runtime::LinuxMemory;
 
-use crate::common::ControllerOpt;
-
 use super::controller::Controller;
+use super::dbus_native::serialize::Variant;
+use crate::common::ControllerOpt;
 
 pub const MEMORY_MIN: &str = "MemoryMin";
 pub const MEMORY_LOW: &str = "MemoryLow";
@@ -118,9 +117,8 @@ mod tests {
     use oci_spec::runtime::LinuxMemoryBuilder;
 
     use super::super::dbus_native::serialize::DbusSerialize;
-    use crate::recast;
-
     use super::*;
+    use crate::recast;
 
     #[test]
     fn test_set_valid_memory_low() -> Result<()> {

--- a/crates/libcgroups/src/systemd/pids.rs
+++ b/crates/libcgroups/src/systemd/pids.rs
@@ -1,11 +1,11 @@
-use std::{collections::HashMap, convert::Infallible};
+use std::collections::HashMap;
+use std::convert::Infallible;
 
-use super::dbus_native::serialize::Variant;
 use oci_spec::runtime::LinuxPids;
 
-use crate::common::ControllerOpt;
-
 use super::controller::Controller;
+use super::dbus_native::serialize::Variant;
+use crate::common::ControllerOpt;
 
 pub const TASKS_MAX: &str = "TasksMax";
 
@@ -43,12 +43,12 @@ impl Pids {
 #[cfg(test)]
 mod tests {
 
-    use super::super::dbus_native::serialize::DbusSerialize;
-    use crate::recast;
-
-    use super::*;
     use anyhow::{anyhow, Context, Result};
     use oci_spec::runtime::{LinuxPidsBuilder, LinuxResources, LinuxResourcesBuilder};
+
+    use super::super::dbus_native::serialize::DbusSerialize;
+    use super::*;
+    use crate::recast;
 
     fn setup(resources: &LinuxResources) -> (ControllerOpt, HashMap<&str, Variant>) {
         let properties = HashMap::new();

--- a/crates/libcgroups/src/systemd/unified.rs
+++ b/crates/libcgroups/src/systemd/unified.rs
@@ -1,12 +1,11 @@
-use super::dbus_native::serialize::Variant;
-use std::{collections::HashMap, num::ParseIntError};
+use std::collections::HashMap;
+use std::num::ParseIntError;
 
-use super::{
-    controller::Controller,
-    cpu::{self, convert_shares_to_cgroup2},
-    cpuset::{self, to_bitmask, BitmaskError},
-    memory, pids,
-};
+use super::controller::Controller;
+use super::cpu::{self, convert_shares_to_cgroup2};
+use super::cpuset::{self, to_bitmask, BitmaskError};
+use super::dbus_native::serialize::Variant;
+use super::{memory, pids};
 use crate::common::ControllerOpt;
 
 #[derive(thiserror::Error, Debug)]
@@ -155,12 +154,11 @@ impl Unified {
 
 #[cfg(test)]
 mod tests {
-    use super::super::dbus_native::serialize::DbusSerialize;
     use anyhow::{Context, Result};
 
-    use crate::recast;
-
+    use super::super::dbus_native::serialize::DbusSerialize;
     use super::*;
+    use crate::recast;
 
     #[test]
     fn test_set() -> Result<()> {

--- a/crates/libcgroups/src/test.rs
+++ b/crates/libcgroups/src/test.rs
@@ -1,10 +1,9 @@
 #![cfg(test)]
 
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
 use anyhow::{Context, Result};
-use std::{
-    io::Write,
-    path::{Path, PathBuf},
-};
 
 pub fn setup(cgroup_file: &str) -> (tempfile::TempDir, PathBuf) {
     let tmp = tempfile::tempdir().expect("create temp directory for test");

--- a/crates/libcgroups/src/test_manager.rs
+++ b/crates/libcgroups/src/test_manager.rs
@@ -1,11 +1,10 @@
-use std::{cell::RefCell, convert::Infallible};
+use std::cell::RefCell;
+use std::convert::Infallible;
 
 use nix::unistd::Pid;
 
-use crate::{
-    common::{CgroupManager, ControllerOpt, FreezerState},
-    stats::Stats,
-};
+use crate::common::{CgroupManager, ControllerOpt, FreezerState};
+use crate::stats::Stats;
 
 #[derive(Debug)]
 pub struct TestManager {

--- a/crates/libcgroups/src/v1/blkio.rs
+++ b/crates/libcgroups/src/v1/blkio.rs
@@ -1,16 +1,11 @@
-use std::{
-    num::ParseIntError,
-    path::{Path, PathBuf},
-};
-
-use crate::{
-    common::{self, ControllerOpt, WrappedIoError},
-    stats::{self, BlkioDeviceStat, BlkioStats, ParseDeviceNumberError, StatsProvider},
-};
+use std::num::ParseIntError;
+use std::path::{Path, PathBuf};
 
 use oci_spec::runtime::LinuxBlockIo;
 
 use super::controller::Controller;
+use crate::common::{self, ControllerOpt, WrappedIoError};
+use crate::stats::{self, BlkioDeviceStat, BlkioStats, ParseDeviceNumberError, StatsProvider};
 
 // Throttling/upper limit policy
 // ---------------------------------------
@@ -259,10 +254,10 @@ impl Blkio {
 mod tests {
     use std::fs;
 
+    use oci_spec::runtime::{LinuxBlockIoBuilder, LinuxThrottleDeviceBuilder};
+
     use super::*;
     use crate::test::{set_fixture, setup};
-
-    use oci_spec::runtime::{LinuxBlockIoBuilder, LinuxThrottleDeviceBuilder};
 
     #[test]
     fn test_set_blkio_weight() {

--- a/crates/libcgroups/src/v1/controller.rs
+++ b/crates/libcgroups/src/v1/controller.rs
@@ -1,4 +1,5 @@
-use std::{fs, path::Path};
+use std::fs;
+use std::path::Path;
 
 use nix::unistd::Pid;
 

--- a/crates/libcgroups/src/v1/cpu.rs
+++ b/crates/libcgroups/src/v1/cpu.rs
@@ -2,12 +2,9 @@ use std::path::{Path, PathBuf};
 
 use oci_spec::runtime::LinuxCpu;
 
-use crate::{
-    common::{self, ControllerOpt, WrappedIoError},
-    stats::{parse_flat_keyed_data, CpuThrottling, ParseFlatKeyedDataError, StatsProvider},
-};
-
 use super::controller::Controller;
+use crate::common::{self, ControllerOpt, WrappedIoError};
+use crate::stats::{parse_flat_keyed_data, CpuThrottling, ParseFlatKeyedDataError, StatsProvider};
 
 const CGROUP_CPU_SHARES: &str = "cpu.shares";
 const CGROUP_CPU_QUOTA: &str = "cpu.cfs_quota_us";
@@ -135,10 +132,12 @@ impl Cpu {
 
 #[cfg(test)]
 mod tests {
+    use std::fs;
+
+    use oci_spec::runtime::LinuxCpuBuilder;
+
     use super::*;
     use crate::test::{set_fixture, setup};
-    use oci_spec::runtime::LinuxCpuBuilder;
-    use std::fs;
 
     #[test]
     fn test_set_shares() {

--- a/crates/libcgroups/src/v1/cpuacct.rs
+++ b/crates/libcgroups/src/v1/cpuacct.rs
@@ -1,14 +1,9 @@
-use std::{
-    num::ParseIntError,
-    path::{Path, PathBuf},
-};
-
-use crate::{
-    common::{self, ControllerOpt, WrappedIoError},
-    stats::{parse_flat_keyed_data, CpuUsage, ParseFlatKeyedDataError, StatsProvider},
-};
+use std::num::ParseIntError;
+use std::path::{Path, PathBuf};
 
 use super::controller::Controller;
+use crate::common::{self, ControllerOpt, WrappedIoError};
+use crate::stats::{parse_flat_keyed_data, CpuUsage, ParseFlatKeyedDataError, StatsProvider};
 
 // Contains user mode and kernel mode cpu consumption
 const CGROUP_CPUACCT_STAT: &str = "cpuacct.stat";
@@ -151,10 +146,8 @@ mod tests {
     use tempfile::TempDir;
 
     use super::*;
-    use crate::{
-        common::CGROUP_PROCS,
-        test::{set_fixture, setup},
-    };
+    use crate::common::CGROUP_PROCS;
+    use crate::test::{set_fixture, setup};
 
     fn setup_total_cpu(stat_content: &str, usage_content: &str) -> TempDir {
         let tmp = tempfile::tempdir().unwrap();

--- a/crates/libcgroups/src/v1/cpuset.rs
+++ b/crates/libcgroups/src/v1/cpuset.rs
@@ -1,19 +1,14 @@
-use std::{
-    fs,
-    path::{Path, PathBuf, StripPrefixError},
-};
+use std::fs;
+use std::path::{Path, PathBuf, StripPrefixError};
 
 use nix::unistd;
 use oci_spec::runtime::LinuxCpu;
 use unistd::Pid;
 
+use super::controller::Controller;
+use super::util::{self, V1MountPointError};
+use super::ControllerType;
 use crate::common::{self, ControllerOpt, WrapIoResult, WrappedIoError, CGROUP_PROCS};
-
-use super::{
-    controller::Controller,
-    util::{self, V1MountPointError},
-    ControllerType,
-};
 
 const CGROUP_CPUSET_CPUS: &str = "cpuset.cpus";
 const CGROUP_CPUSET_MEMS: &str = "cpuset.mems";
@@ -122,9 +117,10 @@ impl CpuSet {
 mod tests {
     use std::fs;
 
+    use oci_spec::runtime::LinuxCpuBuilder;
+
     use super::*;
     use crate::test::setup;
-    use oci_spec::runtime::LinuxCpuBuilder;
 
     #[test]
     fn test_set_cpus() {

--- a/crates/libcgroups/src/v1/devices.rs
+++ b/crates/libcgroups/src/v1/devices.rs
@@ -1,8 +1,9 @@
 use std::path::Path;
 
+use oci_spec::runtime::LinuxDeviceCgroup;
+
 use super::controller::Controller;
 use crate::common::{self, default_allow_devices, default_devices, ControllerOpt, WrappedIoError};
-use oci_spec::runtime::LinuxDeviceCgroup;
 
 pub struct Devices {}
 
@@ -52,10 +53,12 @@ impl Devices {
 
 #[cfg(test)]
 mod tests {
+    use std::fs::read_to_string;
+
+    use oci_spec::runtime::{LinuxDeviceCgroupBuilder, LinuxDeviceType};
+
     use super::*;
     use crate::test::set_fixture;
-    use oci_spec::runtime::{LinuxDeviceCgroupBuilder, LinuxDeviceType};
-    use std::fs::read_to_string;
 
     #[test]
     fn test_set_default_devices() {

--- a/crates/libcgroups/src/v1/freezer.rs
+++ b/crates/libcgroups/src/v1/freezer.rs
@@ -1,10 +1,10 @@
+use std::fs::OpenOptions;
 use std::io::Read;
-use std::{fs::OpenOptions, path::Path, thread, time};
-
-use crate::common::{self, WrapIoResult, WrappedIoError};
-use crate::common::{ControllerOpt, FreezerState};
+use std::path::Path;
+use std::{thread, time};
 
 use super::controller::Controller;
+use crate::common::{self, ControllerOpt, FreezerState, WrapIoResult, WrappedIoError};
 
 const CGROUP_FREEZER_STATE: &str = "freezer.state";
 const FREEZER_STATE_THAWED: &str = "THAWED";
@@ -130,11 +130,12 @@ impl Freezer {
 
 #[cfg(test)]
 mod tests {
+    use nix::unistd::Pid;
+    use oci_spec::runtime::LinuxResourcesBuilder;
+
     use super::*;
     use crate::common::{FreezerState, CGROUP_PROCS};
     use crate::test::set_fixture;
-    use nix::unistd::Pid;
-    use oci_spec::runtime::LinuxResourcesBuilder;
 
     #[test]
     fn test_set_freezer_state() {

--- a/crates/libcgroups/src/v1/hugetlb.rs
+++ b/crates/libcgroups/src/v1/hugetlb.rs
@@ -1,13 +1,14 @@
-use crate::{
-    common::{self, ControllerOpt, EitherError, MustBePowerOfTwo, WrappedIoError},
-    stats::{supported_page_sizes, HugeTlbStats, StatsProvider, SupportedPageSizesError},
-};
-use std::{collections::HashMap, num::ParseIntError, path::Path};
+use std::collections::HashMap;
+use std::num::ParseIntError;
+use std::path::Path;
 
-use crate::common::read_cgroup_file;
 use oci_spec::runtime::LinuxHugepageLimit;
 
 use super::controller::Controller;
+use crate::common::{
+    self, read_cgroup_file, ControllerOpt, EitherError, MustBePowerOfTwo, WrappedIoError,
+};
+use crate::stats::{supported_page_sizes, HugeTlbStats, StatsProvider, SupportedPageSizesError};
 
 #[derive(thiserror::Error, Debug)]
 pub enum V1HugeTlbControllerError {
@@ -153,10 +154,12 @@ impl HugeTlb {
 
 #[cfg(test)]
 mod tests {
+    use std::fs::read_to_string;
+
+    use oci_spec::runtime::LinuxHugepageLimitBuilder;
+
     use super::*;
     use crate::test::set_fixture;
-    use oci_spec::runtime::LinuxHugepageLimitBuilder;
-    use std::fs::read_to_string;
 
     #[test]
     fn test_set_hugetlb() {

--- a/crates/libcgroups/src/v1/manager.rs
+++ b/crates/libcgroups/src/v1/manager.rs
@@ -1,28 +1,28 @@
+use std::collections::HashMap;
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::time::Duration;
-use std::{collections::HashMap, path::PathBuf};
 
 use nix::unistd::Pid;
-
 use procfs::process::Process;
 use procfs::ProcError;
 
-use super::blkio::V1BlkioStatsError;
-use super::cpu::V1CpuStatsError;
-use super::cpuacct::V1CpuAcctStatsError;
-use super::cpuset::V1CpuSetControllerError;
-use super::freezer::V1FreezerControllerError;
-use super::hugetlb::{V1HugeTlbControllerError, V1HugeTlbStatsError};
-use super::memory::{V1MemoryControllerError, V1MemoryStatsError};
+use super::blkio::{Blkio, V1BlkioStatsError};
+use super::controller::Controller;
+use super::controller_type::CONTROLLERS;
+use super::cpu::{Cpu, V1CpuStatsError};
+use super::cpuacct::{CpuAcct, V1CpuAcctStatsError};
+use super::cpuset::{CpuSet, V1CpuSetControllerError};
+use super::devices::Devices;
+use super::freezer::{Freezer, V1FreezerControllerError};
+use super::hugetlb::{HugeTlb, V1HugeTlbControllerError, V1HugeTlbStatsError};
+use super::memory::{Memory, V1MemoryControllerError, V1MemoryStatsError};
+use super::network_classifier::NetworkClassifier;
+use super::network_priority::NetworkPriority;
+use super::perf_event::PerfEvent;
+use super::pids::Pids;
 use super::util::V1MountPointError;
-use super::{
-    blkio::Blkio, controller::Controller, controller_type::CONTROLLERS, cpu::Cpu, cpuacct::CpuAcct,
-    cpuset::CpuSet, devices::Devices, freezer::Freezer, hugetlb::HugeTlb, memory::Memory,
-    network_classifier::NetworkClassifier, network_priority::NetworkPriority,
-    perf_event::PerfEvent, pids::Pids, util, ControllerType as CtrlType,
-};
-
+use super::{util, ControllerType as CtrlType};
 use crate::common::{
     self, AnyCgroupManager, CgroupManager, ControllerOpt, FreezerState, JoinSafelyError,
     PathBufExt, WrapIoResult, WrappedIoError, CGROUP_PROCS,

--- a/crates/libcgroups/src/v1/memory.rs
+++ b/crates/libcgroups/src/v1/memory.rs
@@ -1,20 +1,19 @@
 use std::collections::HashMap;
 use std::fmt::Display;
-use std::io::{prelude::*, Write};
+use std::fs::OpenOptions;
+use std::io::prelude::*;
+use std::io::Write;
 use std::num::ParseIntError;
-use std::path::PathBuf;
-use std::{fs::OpenOptions, path::Path};
+use std::path::{Path, PathBuf};
 
 use nix::errno::Errno;
+use oci_spec::runtime::LinuxMemory;
 
+use super::controller::Controller;
 use crate::common::{self, ControllerOpt, WrapIoResult, WrappedIoError};
 use crate::stats::{
     self, parse_single_value, MemoryData, MemoryStats, ParseFlatKeyedDataError, StatsProvider,
 };
-
-use oci_spec::runtime::LinuxMemory;
-
-use super::controller::Controller;
 
 const CGROUP_MEMORY_SWAP_LIMIT: &str = "memory.memsw.limit_in_bytes";
 const CGROUP_MEMORY_LIMIT: &str = "memory.limit_in_bytes";
@@ -409,10 +408,11 @@ impl Memory {
 
 #[cfg(test)]
 mod tests {
+    use oci_spec::runtime::{LinuxMemoryBuilder, LinuxResourcesBuilder};
+
     use super::*;
     use crate::common::CGROUP_PROCS;
     use crate::test::set_fixture;
-    use oci_spec::runtime::{LinuxMemoryBuilder, LinuxResourcesBuilder};
 
     #[test]
     fn test_set_memory() {

--- a/crates/libcgroups/src/v1/network_classifier.rs
+++ b/crates/libcgroups/src/v1/network_classifier.rs
@@ -1,9 +1,9 @@
 use std::path::Path;
 
-use crate::common::{self, ControllerOpt, WrappedIoError};
 use oci_spec::runtime::LinuxNetwork;
 
 use super::controller::Controller;
+use crate::common::{self, ControllerOpt, WrappedIoError};
 
 pub struct NetworkClassifier {}
 
@@ -38,9 +38,10 @@ impl NetworkClassifier {
 
 #[cfg(test)]
 mod tests {
+    use oci_spec::runtime::LinuxNetworkBuilder;
+
     use super::*;
     use crate::test::set_fixture;
-    use oci_spec::runtime::LinuxNetworkBuilder;
 
     #[test]
     fn test_apply_network_classifier() {

--- a/crates/libcgroups/src/v1/network_priority.rs
+++ b/crates/libcgroups/src/v1/network_priority.rs
@@ -1,9 +1,9 @@
 use std::path::Path;
 
-use crate::common::{self, ControllerOpt, WrappedIoError};
 use oci_spec::runtime::LinuxNetwork;
 
 use super::controller::Controller;
+use crate::common::{self, ControllerOpt, WrappedIoError};
 
 pub struct NetworkPriority {}
 
@@ -39,9 +39,10 @@ impl NetworkPriority {
 
 #[cfg(test)]
 mod tests {
+    use oci_spec::runtime::{LinuxInterfacePriorityBuilder, LinuxNetworkBuilder};
+
     use super::*;
     use crate::test::set_fixture;
-    use oci_spec::runtime::{LinuxInterfacePriorityBuilder, LinuxNetworkBuilder};
 
     #[test]
     fn test_apply_network_priorites() {

--- a/crates/libcgroups/src/v1/perf_event.rs
+++ b/crates/libcgroups/src/v1/perf_event.rs
@@ -1,7 +1,7 @@
-use crate::common::{ControllerOpt, WrappedIoError};
 use std::path::Path;
 
 use super::controller::Controller;
+use crate::common::{ControllerOpt, WrappedIoError};
 
 pub struct PerfEvent {}
 
@@ -25,7 +25,8 @@ mod tests {
     use nix::unistd::Pid;
 
     use super::*;
-    use crate::{common::CGROUP_PROCS, test::setup};
+    use crate::common::CGROUP_PROCS;
+    use crate::test::setup;
 
     #[test]
     fn test_add_task() {

--- a/crates/libcgroups/src/v1/pids.rs
+++ b/crates/libcgroups/src/v1/pids.rs
@@ -1,12 +1,10 @@
 use std::path::Path;
 
-use crate::{
-    common::{self, ControllerOpt, WrappedIoError},
-    stats::{self, PidStats, PidStatsError, StatsProvider},
-};
 use oci_spec::runtime::LinuxPids;
 
 use super::controller::Controller;
+use crate::common::{self, ControllerOpt, WrappedIoError};
+use crate::stats::{self, PidStats, PidStatsError, StatsProvider};
 
 // Contains the maximum allowed number of active pids
 const CGROUP_PIDS_MAX: &str = "pids.max";
@@ -56,9 +54,10 @@ impl Pids {
 
 #[cfg(test)]
 mod tests {
+    use oci_spec::runtime::LinuxPidsBuilder;
+
     use super::*;
     use crate::test::set_fixture;
-    use oci_spec::runtime::LinuxPidsBuilder;
 
     // Contains the current number of active pids
     const CGROUP_PIDS_CURRENT: &str = "pids.current";

--- a/crates/libcgroups/src/v1/util.rs
+++ b/crates/libcgroups/src/v1/util.rs
@@ -1,8 +1,11 @@
-use std::{collections::HashMap, path::PathBuf};
+use std::collections::HashMap;
+use std::path::PathBuf;
 
-use procfs::{process::Process, ProcError};
+use procfs::process::Process;
+use procfs::ProcError;
 
-use super::{controller_type::CONTROLLERS, ControllerType};
+use super::controller_type::CONTROLLERS;
+use super::ControllerType;
 
 #[derive(thiserror::Error, Debug)]
 pub enum V1MountPointError {

--- a/crates/libcgroups/src/v2/cpu.rs
+++ b/crates/libcgroups/src/v2/cpu.rs
@@ -1,16 +1,11 @@
-use std::{
-    borrow::Cow,
-    path::{Path, PathBuf},
-};
-
-use crate::{
-    common::{self, ControllerOpt, WrappedIoError},
-    stats::{self, CpuStats, ParseFlatKeyedDataError, StatsProvider},
-};
+use std::borrow::Cow;
+use std::path::{Path, PathBuf};
 
 use oci_spec::runtime::LinuxCpu;
 
 use super::controller::Controller;
+use crate::common::{self, ControllerOpt, WrappedIoError};
+use crate::stats::{self, CpuStats, ParseFlatKeyedDataError, StatsProvider};
 
 const CGROUP_CPU_WEIGHT: &str = "cpu.weight";
 const CGROUP_CPU_MAX: &str = "cpu.max";
@@ -168,13 +163,13 @@ impl Cpu {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use crate::{
-        stats::{CpuThrottling, CpuUsage},
-        test::{set_fixture, setup},
-    };
-    use oci_spec::runtime::LinuxCpuBuilder;
     use std::fs;
+
+    use oci_spec::runtime::LinuxCpuBuilder;
+
+    use super::*;
+    use crate::stats::{CpuThrottling, CpuUsage};
+    use crate::test::{set_fixture, setup};
 
     #[test]
     fn test_set_valid_shares() {

--- a/crates/libcgroups/src/v2/cpuset.rs
+++ b/crates/libcgroups/src/v2/cpuset.rs
@@ -1,9 +1,9 @@
 use std::path::Path;
 
-use crate::common::{self, ControllerOpt, WrappedIoError};
 use oci_spec::runtime::LinuxCpu;
 
 use super::controller::Controller;
+use crate::common::{self, ControllerOpt, WrappedIoError};
 
 const CGROUP_CPUSET_CPUS: &str = "cpuset.cpus";
 const CGROUP_CPUSET_MEMS: &str = "cpuset.mems";
@@ -40,9 +40,10 @@ impl CpuSet {
 mod tests {
     use std::fs;
 
+    use oci_spec::runtime::LinuxCpuBuilder;
+
     use super::*;
     use crate::test::setup;
-    use oci_spec::runtime::LinuxCpuBuilder;
 
     #[test]
     fn test_set_cpus() {

--- a/crates/libcgroups/src/v2/devices/bpf.rs
+++ b/crates/libcgroups/src/v2/devices/bpf.rs
@@ -14,29 +14,28 @@ pub enum BpfError {
 
 #[cfg_attr(test, automock)]
 pub mod prog {
-    use super::ProgramInfo;
     use std::os::unix::io::RawFd;
     use std::ptr;
 
     use libbpf_sys::{bpf_insn, BPF_CGROUP_DEVICE, BPF_F_ALLOW_MULTI, BPF_PROG_TYPE_CGROUP_DEVICE};
-    use libc::{rlimit, ENOSPC, RLIMIT_MEMLOCK};
-
-    // mocks
-    // TODO: consider use of #[mockall_double]
-    #[cfg(test)]
-    use crate::v2::devices::mocks::mock_libc::setrlimit;
+    #[cfg(not(test))]
+    use libbpf_sys::{
+        bpf_prog_attach, bpf_prog_detach2, bpf_prog_get_fd_by_id, bpf_prog_load, bpf_prog_query,
+    };
     #[cfg(not(test))]
     use libc::setrlimit;
+    use libc::{rlimit, ENOSPC, RLIMIT_MEMLOCK};
 
+    use super::ProgramInfo;
     // TODO: consider use of #[mockall_double]
     #[cfg(test)]
     use crate::v2::devices::mocks::mock_libbpf_sys::{
         bpf_prog_attach, bpf_prog_detach2, bpf_prog_get_fd_by_id, bpf_prog_load, bpf_prog_query,
     };
-    #[cfg(not(test))]
-    use libbpf_sys::{
-        bpf_prog_attach, bpf_prog_detach2, bpf_prog_get_fd_by_id, bpf_prog_load, bpf_prog_query,
-    };
+    // mocks
+    // TODO: consider use of #[mockall_double]
+    #[cfg(test)]
+    use crate::v2::devices::mocks::mock_libc::setrlimit;
 
     pub fn load(license: &str, insns: &[u8]) -> Result<RawFd, super::BpfError> {
         let insns_cnt = insns.len() / std::mem::size_of::<bpf_insn>();
@@ -154,12 +153,12 @@ pub mod prog {
 
 #[cfg(test)]
 mod tests {
-    use super::prog;
-    use crate::v2::devices::mocks::{mock_libbpf_sys, mock_libc};
     use errno::{set_errno, Errno};
     use libc::{ENOSPC, ENOSYS};
-
     use serial_test::serial;
+
+    use super::prog;
+    use crate::v2::devices::mocks::{mock_libbpf_sys, mock_libc};
 
     #[test]
     #[serial(libbpf_sys)] // mock contexts are shared

--- a/crates/libcgroups/src/v2/devices/controller.rs
+++ b/crates/libcgroups/src/v2/devices/controller.rs
@@ -1,21 +1,19 @@
 use std::os::unix::io::AsRawFd;
 use std::path::Path;
 
-use super::bpf::BpfError;
-use super::program::ProgramError;
-use super::*;
+#[cfg(test)]
+use bpf::mock_prog as bpf_prog;
+#[cfg(not(test))]
+use bpf::prog as bpf_prog;
 use nix::fcntl::OFlag;
 use nix::sys::stat::Mode;
 use oci_spec::runtime::LinuxDeviceCgroup;
 
+use super::bpf::BpfError;
+use super::program::ProgramError;
+use super::*;
 use crate::common::{default_allow_devices, default_devices, ControllerOpt};
 use crate::v2::controller::Controller;
-
-#[cfg(test)]
-use bpf::mock_prog as bpf_prog;
-
-#[cfg(not(test))]
-use bpf::prog as bpf_prog;
 
 const LICENSE: &str = "Apache";
 
@@ -116,14 +114,14 @@ impl Devices {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use crate::test::setup;
-    use serial_test::serial;
-
-    use oci_spec::runtime::{LinuxDeviceCgroupBuilder, LinuxDeviceType};
     use std::os::unix::io::RawFd;
 
     use bpf::mock_prog;
+    use oci_spec::runtime::{LinuxDeviceCgroupBuilder, LinuxDeviceType};
+    use serial_test::serial;
+
+    use super::*;
+    use crate::test::setup;
 
     #[test]
     #[serial(bpf)] // mock contexts are shared

--- a/crates/libcgroups/src/v2/devices/emulator.rs
+++ b/crates/libcgroups/src/v2/devices/emulator.rs
@@ -53,8 +53,9 @@ impl Emulator {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use oci_spec::runtime::LinuxDeviceCgroupBuilder;
+
+    use super::*;
 
     #[test]
     fn test_with_default_allow() {

--- a/crates/libcgroups/src/v2/devices/program.rs
+++ b/crates/libcgroups/src/v2/devices/program.rs
@@ -1,8 +1,6 @@
 use oci_spec::runtime::*;
-
 use rbpf::disassembler::disassemble;
-use rbpf::insn_builder::Arch as RbpfArch;
-use rbpf::insn_builder::*;
+use rbpf::insn_builder::{Arch as RbpfArch, *};
 
 pub struct Program {
     prog: BpfCode,
@@ -259,9 +257,10 @@ fn bpf_cgroup_dev_ctx(
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use anyhow::Result;
     use oci_spec::runtime::LinuxDeviceCgroupBuilder;
+
+    use super::*;
 
     fn build_bpf_program(rules: &Option<Vec<LinuxDeviceCgroup>>) -> Result<Program> {
         let mut em = crate::v2::devices::emulator::Emulator::with_default_allow(false);

--- a/crates/libcgroups/src/v2/freezer.rs
+++ b/crates/libcgroups/src/v2/freezer.rs
@@ -1,15 +1,12 @@
-use std::{
-    fs::OpenOptions,
-    io::{BufRead, BufReader, Read, Seek, Write},
-    path::Path,
-    str::{self, Utf8Error},
-    thread,
-    time::Duration,
-};
-
-use crate::common::{ControllerOpt, FreezerState, WrapIoResult, WrappedIoError};
+use std::fs::OpenOptions;
+use std::io::{BufRead, BufReader, Read, Seek, Write};
+use std::path::Path;
+use std::str::{self, Utf8Error};
+use std::thread;
+use std::time::Duration;
 
 use super::controller::Controller;
+use crate::common::{ControllerOpt, FreezerState, WrapIoResult, WrappedIoError};
 
 const CGROUP_FREEZE: &str = "cgroup.freeze";
 const CGROUP_EVENTS: &str = "cgroup.events";
@@ -147,10 +144,11 @@ impl Freezer {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use super::*;
     use crate::common::FreezerState;
     use crate::test::set_fixture;
-    use std::sync::Arc;
 
     #[test]
     fn test_set_freezer_state() {

--- a/crates/libcgroups/src/v2/hugetlb.rs
+++ b/crates/libcgroups/src/v2/hugetlb.rs
@@ -1,20 +1,16 @@
-use std::{
-    collections::HashMap,
-    num::ParseIntError,
-    path::{Path, PathBuf},
-};
+use std::collections::HashMap;
+use std::num::ParseIntError;
+use std::path::{Path, PathBuf};
+
+use oci_spec::runtime::LinuxHugepageLimit;
 
 use super::controller::Controller;
-use crate::{
-    common::{self, ControllerOpt, EitherError, MustBePowerOfTwo, WrappedIoError},
-    stats::{
-        parse_single_value, supported_page_sizes, HugeTlbStats, StatsProvider,
-        SupportedPageSizesError,
-    },
+use crate::common::{
+    self, read_cgroup_file, ControllerOpt, EitherError, MustBePowerOfTwo, WrappedIoError,
 };
-
-use crate::common::read_cgroup_file;
-use oci_spec::runtime::LinuxHugepageLimit;
+use crate::stats::{
+    parse_single_value, supported_page_sizes, HugeTlbStats, StatsProvider, SupportedPageSizesError,
+};
 
 #[derive(thiserror::Error, Debug)]
 pub enum V2HugeTlbControllerError {
@@ -151,10 +147,12 @@ impl HugeTlb {
 
 #[cfg(test)]
 mod tests {
+    use std::fs::read_to_string;
+
+    use oci_spec::runtime::LinuxHugepageLimitBuilder;
+
     use super::*;
     use crate::test::set_fixture;
-    use oci_spec::runtime::LinuxHugepageLimitBuilder;
-    use std::fs::read_to_string;
 
     #[test]
     fn test_set_hugetlb() {

--- a/crates/libcgroups/src/v2/io.rs
+++ b/crates/libcgroups/src/v2/io.rs
@@ -1,18 +1,14 @@
-use std::{
-    num::ParseIntError,
-    path::{Path, PathBuf},
-};
+use std::num::ParseIntError;
+use std::path::{Path, PathBuf};
 
-use crate::{
-    common::{self, ControllerOpt, WrappedIoError},
-    stats::{
-        self, psi_stats, BlkioDeviceStat, BlkioStats, ParseDeviceNumberError,
-        ParseNestedKeyedDataError, StatsProvider,
-    },
-};
+use oci_spec::runtime::LinuxBlockIo;
 
 use super::controller::Controller;
-use oci_spec::runtime::LinuxBlockIo;
+use crate::common::{self, ControllerOpt, WrappedIoError};
+use crate::stats::{
+    self, psi_stats, BlkioDeviceStat, BlkioStats, ParseDeviceNumberError,
+    ParseNestedKeyedDataError, StatsProvider,
+};
 
 const CGROUP_BFQ_IO_WEIGHT: &str = "io.bfq.weight";
 const CGROUP_IO_WEIGHT: &str = "io.weight";
@@ -197,13 +193,14 @@ impl Io {
 }
 #[cfg(test)]
 mod test {
-    use super::*;
-    use crate::test::{set_fixture, setup};
+    use std::fs;
 
     use oci_spec::runtime::{
         LinuxBlockIoBuilder, LinuxThrottleDeviceBuilder, LinuxWeightDeviceBuilder,
     };
-    use std::fs;
+
+    use super::*;
+    use crate::test::{set_fixture, setup};
 
     #[test]
     fn test_set_io_read_bps() {

--- a/crates/libcgroups/src/v2/manager.rs
+++ b/crates/libcgroups/src/v2/manager.rs
@@ -1,36 +1,31 @@
-use std::{
-    fs::{self},
-    os::unix::fs::PermissionsExt,
-    path::{Component::RootDir, Path, PathBuf},
-    time::Duration,
-};
+use std::fs::{self};
+use std::os::unix::fs::PermissionsExt;
+use std::path::Component::RootDir;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
 
 use nix::unistd::Pid;
 
+use super::controller::Controller;
+use super::controller_type::{
+    ControllerType, PseudoControllerType, CONTROLLER_TYPES, PSEUDO_CONTROLLER_TYPES,
+};
+use super::cpu::{Cpu, V2CpuControllerError, V2CpuStatsError};
+use super::cpuset::CpuSet;
 #[cfg(feature = "cgroupsv2_devices")]
 use super::devices::Devices;
-use super::{
-    controller::Controller,
-    controller_type::{
-        ControllerType, PseudoControllerType, CONTROLLER_TYPES, PSEUDO_CONTROLLER_TYPES,
-    },
-    cpu::{Cpu, V2CpuControllerError, V2CpuStatsError},
-    cpuset::CpuSet,
-    freezer::{Freezer, V2FreezerError},
-    hugetlb::{HugeTlb, V2HugeTlbControllerError, V2HugeTlbStatsError},
-    io::{Io, V2IoControllerError, V2IoStatsError},
-    memory::{Memory, V2MemoryControllerError, V2MemoryStatsError},
-    pids::Pids,
-    unified::{Unified, V2UnifiedError},
-    util::{self, V2UtilError, CGROUP_SUBTREE_CONTROL},
+use super::freezer::{Freezer, V2FreezerError};
+use super::hugetlb::{HugeTlb, V2HugeTlbControllerError, V2HugeTlbStatsError};
+use super::io::{Io, V2IoControllerError, V2IoStatsError};
+use super::memory::{Memory, V2MemoryControllerError, V2MemoryStatsError};
+use super::pids::Pids;
+use super::unified::{Unified, V2UnifiedError};
+use super::util::{self, V2UtilError, CGROUP_SUBTREE_CONTROL};
+use crate::common::{
+    self, AnyCgroupManager, CgroupManager, ControllerOpt, FreezerState, JoinSafelyError,
+    PathBufExt, WrapIoResult, WrappedIoError, CGROUP_PROCS,
 };
-use crate::{
-    common::{
-        self, AnyCgroupManager, CgroupManager, ControllerOpt, FreezerState, JoinSafelyError,
-        PathBufExt, WrapIoResult, WrappedIoError, CGROUP_PROCS,
-    },
-    stats::{PidStatsError, Stats, StatsProvider},
-};
+use crate::stats::{PidStatsError, Stats, StatsProvider};
 
 pub const CGROUP_KILL: &str = "cgroup.kill";
 

--- a/crates/libcgroups/src/v2/memory.rs
+++ b/crates/libcgroups/src/v2/memory.rs
@@ -2,12 +2,9 @@ use std::path::Path;
 
 use oci_spec::runtime::LinuxMemory;
 
-use crate::{
-    common::{self, ControllerOpt, WrappedIoError},
-    stats::{self, MemoryData, MemoryStats, ParseFlatKeyedDataError, StatsProvider},
-};
-
 use super::controller::Controller;
+use crate::common::{self, ControllerOpt, WrappedIoError};
+use crate::stats::{self, MemoryData, MemoryStats, ParseFlatKeyedDataError, StatsProvider};
 
 const CGROUP_MEMORY_SWAP: &str = "memory.swap.max";
 const CGROUP_MEMORY_MAX: &str = "memory.max";
@@ -166,10 +163,12 @@ impl Memory {
 
 #[cfg(test)]
 mod tests {
+    use std::fs::read_to_string;
+
+    use oci_spec::runtime::LinuxMemoryBuilder;
+
     use super::*;
     use crate::test::set_fixture;
-    use oci_spec::runtime::LinuxMemoryBuilder;
-    use std::fs::read_to_string;
 
     #[test]
     fn test_set_memory() {

--- a/crates/libcgroups/src/v2/pids.rs
+++ b/crates/libcgroups/src/v2/pids.rs
@@ -1,12 +1,10 @@
 use std::path::Path;
 
-use crate::{
-    common::{self, ControllerOpt, WrappedIoError},
-    stats::{self, PidStats, PidStatsError, StatsProvider},
-};
+use oci_spec::runtime::LinuxPids;
 
 use super::controller::Controller;
-use oci_spec::runtime::LinuxPids;
+use crate::common::{self, ControllerOpt, WrappedIoError};
+use crate::stats::{self, PidStats, PidStatsError, StatsProvider};
 
 pub struct Pids {}
 
@@ -47,9 +45,10 @@ impl Pids {
 
 #[cfg(test)]
 mod tests {
+    use oci_spec::runtime::LinuxPidsBuilder;
+
     use super::*;
     use crate::test::set_fixture;
-    use oci_spec::runtime::LinuxPidsBuilder;
 
     #[test]
     fn test_set_pids() {

--- a/crates/libcgroups/src/v2/unified.rs
+++ b/crates/libcgroups/src/v2/unified.rs
@@ -1,4 +1,5 @@
-use std::{collections::HashMap, path::Path};
+use std::collections::HashMap;
+use std::path::Path;
 
 use super::controller_type::ControllerType;
 use crate::common::{self, ControllerOpt, WrappedIoError};
@@ -61,10 +62,9 @@ mod tests {
 
     use oci_spec::runtime::LinuxResourcesBuilder;
 
+    use super::*;
     use crate::test::set_fixture;
     use crate::v2::controller_type::ControllerType;
-
-    use super::*;
 
     #[test]
     fn test_set_unified() {

--- a/crates/libcgroups/src/v2/util.rs
+++ b/crates/libcgroups/src/v2/util.rs
@@ -1,10 +1,10 @@
 use std::path::{Path, PathBuf};
 
-use procfs::{process::Process, ProcError};
-
-use crate::common::{self, WrappedIoError};
+use procfs::process::Process;
+use procfs::ProcError;
 
 use super::controller_type::ControllerType;
+use crate::common::{self, WrappedIoError};
 
 pub const CGROUP_CONTROLLERS: &str = "cgroup.controllers";
 pub const CGROUP_SUBTREE_CONTROL: &str = "cgroup.subtree_control";

--- a/crates/libcontainer/src/apparmor.rs
+++ b/crates/libcontainer/src/apparmor.rs
@@ -1,8 +1,7 @@
+use std::fs::{self};
+use std::path::Path;
+
 use crate::utils;
-use std::{
-    fs::{self},
-    path::Path,
-};
 
 #[derive(Debug, thiserror::Error)]
 pub enum AppArmorError {

--- a/crates/libcontainer/src/capabilities.rs
+++ b/crates/libcontainer/src/capabilities.rs
@@ -1,9 +1,8 @@
 //! Handles Management of Capabilities
-use crate::syscall::{Syscall, SyscallError};
-use caps::Capability as CapsCapability;
-use caps::*;
-
+use caps::{Capability as CapsCapability, *};
 use oci_spec::runtime::{Capabilities, Capability as SpecCapability, LinuxCapabilities};
+
+use crate::syscall::{Syscall, SyscallError};
 
 /// Converts a list of capability types to capabilities has set
 fn to_set(caps: &Capabilities) -> CapsHashSet {
@@ -165,8 +164,9 @@ pub fn drop_privileges<S: Syscall + ?Sized>(
 
 #[cfg(test)]
 mod tests {
-    use oci_spec::runtime::LinuxCapabilitiesBuilder;
     use std::collections::HashSet;
+
+    use oci_spec::runtime::LinuxCapabilitiesBuilder;
 
     use super::*;
     use crate::syscall::test::TestHelperSyscall;

--- a/crates/libcontainer/src/channel.rs
+++ b/crates/libcontainer/src/channel.rs
@@ -1,13 +1,11 @@
-use nix::{
-    sys::socket::{self, UnixAddr},
-    unistd::{self},
-};
+use std::io::{IoSlice, IoSliceMut};
+use std::marker::PhantomData;
+use std::os::fd::AsRawFd;
+use std::os::unix::prelude::RawFd;
+
+use nix::sys::socket::{self, UnixAddr};
+use nix::unistd::{self};
 use serde::{Deserialize, Serialize};
-use std::{
-    io::{IoSlice, IoSliceMut},
-    marker::PhantomData,
-    os::{fd::AsRawFd, unix::prelude::RawFd},
-};
 
 #[derive(Debug, thiserror::Error)]
 pub enum ChannelError {

--- a/crates/libcontainer/src/config.rs
+++ b/crates/libcontainer/src/config.rs
@@ -1,11 +1,11 @@
-use crate::utils;
+use std::fs;
+use std::io::{BufReader, BufWriter, Write};
+use std::path::{Path, PathBuf};
+
 use oci_spec::runtime::{Hooks, Spec};
 use serde::{Deserialize, Serialize};
-use std::{
-    fs,
-    io::{BufReader, BufWriter, Write},
-    path::{Path, PathBuf},
-};
+
+use crate::utils;
 
 #[derive(Debug, thiserror::Error)]
 pub enum ConfigError {
@@ -98,8 +98,9 @@ impl<'a> YoukiConfig {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use anyhow::Result;
+
+    use super::*;
 
     #[test]
     fn test_config_from_spec() -> Result<()> {

--- a/crates/libcontainer/src/container/builder.rs
+++ b/crates/libcontainer/src/container/builder.rs
@@ -1,10 +1,11 @@
+use std::path::PathBuf;
+
+use super::init_builder::InitContainerBuilder;
+use super::tenant_builder::TenantContainerBuilder;
 use crate::error::{ErrInvalidID, LibcontainerError};
 use crate::syscall::syscall::SyscallType;
 use crate::utils::PathBufExt;
 use crate::workload::{self, Executor};
-use std::path::PathBuf;
-
-use super::{init_builder::InitContainerBuilder, tenant_builder::TenantContainerBuilder};
 
 pub struct ContainerBuilder {
     /// Id of the container
@@ -260,9 +261,12 @@ impl ContainerBuilder {
 
 #[cfg(test)]
 mod tests {
-    use crate::{container::builder::ContainerBuilder, syscall::syscall::SyscallType};
-    use anyhow::{Context, Result};
     use std::path::PathBuf;
+
+    use anyhow::{Context, Result};
+
+    use crate::container::builder::ContainerBuilder;
+    use crate::syscall::syscall::SyscallType;
 
     #[test]
     fn test_failable_functions() -> Result<()> {

--- a/crates/libcontainer/src/container/builder_impl.rs
+++ b/crates/libcontainer/src/container/builder_impl.rs
@@ -1,24 +1,23 @@
-use std::{fs, io::Write, os::unix::prelude::RawFd, path::PathBuf, rc::Rc};
+use std::fs;
+use std::io::Write;
+use std::os::unix::prelude::RawFd;
+use std::path::PathBuf;
+use std::rc::Rc;
 
 use libcgroups::common::CgroupManager;
 use nix::unistd::Pid;
 use oci_spec::runtime::Spec;
 
 use super::{Container, ContainerStatus};
-use crate::{
-    error::{LibcontainerError, MissingSpecError},
-    hooks,
-    notify_socket::NotifyListener,
-    process::{
-        self,
-        args::{ContainerArgs, ContainerType},
-        intel_rdt::delete_resctrl_subdirectory,
-    },
-    syscall::syscall::SyscallType,
-    user_ns::UserNamespaceConfig,
-    utils,
-    workload::Executor,
-};
+use crate::error::{LibcontainerError, MissingSpecError};
+use crate::notify_socket::NotifyListener;
+use crate::process::args::{ContainerArgs, ContainerType};
+use crate::process::intel_rdt::delete_resctrl_subdirectory;
+use crate::process::{self};
+use crate::syscall::syscall::SyscallType;
+use crate::user_ns::UserNamespaceConfig;
+use crate::workload::Executor;
+use crate::{hooks, utils};
 
 pub(super) struct ContainerBuilderImpl {
     /// Flag indicating if an init or a tenant container should be created

--- a/crates/libcontainer/src/container/container.rs
+++ b/crates/libcontainer/src/container/container.rs
@@ -1,17 +1,16 @@
-use crate::config::YoukiConfig;
-use crate::container::{ContainerStatus, State};
-use crate::error::LibcontainerError;
-use crate::syscall::syscall::create_syscall;
-
-use chrono::DateTime;
-use chrono::Utc;
-use nix::unistd::Pid;
-use procfs::process::Process;
-
 use std::collections::HashMap;
 use std::ffi::OsString;
 use std::fs;
 use std::path::{Path, PathBuf};
+
+use chrono::{DateTime, Utc};
+use nix::unistd::Pid;
+use procfs::process::Process;
+
+use crate::config::YoukiConfig;
+use crate::container::{ContainerStatus, State};
+use crate::error::LibcontainerError;
+use crate::syscall::syscall::create_syscall;
 
 /// Structure representing the container data
 #[derive(Debug, Clone)]
@@ -228,10 +227,10 @@ pub struct CheckpointOptions {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use anyhow::Context;
-    use anyhow::Result;
+    use anyhow::{Context, Result};
     use serial_test::serial;
+
+    use super::*;
 
     #[test]
     fn test_get_set_pid() {

--- a/crates/libcontainer/src/container/container_checkpoint.rs
+++ b/crates/libcontainer/src/container/container_checkpoint.rs
@@ -1,14 +1,15 @@
-use super::{Container, ContainerStatus};
-use crate::container::container::CheckpointOptions;
-use crate::error::LibcontainerError;
+use std::fs::{self, File};
+use std::io::Write;
+use std::os::unix::io::AsRawFd;
 
 use libcgroups::common::CgroupSetup::{Hybrid, Legacy};
 #[cfg(feature = "v1")]
 use libcgroups::common::DEFAULT_CGROUP_ROOT;
 use oci_spec::runtime::Spec;
-use std::fs::{self, File};
-use std::io::Write;
-use std::os::unix::io::AsRawFd;
+
+use super::{Container, ContainerStatus};
+use crate::container::container::CheckpointOptions;
+use crate::error::LibcontainerError;
 
 const CRIU_CHECKPOINT_LOG_FILE: &str = "dump.log";
 const DESCRIPTORS_JSON: &str = "descriptors.json";

--- a/crates/libcontainer/src/container/container_delete.rs
+++ b/crates/libcontainer/src/container/container_delete.rs
@@ -1,10 +1,14 @@
+use std::fs;
+
+use libcgroups::common::CgroupManager;
+use libcgroups::{self};
+use nix::sys::signal;
+
 use super::{Container, ContainerStatus};
+use crate::config::YoukiConfig;
+use crate::error::LibcontainerError;
 use crate::hooks;
 use crate::process::intel_rdt::delete_resctrl_subdirectory;
-use crate::{config::YoukiConfig, error::LibcontainerError};
-use libcgroups::{self, common::CgroupManager};
-use nix::sys::signal;
-use std::fs;
 
 impl Container {
     /// Deletes the container

--- a/crates/libcontainer/src/container/container_events.rs
+++ b/crates/libcontainer/src/container/container_events.rs
@@ -1,9 +1,10 @@
-use std::{thread, time::Duration};
+use std::thread;
+use std::time::Duration;
 
-use crate::error::LibcontainerError;
+use libcgroups::common::CgroupManager;
 
 use super::{Container, ContainerStatus};
-use libcgroups::common::CgroupManager;
+use crate::error::LibcontainerError;
 
 impl Container {
     /// Displays container events

--- a/crates/libcontainer/src/container/container_kill.rs
+++ b/crates/libcontainer/src/container/container_kill.rs
@@ -1,7 +1,9 @@
-use super::{Container, ContainerStatus};
-use crate::{error::LibcontainerError, signal::Signal};
 use libcgroups::common::{get_cgroup_setup, CgroupManager};
 use nix::sys::signal::{self};
+
+use super::{Container, ContainerStatus};
+use crate::error::LibcontainerError;
+use crate::signal::Signal;
 
 impl Container {
     /// Sends the specified signal to the container init process

--- a/crates/libcontainer/src/container/container_pause.rs
+++ b/crates/libcontainer/src/container/container_pause.rs
@@ -1,7 +1,7 @@
-use crate::error::LibcontainerError;
+use libcgroups::common::{CgroupManager, FreezerState};
 
 use super::{Container, ContainerStatus};
-use libcgroups::common::{CgroupManager, FreezerState};
+use crate::error::LibcontainerError;
 
 impl Container {
     /// Suspends all processes within the container

--- a/crates/libcontainer/src/container/container_resume.rs
+++ b/crates/libcontainer/src/container/container_resume.rs
@@ -1,8 +1,7 @@
-use crate::error::LibcontainerError;
+use libcgroups::common::{CgroupManager, FreezerState};
 
 use super::{Container, ContainerStatus};
-
-use libcgroups::common::{CgroupManager, FreezerState};
+use crate::error::LibcontainerError;
 
 impl Container {
     /// Resumes all processes within the container

--- a/crates/libcontainer/src/container/container_start.rs
+++ b/crates/libcontainer/src/container/container_start.rs
@@ -1,12 +1,10 @@
 use nix::sys::signal;
 
 use super::{Container, ContainerStatus};
-use crate::{
-    config::YoukiConfig,
-    error::LibcontainerError,
-    hooks,
-    notify_socket::{NotifySocket, NOTIFY_FILE},
-};
+use crate::config::YoukiConfig;
+use crate::error::LibcontainerError;
+use crate::hooks;
+use crate::notify_socket::{NotifySocket, NOTIFY_FILE};
 
 impl Container {
     /// Starts a previously created container

--- a/crates/libcontainer/src/container/init_builder.rs
+++ b/crates/libcontainer/src/container/init_builder.rs
@@ -1,23 +1,18 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::rc::Rc;
+
 use oci_spec::runtime::Spec;
-use std::{
-    fs,
-    path::{Path, PathBuf},
-    rc::Rc,
-};
 use user_ns::UserNamespaceConfig;
 
-use crate::{
-    apparmor,
-    config::YoukiConfig,
-    error::{ErrInvalidSpec, LibcontainerError, MissingSpecError},
-    notify_socket::NOTIFY_FILE,
-    process::args::ContainerType,
-    tty, user_ns, utils,
-};
-
-use super::{
-    builder::ContainerBuilder, builder_impl::ContainerBuilderImpl, Container, ContainerStatus,
-};
+use super::builder::ContainerBuilder;
+use super::builder_impl::ContainerBuilderImpl;
+use super::{Container, ContainerStatus};
+use crate::config::YoukiConfig;
+use crate::error::{ErrInvalidSpec, LibcontainerError, MissingSpecError};
+use crate::notify_socket::NOTIFY_FILE;
+use crate::process::args::ContainerType;
+use crate::{apparmor, tty, user_ns, utils};
 
 // Builder that can be used to configure the properties of a new container
 pub struct InitContainerBuilder {

--- a/crates/libcontainer/src/container/mod.rs
+++ b/crates/libcontainer/src/container/mod.rs
@@ -18,7 +18,6 @@ mod container_start;
 pub mod init_builder;
 pub mod state;
 pub mod tenant_builder;
-pub use container::CheckpointOptions;
-pub use container::Container;
+pub use container::{CheckpointOptions, Container};
 pub use container_checkpoint::CheckpointError;
 pub use state::{ContainerProcessState, ContainerStatus, State};

--- a/crates/libcontainer/src/container/state.rs
+++ b/crates/libcontainer/src/container/state.rs
@@ -2,9 +2,9 @@
 use std::collections::HashMap;
 use std::fmt::Display;
 use std::fs;
+use std::fs::File;
 use std::io::{BufReader, BufWriter, Write};
-use std::path::PathBuf;
-use std::{fs::File, path::Path};
+use std::path::{Path, PathBuf};
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};

--- a/crates/libcontainer/src/container/tenant_builder.rs
+++ b/crates/libcontainer/src/container/tenant_builder.rs
@@ -1,3 +1,13 @@
+use std::collections::HashMap;
+use std::convert::TryFrom;
+use std::ffi::{OsStr, OsString};
+use std::fs;
+use std::io::BufReader;
+use std::os::unix::prelude::RawFd;
+use std::path::{Path, PathBuf};
+use std::rc::Rc;
+use std::str::FromStr;
+
 use caps::Capability;
 use nix::fcntl::OFlag;
 use nix::unistd::{close, pipe2, read, Pid};
@@ -8,24 +18,15 @@ use oci_spec::runtime::{
 };
 use procfs::process::Namespace;
 
-use std::rc::Rc;
-use std::{
-    collections::HashMap,
-    convert::TryFrom,
-    ffi::{OsStr, OsString},
-    fs,
-    io::BufReader,
-    os::unix::prelude::RawFd,
-    path::{Path, PathBuf},
-    str::FromStr,
-};
-
+use super::builder::ContainerBuilder;
+use super::Container;
+use crate::capabilities::CapabilityExt;
+use crate::container::builder_impl::ContainerBuilderImpl;
 use crate::error::{ErrInvalidSpec, LibcontainerError, MissingSpecError};
+use crate::notify_socket::NotifySocket;
 use crate::process::args::ContainerType;
-use crate::{capabilities::CapabilityExt, container::builder_impl::ContainerBuilderImpl};
-use crate::{notify_socket::NotifySocket, tty, user_ns::UserNamespaceConfig, utils};
-
-use super::{builder::ContainerBuilder, Container};
+use crate::user_ns::UserNamespaceConfig;
+use crate::{tty, utils};
 
 const NAMESPACE_TYPES: &[&str] = &["ipc", "uts", "net", "pid", "mnt", "cgroup"];
 const TENANT_NOTIFY: &str = "tenant-notify-";

--- a/crates/libcontainer/src/hooks.rs
+++ b/crates/libcontainer/src/hooks.rs
@@ -1,15 +1,15 @@
-use std::{
-    collections::HashMap,
-    io::{ErrorKind, Write},
-    os::unix::prelude::CommandExt,
-    path::Path,
-    process, thread, time,
-};
+use std::collections::HashMap;
+use std::io::{ErrorKind, Write};
+use std::os::unix::prelude::CommandExt;
+use std::path::Path;
+use std::{process, thread, time};
 
-use nix::{sys::signal, unistd::Pid};
+use nix::sys::signal;
+use nix::unistd::Pid;
 use oci_spec::runtime::Hook;
 
-use crate::{container::Container, utils};
+use crate::container::Container;
+use crate::utils;
 
 #[derive(Debug, thiserror::Error)]
 pub enum HookError {
@@ -144,11 +144,13 @@ pub fn run_hooks(
 
 #[cfg(test)]
 mod test {
-    use super::*;
+    use std::{env, fs};
+
     use anyhow::{bail, Context, Result};
     use oci_spec::runtime::HookBuilder;
     use serial_test::serial;
-    use std::{env, fs};
+
+    use super::*;
 
     fn is_command_in_path(program: &str) -> bool {
         if let Ok(path) = env::var("PATH") {

--- a/crates/libcontainer/src/namespaces.rs
+++ b/crates/libcontainer/src/namespaces.rs
@@ -7,10 +7,15 @@
 //! UTS (hostname and domain information, processes will think they're running on servers with different names),
 //! Cgroup (Resource limits, execution priority etc.)
 
-use crate::syscall::{syscall::create_syscall, Syscall};
-use nix::{fcntl, sched::CloneFlags, sys::stat, unistd};
-use oci_spec::runtime::{LinuxNamespace, LinuxNamespaceType};
 use std::collections;
+
+use nix::sched::CloneFlags;
+use nix::sys::stat;
+use nix::{fcntl, unistd};
+use oci_spec::runtime::{LinuxNamespace, LinuxNamespaceType};
+
+use crate::syscall::syscall::create_syscall;
+use crate::syscall::Syscall;
 
 type Result<T> = std::result::Result<T, NamespaceError>;
 
@@ -135,10 +140,11 @@ impl Namespaces {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use crate::syscall::test::TestHelperSyscall;
     use oci_spec::runtime::{LinuxNamespaceBuilder, LinuxNamespaceType};
     use serial_test::serial;
+
+    use super::*;
+    use crate::syscall::test::TestHelperSyscall;
 
     fn gen_sample_linux_namespaces() -> Vec<LinuxNamespace> {
         vec![

--- a/crates/libcontainer/src/notify_socket.rs
+++ b/crates/libcontainer/src/notify_socket.rs
@@ -1,10 +1,11 @@
-use nix::unistd::{self, close};
 use std::env;
 use std::io::prelude::*;
 use std::os::fd::FromRawFd;
 use std::os::unix::io::AsRawFd;
 use std::os::unix::net::{UnixListener, UnixStream};
 use std::path::{Path, PathBuf};
+
+use nix::unistd::{self, close};
 
 pub const NOTIFY_FILE: &str = "notify.sock";
 

--- a/crates/libcontainer/src/process/args.rs
+++ b/crates/libcontainer/src/process/args.rs
@@ -1,8 +1,9 @@
-use libcgroups::common::CgroupConfig;
-use oci_spec::runtime::Spec;
 use std::os::unix::prelude::RawFd;
 use std::path::PathBuf;
 use std::rc::Rc;
+
+use libcgroups::common::CgroupConfig;
+use oci_spec::runtime::Spec;
 
 use crate::container::Container;
 use crate::notify_socket::NotifyListener;

--- a/crates/libcontainer/src/process/channel.rs
+++ b/crates/libcontainer/src/process/channel.rs
@@ -1,7 +1,9 @@
+use std::os::unix::prelude::{AsRawFd, RawFd};
+
+use nix::unistd::Pid;
+
 use crate::channel::{channel, Receiver, Sender};
 use crate::process::message::Message;
-use nix::unistd::Pid;
-use std::os::unix::prelude::{AsRawFd, RawFd};
 
 #[derive(Debug, thiserror::Error)]
 pub enum ChannelError {
@@ -308,11 +310,12 @@ impl InitReceiver {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use anyhow::{Context, Result};
     use nix::sys::wait;
     use nix::unistd;
     use serial_test::serial;
+
+    use super::*;
 
     // Note: due to cargo test by default runs tests in parallel using a single
     // process, these tests should not be running in parallel with other tests.

--- a/crates/libcontainer/src/process/container_init_process.rs
+++ b/crates/libcontainer/src/process/container_init_process.rs
@@ -1,40 +1,28 @@
-use std::{
-    collections::HashMap,
-    env, fs, mem,
-    os::unix::io::AsRawFd,
-    path::{Path, PathBuf},
-};
-
-use super::args::{ContainerArgs, ContainerType};
-#[cfg(feature = "libseccomp")]
-use crate::seccomp;
-use crate::{
-    apparmor, capabilities,
-    error::MissingSpecError,
-    hooks,
-    namespaces::{NamespaceError, Namespaces},
-    notify_socket,
-    process::channel,
-    rootfs,
-    rootfs::RootFS,
-    syscall::{Syscall, SyscallError},
-    tty,
-    user_ns::UserNamespaceConfig,
-    utils, workload,
-};
+use std::collections::HashMap;
+use std::os::unix::io::AsRawFd;
+use std::path::{Path, PathBuf};
+use std::{env, fs, mem};
 
 use nc;
-use nix::{
-    mount::MsFlags,
-    sched::CloneFlags,
-    sys::stat::Mode,
-    unistd::setsid,
-    unistd::{self, Gid, Uid},
-};
+use nix::mount::MsFlags;
+use nix::sched::CloneFlags;
+use nix::sys::stat::Mode;
+use nix::unistd::{self, setsid, Gid, Uid};
 use oci_spec::runtime::{
     IOPriorityClass, LinuxIOPriority, LinuxNamespaceType, LinuxSchedulerFlag, LinuxSchedulerPolicy,
     Scheduler, Spec, User,
 };
+
+use super::args::{ContainerArgs, ContainerType};
+use crate::error::MissingSpecError;
+use crate::namespaces::{NamespaceError, Namespaces};
+use crate::process::channel;
+use crate::rootfs::RootFS;
+#[cfg(feature = "libseccomp")]
+use crate::seccomp;
+use crate::syscall::{Syscall, SyscallError};
+use crate::user_ns::UserNamespaceConfig;
+use crate::{apparmor, capabilities, hooks, notify_socket, rootfs, tty, utils, workload};
 
 #[derive(Debug, thiserror::Error)]
 pub enum InitProcessError {
@@ -879,18 +867,18 @@ fn verify_cwd() -> Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use crate::syscall::{
-        syscall::create_syscall,
-        test::{ArgName, IoPriorityArgs, MountArgs, TestHelperSyscall},
-    };
+    use std::fs;
+
     use anyhow::Result;
     #[cfg(feature = "libseccomp")]
     use nix::unistd;
     use oci_spec::runtime::{LinuxNamespaceBuilder, SpecBuilder, UserBuilder};
     #[cfg(feature = "libseccomp")]
     use serial_test::serial;
-    use std::fs;
+
+    use super::*;
+    use crate::syscall::syscall::create_syscall;
+    use crate::syscall::test::{ArgName, IoPriorityArgs, MountArgs, TestHelperSyscall};
 
     #[test]
     fn test_readonly_path() -> Result<()> {

--- a/crates/libcontainer/src/process/container_intermediate_process.rs
+++ b/crates/libcontainer/src/process/container_intermediate_process.rs
@@ -1,8 +1,5 @@
-use crate::error::MissingSpecError;
-use crate::{namespaces::Namespaces, process::channel, process::fork};
 use libcgroups::common::CgroupManager;
-use nix::unistd::{close, write};
-use nix::unistd::{Gid, Pid, Uid};
+use nix::unistd::{close, write, Gid, Pid, Uid};
 use oci_spec::runtime::{LinuxNamespace, LinuxNamespaceType, LinuxResources};
 use procfs::process::Process;
 
@@ -10,6 +7,9 @@ use super::args::{ContainerArgs, ContainerType};
 use super::channel::{IntermediateReceiver, MainSender};
 use super::container_init_process::container_init_process;
 use super::fork::CloneCb;
+use crate::error::MissingSpecError;
+use crate::namespaces::Namespaces;
+use crate::process::{channel, fork};
 
 #[derive(Debug, thiserror::Error)]
 pub enum IntermediateProcessError {
@@ -261,12 +261,13 @@ fn apply_cgroups<
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use anyhow::Result;
     use libcgroups::test_manager::TestManager;
     use nix::unistd::Pid;
     use oci_spec::runtime::LinuxResources;
     use procfs::process::Process;
+
+    use super::*;
 
     #[test]
     fn apply_cgroup_init() -> Result<()> {

--- a/crates/libcontainer/src/process/container_main_process.rs
+++ b/crates/libcontainer/src/process/container_main_process.rs
@@ -1,15 +1,12 @@
-use crate::{
-    process::{
-        args::ContainerArgs,
-        channel, container_intermediate_process,
-        fork::{self, CloneCb},
-        intel_rdt::setup_intel_rdt,
-    },
-    syscall::SyscallError,
-    user_ns::UserNamespaceConfig,
-};
 use nix::sys::wait::{waitpid, WaitStatus};
 use nix::unistd::Pid;
+
+use crate::process::args::ContainerArgs;
+use crate::process::fork::{self, CloneCb};
+use crate::process::intel_rdt::setup_intel_rdt;
+use crate::process::{channel, container_intermediate_process};
+use crate::syscall::SyscallError;
+use crate::user_ns::UserNamespaceConfig;
 
 #[derive(Debug, thiserror::Error)]
 pub enum ProcessError {
@@ -231,17 +228,17 @@ fn setup_mapping(config: &UserNamespaceConfig, pid: Pid) -> Result<()> {
 
 #[cfg(test)]
 mod tests {
+    use std::fs;
+
+    use anyhow::Result;
+    use nix::sched::{unshare, CloneFlags};
+    use nix::unistd::{self, getgid, getuid};
+    use oci_spec::runtime::LinuxIdMappingBuilder;
+    use serial_test::serial;
+
     use super::*;
     use crate::process::channel::{intermediate_channel, main_channel};
     use crate::user_ns::UserNamespaceIDMapper;
-    use anyhow::Result;
-    use nix::{
-        sched::{unshare, CloneFlags},
-        unistd::{self, getgid, getuid},
-    };
-    use oci_spec::runtime::LinuxIdMappingBuilder;
-    use serial_test::serial;
-    use std::fs;
 
     #[test]
     #[serial]

--- a/crates/libcontainer/src/process/fork.rs
+++ b/crates/libcontainer/src/process/fork.rs
@@ -1,10 +1,10 @@
-use std::{ffi::c_int, fs::File, num::NonZeroUsize};
+use std::ffi::c_int;
+use std::fs::File;
+use std::num::NonZeroUsize;
 
 use libc::SIGCHLD;
-use nix::{
-    sys::{mman, resource},
-    unistd::Pid,
-};
+use nix::sys::{mman, resource};
+use nix::unistd::Pid;
 
 #[derive(Debug, thiserror::Error)]
 pub enum CloneError {
@@ -243,12 +243,12 @@ fn clone(cb: CloneCb, flags: u64, exit_signal: Option<u64>) -> Result<Pid, Clone
 
 #[cfg(test)]
 mod test {
-    use crate::channel::channel;
-
-    use super::*;
     use anyhow::{bail, Context, Result};
     use nix::sys::wait::{waitpid, WaitStatus};
     use nix::unistd;
+
+    use super::*;
+    use crate::channel::channel;
 
     #[test]
     fn test_container_fork() -> Result<()> {
@@ -331,10 +331,11 @@ mod test {
     #[cfg(feature = "libseccomp")]
     #[test]
     fn test_clone_fallback() -> Result<()> {
-        use crate::test_utils::TestCallbackError;
         use oci_spec::runtime::{
             Arch, LinuxSeccompAction, LinuxSeccompBuilder, LinuxSyscallBuilder,
         };
+
+        use crate::test_utils::TestCallbackError;
 
         fn has_clone3() -> bool {
             // We use the probe syscall to check if the kernel supports clone3 or

--- a/crates/libcontainer/src/process/intel_rdt.rs
+++ b/crates/libcontainer/src/process/intel_rdt.rs
@@ -1,15 +1,13 @@
-use once_cell::sync::Lazy;
-use regex::Regex;
 use std::collections::HashMap;
+use std::fs::{self, OpenOptions};
 use std::io::Write;
-use std::{
-    fs::{self, OpenOptions},
-    path::{Path, PathBuf},
-};
+use std::path::{Path, PathBuf};
 
 use nix::unistd::Pid;
 use oci_spec::runtime::LinuxIntelRdt;
+use once_cell::sync::Lazy;
 use procfs::process::Process;
+use regex::Regex;
 
 #[derive(Debug, thiserror::Error)]
 pub enum IntelRdtError {
@@ -410,8 +408,9 @@ pub fn setup_intel_rdt(
 
 #[cfg(test)]
 mod test {
-    use super::*;
     use anyhow::Result;
+
+    use super::*;
 
     #[test]
     fn test_combine_schemas() -> Result<()> {

--- a/crates/libcontainer/src/process/message.rs
+++ b/crates/libcontainer/src/process/message.rs
@@ -1,4 +1,5 @@
 use core::fmt;
+
 use serde::{Deserialize, Serialize};
 
 /// Used as a wrapper for messages to be sent between child and parent processes

--- a/crates/libcontainer/src/process/seccomp_listener.rs
+++ b/crates/libcontainer/src/process/seccomp_listener.rs
@@ -1,13 +1,14 @@
-use crate::container::ContainerProcessState;
-use crate::seccomp;
-use nix::{
-    sys::socket::{self, UnixAddr},
-    unistd,
-};
+use std::io::IoSlice;
+use std::os::fd::AsRawFd;
+use std::path::Path;
+
+use nix::sys::socket::{self, UnixAddr};
+use nix::unistd;
 use oci_spec::runtime;
-use std::{io::IoSlice, os::fd::AsRawFd, path::Path};
 
 use super::channel;
+use crate::container::ContainerProcessState;
+use crate::seccomp;
 
 #[derive(Debug, thiserror::Error)]
 pub enum SeccompListenerError {
@@ -109,12 +110,13 @@ fn sync_seccomp_send_msg(listener_path: &Path, msg: &[u8], fd: i32) -> Result<()
 
 #[cfg(test)]
 mod tests {
-    use crate::{container::ContainerProcessState, process::channel};
-
-    use super::*;
     use anyhow::Result;
     use oci_spec::runtime::{LinuxSeccompAction, LinuxSeccompBuilder, LinuxSyscallBuilder};
     use serial_test::serial;
+
+    use super::*;
+    use crate::container::ContainerProcessState;
+    use crate::process::channel;
 
     #[test]
     #[serial]

--- a/crates/libcontainer/src/rootfs/device.rs
+++ b/crates/libcontainer/src/rootfs/device.rs
@@ -1,14 +1,15 @@
-use super::utils::to_sflag;
-use crate::syscall::{syscall::create_syscall, Syscall};
-use crate::utils::PathBufExt;
-use nix::{
-    fcntl::{open, OFlag},
-    mount::MsFlags,
-    sys::stat::{umask, Mode},
-    unistd::{close, Gid, Uid},
-};
-use oci_spec::runtime::LinuxDevice;
 use std::path::{Path, PathBuf};
+
+use nix::fcntl::{open, OFlag};
+use nix::mount::MsFlags;
+use nix::sys::stat::{umask, Mode};
+use nix::unistd::{close, Gid, Uid};
+use oci_spec::runtime::LinuxDevice;
+
+use super::utils::to_sflag;
+use crate::syscall::syscall::create_syscall;
+use crate::syscall::Syscall;
+use crate::utils::PathBufExt;
 
 #[derive(Debug, thiserror::Error)]
 pub enum DeviceError {
@@ -194,15 +195,15 @@ fn create_container_dev_path(rootfs: &Path, dev: &LinuxDevice) -> Result<PathBuf
 
 #[cfg(test)]
 mod tests {
+    use std::path::PathBuf;
+
+    use anyhow::Result;
+    use nix::sys::stat::SFlag;
+    use nix::unistd::{Gid, Uid};
+    use oci_spec::runtime::{LinuxDeviceBuilder, LinuxDeviceType};
+
     use super::*;
     use crate::syscall::test::{ChownArgs, MknodArgs, MountArgs, TestHelperSyscall};
-    use anyhow::Result;
-    use nix::{
-        sys::stat::SFlag,
-        unistd::{Gid, Uid},
-    };
-    use oci_spec::runtime::{LinuxDeviceBuilder, LinuxDeviceType};
-    use std::path::PathBuf;
 
     #[test]
     fn test_bind_dev() -> Result<()> {

--- a/crates/libcontainer/src/rootfs/rootfs.rs
+++ b/crates/libcontainer/src/rootfs/rootfs.rs
@@ -1,17 +1,17 @@
-use super::{
-    device::Device,
-    mount::{Mount, MountOptions},
-    symlink::Symlink,
-    utils::default_devices,
-    Result, RootfsError,
-};
-use crate::{
-    error::MissingSpecError,
-    syscall::{syscall::create_syscall, Syscall},
-};
+use std::collections::HashSet;
+use std::path::Path;
+
 use nix::mount::MsFlags;
 use oci_spec::runtime::{Linux, Spec};
-use std::{collections::HashSet, path::Path};
+
+use super::device::Device;
+use super::mount::{Mount, MountOptions};
+use super::symlink::Symlink;
+use super::utils::default_devices;
+use super::{Result, RootfsError};
+use crate::error::MissingSpecError;
+use crate::syscall::syscall::create_syscall;
+use crate::syscall::Syscall;
 
 /// Holds information about rootfs
 pub struct RootFS {

--- a/crates/libcontainer/src/rootfs/symlink.rs
+++ b/crates/libcontainer/src/rootfs/symlink.rs
@@ -1,6 +1,8 @@
-use crate::syscall::{syscall::create_syscall, Syscall};
 use std::fs::remove_file;
 use std::path::Path;
+
+use crate::syscall::syscall::create_syscall;
+use crate::syscall::Syscall;
 
 #[derive(Debug, thiserror::Error)]
 pub enum SymlinkError {
@@ -108,19 +110,19 @@ impl Symlink {
 
 #[cfg(test)]
 mod tests {
+    #[cfg(feature = "v1")]
+    use std::fs;
+    use std::path::PathBuf;
+
+    #[cfg(feature = "v1")]
+    use anyhow::{Context, Result};
+    use nix::fcntl::{open, OFlag};
+    use nix::sys::stat::Mode;
+
     use super::*;
     #[cfg(feature = "v1")]
     use crate::syscall::linux::LinuxSyscall;
     use crate::syscall::test::TestHelperSyscall;
-    #[cfg(feature = "v1")]
-    use anyhow::{Context, Result};
-    use nix::{
-        fcntl::{open, OFlag},
-        sys::stat::Mode,
-    };
-    #[cfg(feature = "v1")]
-    use std::fs;
-    use std::path::PathBuf;
 
     #[test]
     fn test_setup_ptmx() {

--- a/crates/libcontainer/src/rootfs/utils.rs
+++ b/crates/libcontainer/src/rootfs/utils.rs
@@ -1,9 +1,12 @@
-use crate::syscall::linux::{self, MountAttrOption};
-use nix::{mount::MsFlags, sys::stat::SFlag};
+use std::path::PathBuf;
+use std::str::FromStr;
+
+use nix::mount::MsFlags;
+use nix::sys::stat::SFlag;
 use oci_spec::runtime::{LinuxDevice, LinuxDeviceBuilder, LinuxDeviceType, Mount};
-use std::{path::PathBuf, str::FromStr};
 
 use super::mount::MountError;
+use crate::syscall::linux::{self, MountAttrOption};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct MountOptionConfig {
@@ -186,12 +189,11 @@ pub fn parse_mount(m: &Mount) -> std::result::Result<MountOptionConfig, MountErr
 
 #[cfg(test)]
 mod tests {
-    use crate::syscall::linux::MountAttr;
-
-    use super::*;
-
     use anyhow::Result;
     use oci_spec::runtime::MountBuilder;
+
+    use super::*;
+    use crate::syscall::linux::MountAttr;
 
     #[test]
     fn test_to_sflag() {

--- a/crates/libcontainer/src/seccomp/mod.rs
+++ b/crates/libcontainer/src/seccomp/mod.rs
@@ -1,16 +1,12 @@
-use libseccomp::ScmpAction;
-use libseccomp::ScmpArch;
-use libseccomp::ScmpArgCompare;
-use libseccomp::ScmpCompareOp;
-use libseccomp::ScmpFilterContext;
-use libseccomp::ScmpSyscall;
-use oci_spec::runtime::Arch;
-use oci_spec::runtime::LinuxSeccomp;
-use oci_spec::runtime::LinuxSeccompAction;
-use oci_spec::runtime::LinuxSeccompFilterFlag;
-use oci_spec::runtime::LinuxSeccompOperator;
 use std::num::TryFromIntError;
 use std::os::unix::io;
+
+use libseccomp::{
+    ScmpAction, ScmpArch, ScmpArgCompare, ScmpCompareOp, ScmpFilterContext, ScmpSyscall,
+};
+use oci_spec::runtime::{
+    Arch, LinuxSeccomp, LinuxSeccompAction, LinuxSeccompFilterFlag, LinuxSeccompOperator,
+};
 
 #[derive(Debug, thiserror::Error)]
 pub enum SeccompError {
@@ -287,13 +283,14 @@ pub fn is_notify(seccomp: &LinuxSeccomp) -> bool {
 
 #[cfg(test)]
 mod tests {
+    use std::path;
+
+    use anyhow::{Context, Result};
+    use oci_spec::runtime::{Arch, LinuxSeccompBuilder, LinuxSyscallBuilder};
+    use serial_test::serial;
+
     use super::*;
     use crate::test_utils::{self, TestCallbackError};
-    use anyhow::{Context, Result};
-    use oci_spec::runtime::Arch;
-    use oci_spec::runtime::{LinuxSeccompBuilder, LinuxSyscallBuilder};
-    use serial_test::serial;
-    use std::path;
 
     #[test]
     #[serial]

--- a/crates/libcontainer/src/signal.rs
+++ b/crates/libcontainer/src/signal.rs
@@ -1,7 +1,8 @@
 //! Returns *nix signal enum value from passed string
 
-use nix::sys::signal::Signal as NixSignal;
 use std::convert::TryFrom;
+
+use nix::sys::signal::Signal as NixSignal;
 
 /// POSIX Signal
 #[derive(Debug)]
@@ -80,9 +81,11 @@ impl Signal {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use nix::sys::signal::Signal::*;
     use std::collections::HashMap;
+
+    use nix::sys::signal::Signal::*;
+
+    use super::*;
 
     #[test]
     fn test_conversion_from_string() {

--- a/crates/libcontainer/src/syscall/linux.rs
+++ b/crates/libcontainer/src/syscall/linux.rs
@@ -1,24 +1,24 @@
 //! Implements Command trait for Linux systems
-use caps::{CapSet, CapsHashSet};
-use libc::{c_char, setdomainname, uid_t};
-use nix::fcntl;
-use nix::{
-    fcntl::{open, OFlag},
-    mount::{mount, umount2, MntFlags, MsFlags},
-    sched::{unshare, CloneFlags},
-    sys::stat::{mknod, Mode, SFlag},
-    unistd::{chown, chroot, fchdir, pivot_root, sethostname, Gid, Uid},
-};
-use oci_spec::runtime::LinuxRlimit;
+use std::any::Any;
 use std::ffi::{CStr, CString, OsStr};
-use std::fs;
 use std::os::fd::BorrowedFd;
 use std::os::unix::ffi::OsStrExt;
 use std::os::unix::fs::symlink;
 use std::os::unix::io::RawFd;
+use std::path::Path;
 use std::str::FromStr;
 use std::sync::Arc;
-use std::{any::Any, mem, path::Path, ptr};
+use std::{fs, mem, ptr};
+
+use caps::{CapSet, CapsHashSet};
+use libc::{c_char, setdomainname, uid_t};
+use nix::fcntl;
+use nix::fcntl::{open, OFlag};
+use nix::mount::{mount, umount2, MntFlags, MsFlags};
+use nix::sched::{unshare, CloneFlags};
+use nix::sys::stat::{mknod, Mode, SFlag};
+use nix::unistd::{chown, chroot, fchdir, pivot_root, sethostname, Gid, Uid};
+use oci_spec::runtime::LinuxRlimit;
 
 use super::{Result, Syscall, SyscallError};
 use crate::{capabilities, utils};
@@ -604,15 +604,15 @@ mod tests {
     // cleanup_file_descriptors test is especially evil when running with other
     // tests because it would ran around close down different fds.
 
-    use std::{fs, os::unix::prelude::AsRawFd};
+    use std::fs;
+    use std::os::unix::prelude::AsRawFd;
 
     use anyhow::{bail, Context, Result};
     use nix::{fcntl, sys, unistd};
     use serial_test::serial;
 
-    use crate::syscall::Syscall;
-
     use super::LinuxSyscall;
+    use crate::syscall::Syscall;
 
     #[test]
     #[serial]

--- a/crates/libcontainer/src/syscall/syscall.rs
+++ b/crates/libcontainer/src/syscall/syscall.rs
@@ -1,23 +1,22 @@
 //! An interface trait so that rest of Youki can call
 //! necessary functions without having to worry about their
 //! implementation details
+use std::any::Any;
+use std::ffi::OsStr;
+use std::path::Path;
+use std::sync::Arc;
+
 use caps::{CapSet, CapsHashSet};
 use libc;
-use nix::{
-    mount::MsFlags,
-    sched::CloneFlags,
-    sys::stat::{Mode, SFlag},
-    unistd::{Gid, Uid},
-};
-use std::{any::Any, ffi::OsStr, path::Path, sync::Arc};
-
+use nix::mount::MsFlags;
+use nix::sched::CloneFlags;
+use nix::sys::stat::{Mode, SFlag};
+use nix::unistd::{Gid, Uid};
 use oci_spec::runtime::LinuxRlimit;
 
-use crate::syscall::{
-    linux::{LinuxSyscall, MountAttr},
-    test::TestHelperSyscall,
-    Result,
-};
+use crate::syscall::linux::{LinuxSyscall, MountAttr};
+use crate::syscall::test::TestHelperSyscall;
+use crate::syscall::Result;
 
 /// This specifies various kernel/other functionalities required for
 /// container management

--- a/crates/libcontainer/src/syscall/test.rs
+++ b/crates/libcontainer/src/syscall/test.rs
@@ -1,20 +1,15 @@
-use std::{
-    any::Any,
-    cell::{Ref, RefCell, RefMut},
-    collections::HashMap,
-    ffi::{OsStr, OsString},
-    path::{Path, PathBuf},
-    sync::Arc,
-};
+use std::any::Any;
+use std::cell::{Ref, RefCell, RefMut};
+use std::collections::HashMap;
+use std::ffi::{OsStr, OsString};
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
 
 use caps::{CapSet, CapsHashSet};
-use nix::{
-    mount::MsFlags,
-    sched::CloneFlags,
-    sys::stat::{Mode, SFlag},
-    unistd::{Gid, Uid},
-};
-
+use nix::mount::MsFlags;
+use nix::sched::CloneFlags;
+use nix::sys::stat::{Mode, SFlag};
+use nix::unistd::{Gid, Uid};
 use oci_spec::runtime::LinuxRlimit;
 
 use super::{linux, Result, Syscall};

--- a/crates/libcontainer/src/test_utils.rs
+++ b/crates/libcontainer/src/test_utils.rs
@@ -111,8 +111,9 @@ where
 mod tests {
     use core::panic;
 
-    use super::*;
     use anyhow::{bail, Result};
+
+    use super::*;
 
     #[test]
     fn test_child_process() -> Result<()> {

--- a/crates/libcontainer/src/tty.rs
+++ b/crates/libcontainer/src/tty.rs
@@ -1,14 +1,14 @@
 //! tty (teletype) for user-system interaction
 
-use nix::errno::Errno;
-use nix::sys::socket::{self, UnixAddr};
-use nix::unistd::close;
-use nix::unistd::dup2;
 use std::io::IoSlice;
 use std::os::unix::fs::symlink;
 use std::os::unix::io::AsRawFd;
 use std::os::unix::prelude::RawFd;
 use std::path::{Path, PathBuf};
+
+use nix::errno::Errno;
+use nix::sys::socket::{self, UnixAddr};
+use nix::unistd::{close, dup2};
 
 #[derive(Debug)]
 pub enum StdIO {
@@ -163,12 +163,13 @@ fn connect_stdio(stdin: &RawFd, stdout: &RawFd, stderr: &RawFd) -> Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use std::fs::File;
+    use std::os::unix::net::UnixListener;
 
     use anyhow::{Ok, Result};
     use serial_test::serial;
-    use std::fs::File;
-    use std::os::unix::net::UnixListener;
+
+    use super::*;
 
     const CONSOLE_SOCKET: &str = "console-socket";
 

--- a/crates/libcontainer/src/user_ns.rs
+++ b/crates/libcontainer/src/user_ns.rs
@@ -1,12 +1,13 @@
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::{env, fs};
+
+use nix::unistd::Pid;
+use oci_spec::runtime::{Linux, LinuxIdMapping, LinuxNamespace, LinuxNamespaceType, Mount, Spec};
+
 use crate::error::MissingSpecError;
 use crate::namespaces::{NamespaceError, Namespaces};
 use crate::utils;
-use nix::unistd::Pid;
-use oci_spec::runtime::{Linux, LinuxIdMapping, LinuxNamespace, LinuxNamespaceType, Mount, Spec};
-use std::fs;
-use std::path::Path;
-use std::process::Command;
-use std::{env, path::PathBuf};
 
 // Wrap the uid/gid path function into a struct for dependency injection. This
 // allows us to mock the id mapping logic in unit tests by using a different
@@ -446,7 +447,6 @@ fn write_id_mapping(
 mod tests {
     use std::fs;
 
-    use super::*;
     use anyhow::Result;
     use nix::unistd::getpid;
     use oci_spec::runtime::{
@@ -454,6 +454,8 @@ mod tests {
     };
     use rand::Rng;
     use serial_test::serial;
+
+    use super::*;
 
     fn gen_u32() -> u32 {
         rand::thread_rng().gen()

--- a/crates/libcontainer/src/utils.rs
+++ b/crates/libcontainer/src/utils.rs
@@ -287,10 +287,11 @@ pub fn validate_spec_for_new_user_ns(spec: &Spec) -> Result<(), LibcontainerErro
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use crate::test_utils;
     use anyhow::{bail, Result};
     use serial_test::serial;
+
+    use super::*;
+    use crate::test_utils;
 
     #[test]
     pub fn test_get_unix_user() {

--- a/crates/libcontainer/src/workload/default.rs
+++ b/crates/libcontainer/src/workload/default.rs
@@ -1,7 +1,5 @@
-use std::{
-    ffi::CString,
-    path::{Path, PathBuf},
-};
+use std::ffi::CString;
+use std::path::{Path, PathBuf};
 
 use nix::unistd;
 use oci_spec::runtime::Spec;

--- a/crates/liboci-cli/src/checkpoint.rs
+++ b/crates/liboci-cli/src/checkpoint.rs
@@ -1,5 +1,6 @@
-use clap::Parser;
 use std::path::PathBuf;
+
+use clap::Parser;
 
 /// Checkpoint a running container
 /// Reference: https://github.com/opencontainers/runc/blob/main/man/runc-checkpoint.8.md

--- a/crates/liboci-cli/src/create.rs
+++ b/crates/liboci-cli/src/create.rs
@@ -1,6 +1,7 @@
 //! Handles the creation of a new container
-use clap::Parser;
 use std::path::PathBuf;
+
+use clap::Parser;
 
 /// Create a container
 /// Reference: https://github.com/opencontainers/runc/blob/main/man/runc-create.8.md

--- a/crates/liboci-cli/src/lib.rs
+++ b/crates/liboci-cli/src/lib.rs
@@ -11,7 +11,11 @@ mod kill;
 mod start;
 mod state;
 
-pub use {create::Create, delete::Delete, kill::Kill, start::Start, state::State};
+pub use create::Create;
+pub use delete::Delete;
+pub use kill::Kill;
+pub use start::Start;
+pub use state::State;
 
 // Other common subcommands that aren't specified in the document
 mod checkpoint;
@@ -26,10 +30,17 @@ mod run;
 mod spec;
 mod update;
 
-pub use {
-    checkpoint::Checkpoint, events::Events, exec::Exec, features::Features, list::List,
-    pause::Pause, ps::Ps, resume::Resume, run::Run, spec::Spec, update::Update,
-};
+pub use checkpoint::Checkpoint;
+pub use events::Events;
+pub use exec::Exec;
+pub use features::Features;
+pub use list::List;
+pub use pause::Pause;
+pub use ps::Ps;
+pub use resume::Resume;
+pub use run::Run;
+pub use spec::Spec;
+pub use update::Update;
 
 // Subcommands parsed by liboci-cli, based on the [OCI
 // runtime-spec](https://github.com/opencontainers/runtime-spec/blob/master/runtime.md)

--- a/crates/liboci-cli/src/run.rs
+++ b/crates/liboci-cli/src/run.rs
@@ -1,5 +1,6 @@
-use clap::Parser;
 use std::path::PathBuf;
+
+use clap::Parser;
 
 /// Create a container and immediately start it
 #[derive(Parser, Debug)]

--- a/crates/liboci-cli/src/spec.rs
+++ b/crates/liboci-cli/src/spec.rs
@@ -1,5 +1,6 @@
-use clap::Parser;
 use std::path::PathBuf;
+
+use clap::Parser;
 
 /// Command generates a config.json
 #[derive(Parser, Debug)]

--- a/crates/liboci-cli/src/update.rs
+++ b/crates/liboci-cli/src/update.rs
@@ -1,5 +1,6 @@
-use clap::Parser;
 use std::path::PathBuf;
+
+use clap::Parser;
 
 /// Update running container resource constraints
 #[derive(Parser, Debug)]

--- a/crates/youki/src/commands/checkpoint.rs
+++ b/crates/youki/src/commands/checkpoint.rs
@@ -1,10 +1,10 @@
 //! Contains functionality of pause container command
-use crate::commands::load_container;
 use std::path::PathBuf;
 
 use anyhow::{Context, Result};
-
 use liboci_cli::Checkpoint;
+
+use crate::commands::load_container;
 
 pub fn checkpoint(args: Checkpoint, root_path: PathBuf) -> Result<()> {
     tracing::debug!("start checkpointing container {}", args.container_id);

--- a/crates/youki/src/commands/completion.rs
+++ b/crates/youki/src/commands/completion.rs
@@ -1,8 +1,8 @@
+use std::io;
+
 use anyhow::Result;
 use clap::{Command, Parser};
-
 use clap_complete::{generate, Shell};
-use std::io;
 
 #[derive(Debug, Parser)]
 /// Generate scripts for shell completion

--- a/crates/youki/src/commands/create.rs
+++ b/crates/youki/src/commands/create.rs
@@ -1,8 +1,9 @@
 //! Handles the creation of a new container
-use anyhow::Result;
 use std::path::PathBuf;
 
-use libcontainer::{container::builder::ContainerBuilder, syscall::syscall::SyscallType};
+use anyhow::Result;
+use libcontainer::container::builder::ContainerBuilder;
+use libcontainer::syscall::syscall::SyscallType;
 use liboci_cli::Create;
 
 use crate::workload::executor::default_executor;

--- a/crates/youki/src/commands/delete.rs
+++ b/crates/youki/src/commands/delete.rs
@@ -1,8 +1,9 @@
-use crate::commands::{container_exists, load_container};
-use anyhow::{Context, Result};
 use std::path::PathBuf;
 
+use anyhow::{Context, Result};
 use liboci_cli::Delete;
+
+use crate::commands::{container_exists, load_container};
 
 pub fn delete(args: Delete, root_path: PathBuf) -> Result<()> {
     tracing::debug!("start deleting {}", args.container_id);

--- a/crates/youki/src/commands/events.rs
+++ b/crates/youki/src/commands/events.rs
@@ -1,7 +1,6 @@
 use std::path::PathBuf;
 
 use anyhow::{Context, Result};
-
 use liboci_cli::Events;
 
 use crate::commands::load_container;

--- a/crates/youki/src/commands/exec.rs
+++ b/crates/youki/src/commands/exec.rs
@@ -1,9 +1,10 @@
-use anyhow::Result;
-use nix::sys::wait::{waitpid, WaitStatus};
 use std::path::PathBuf;
 
-use libcontainer::{container::builder::ContainerBuilder, syscall::syscall::SyscallType};
+use anyhow::Result;
+use libcontainer::container::builder::ContainerBuilder;
+use libcontainer::syscall::syscall::SyscallType;
 use liboci_cli::Exec;
+use nix::sys::wait::{waitpid, WaitStatus};
 
 use crate::workload::executor::default_executor;
 

--- a/crates/youki/src/commands/info.rs
+++ b/crates/youki/src/commands/info.rs
@@ -1,15 +1,15 @@
 //! Contains functions related to printing information about system running Youki
 #[cfg(feature = "v2")]
 use std::collections::HashSet;
-use std::{fs, path::Path};
+use std::fs;
+use std::path::Path;
 
 use anyhow::Result;
 use clap::Parser;
-use libcontainer::user_ns;
-use procfs::{CpuInfo, Current, Meminfo};
-
 #[cfg(feature = "v2")]
 use libcgroups::{common::CgroupSetup, v2::controller_type::ControllerType};
+use libcontainer::user_ns;
+use procfs::{CpuInfo, Current, Meminfo};
 /// Show information about the system
 #[derive(Parser, Debug)]
 pub struct Info {}

--- a/crates/youki/src/commands/kill.rs
+++ b/crates/youki/src/commands/kill.rs
@@ -1,11 +1,13 @@
 //! Contains functionality of kill container command
-use std::{convert::TryInto, path::PathBuf};
+use std::convert::TryInto;
+use std::path::PathBuf;
 
 use anyhow::{anyhow, Result};
+use libcontainer::container::ContainerStatus;
+use libcontainer::signal::Signal;
+use liboci_cli::Kill;
 
 use crate::commands::load_container;
-use libcontainer::{container::ContainerStatus, signal::Signal};
-use liboci_cli::Kill;
 
 pub fn kill(args: Kill, root_path: PathBuf) -> Result<()> {
     let mut container = load_container(root_path, &args.container_id)?;

--- a/crates/youki/src/commands/list.rs
+++ b/crates/youki/src/commands/list.rs
@@ -1,16 +1,15 @@
 //! Contains Functionality of list container command
 use std::fmt::Write as _;
-use std::fs;
-use std::io;
 use std::io::Write;
 use std::path::PathBuf;
+use std::{fs, io};
 
 use anyhow::Result;
 use chrono::{DateTime, Local};
-use tabwriter::TabWriter;
-
-use libcontainer::container::{state::State, Container};
+use libcontainer::container::state::State;
+use libcontainer::container::Container;
 use liboci_cli::List;
+use tabwriter::TabWriter;
 
 /// lists all existing containers
 pub fn list(_: List, root_path: PathBuf) -> Result<()> {

--- a/crates/youki/src/commands/mod.rs
+++ b/crates/youki/src/commands/mod.rs
@@ -1,9 +1,7 @@
-use anyhow::{bail, Context, Result};
-use std::{
-    fs,
-    path::{Path, PathBuf},
-};
+use std::fs;
+use std::path::{Path, PathBuf};
 
+use anyhow::{bail, Context, Result};
 use libcgroups::common::AnyCgroupManager;
 use libcontainer::container::Container;
 

--- a/crates/youki/src/commands/pause.rs
+++ b/crates/youki/src/commands/pause.rs
@@ -1,10 +1,10 @@
 //! Contains functionality of pause container command
-use crate::commands::load_container;
 use std::path::PathBuf;
 
 use anyhow::{Context, Result};
-
 use liboci_cli::Pause;
+
+use crate::commands::load_container;
 
 // Pausing a container indicates suspending all processes in given container
 // This uses Freezer cgroup to suspend and resume processes

--- a/crates/youki/src/commands/ps.rs
+++ b/crates/youki/src/commands/ps.rs
@@ -1,8 +1,11 @@
-use crate::commands::create_cgroup_manager;
+use std::path::PathBuf;
+use std::process::Command;
+
 use anyhow::{bail, Result};
 use libcgroups::common::CgroupManager;
 use liboci_cli::Ps;
-use std::{path::PathBuf, process::Command};
+
+use crate::commands::create_cgroup_manager;
 
 pub fn ps(args: Ps, root_path: PathBuf) -> Result<()> {
     let cmanager = create_cgroup_manager(root_path, &args.container_id)?;

--- a/crates/youki/src/commands/resume.rs
+++ b/crates/youki/src/commands/resume.rs
@@ -2,10 +2,9 @@
 use std::path::PathBuf;
 
 use anyhow::{Context, Result};
+use liboci_cli::Resume;
 
 use crate::commands::load_container;
-
-use liboci_cli::Resume;
 
 // Resuming a container indicates resuming all processes in given container from paused state
 // This uses Freezer cgroup to suspend and resume processes

--- a/crates/youki/src/commands/run.rs
+++ b/crates/youki/src/commands/run.rs
@@ -1,16 +1,13 @@
 use std::path::PathBuf;
 
 use anyhow::{Context, Result};
-use libcontainer::{container::builder::ContainerBuilder, syscall::syscall::SyscallType};
+use libcontainer::container::builder::ContainerBuilder;
+use libcontainer::syscall::syscall::SyscallType;
 use liboci_cli::Run;
-use nix::{
-    sys::{
-        signal::{self, kill},
-        signalfd::SigSet,
-        wait::{waitpid, WaitPidFlag, WaitStatus},
-    },
-    unistd::Pid,
-};
+use nix::sys::signal::{self, kill};
+use nix::sys::signalfd::SigSet;
+use nix::sys::wait::{waitpid, WaitPidFlag, WaitStatus};
+use nix::unistd::Pid;
 
 use crate::workload::executor::default_executor;
 
@@ -122,10 +119,9 @@ fn handle_foreground(init_pid: Pid) -> Result<i32> {
 mod tests {
     use std::time::Duration;
 
-    use nix::{
-        sys::{signal::Signal::SIGINT, wait},
-        unistd,
-    };
+    use nix::sys::signal::Signal::SIGINT;
+    use nix::sys::wait;
+    use nix::unistd;
 
     use super::*;
 

--- a/crates/youki/src/commands/spec_json.rs
+++ b/crates/youki/src/commands/spec_json.rs
@@ -1,15 +1,14 @@
+use std::fs::File;
+use std::io::{BufWriter, Write};
+use std::path::{Path, PathBuf};
+
 use anyhow::Result;
-use libcontainer::oci_spec::runtime::Mount;
 use libcontainer::oci_spec::runtime::{
     LinuxBuilder, LinuxIdMappingBuilder, LinuxNamespace, LinuxNamespaceBuilder, LinuxNamespaceType,
-    Spec,
+    Mount, Spec,
 };
 use nix;
 use serde_json::to_writer_pretty;
-use std::fs::File;
-use std::io::{BufWriter, Write};
-use std::path::Path;
-use std::path::PathBuf;
 
 pub fn get_default() -> Result<Spec> {
     Ok(Spec::default())
@@ -101,8 +100,9 @@ pub fn spec(args: liboci_cli::Spec) -> Result<()> {
 #[cfg(test)]
 // Tests become unstable if not serial. The cause is not known.
 mod tests {
-    use super::*;
     use serial_test::serial;
+
+    use super::*;
 
     #[test]
     #[serial]

--- a/crates/youki/src/commands/start.rs
+++ b/crates/youki/src/commands/start.rs
@@ -3,10 +3,9 @@
 use std::path::PathBuf;
 
 use anyhow::{Context, Result};
+use liboci_cli::Start;
 
 use crate::commands::load_container;
-
-use liboci_cli::Start;
 
 pub fn start(args: Start, root_path: PathBuf) -> Result<()> {
     let mut container = load_container(root_path, &args.container_id)?;

--- a/crates/youki/src/commands/state.rs
+++ b/crates/youki/src/commands/state.rs
@@ -1,9 +1,9 @@
 use std::path::PathBuf;
 
 use anyhow::Result;
+use liboci_cli::State;
 
 use crate::commands::load_container;
-use liboci_cli::State;
 
 pub fn state(args: State, root_path: PathBuf) -> Result<()> {
     let container = load_container(root_path, &args.container_id)?;

--- a/crates/youki/src/commands/update.rs
+++ b/crates/youki/src/commands/update.rs
@@ -1,13 +1,13 @@
-use std::fs;
-use std::io;
 use std::path::PathBuf;
+use std::{fs, io};
 
-use crate::commands::create_cgroup_manager;
 use anyhow::Result;
-use libcgroups::common::CgroupManager;
-use libcgroups::{self, common::ControllerOpt};
+use libcgroups::common::{CgroupManager, ControllerOpt};
+use libcgroups::{self};
 use libcontainer::oci_spec::runtime::{LinuxPidsBuilder, LinuxResources, LinuxResourcesBuilder};
 use liboci_cli::Update;
+
+use crate::commands::create_cgroup_manager;
 
 pub fn update(args: Update, root_path: PathBuf) -> Result<()> {
     let cmanager = create_cgroup_manager(root_path, &args.container_id)?;

--- a/crates/youki/src/main.rs
+++ b/crates/youki/src/main.rs
@@ -6,14 +6,11 @@ mod observability;
 mod rootpath;
 mod workload;
 
-use anyhow::Context;
-use anyhow::Result;
-use clap::CommandFactory;
-use clap::{crate_version, Parser};
+use anyhow::{Context, Result};
+use clap::{crate_version, CommandFactory, Parser};
+use liboci_cli::{CommonCmd, GlobalOpts, StandardCmd};
 
 use crate::commands::info;
-
-use liboci_cli::{CommonCmd, GlobalOpts, StandardCmd};
 
 // Additional options that are not defined in OCI runtime-spec, but are used by Youki.
 #[derive(Parser, Debug)]

--- a/crates/youki/src/observability.rs
+++ b/crates/youki/src/observability.rs
@@ -1,8 +1,9 @@
-use anyhow::{bail, Context, Result};
 use std::borrow::Cow;
 use std::fs::OpenOptions;
 use std::path::PathBuf;
 use std::str::FromStr;
+
+use anyhow::{bail, Context, Result};
 use tracing::Level;
 use tracing_subscriber::prelude::*;
 
@@ -164,9 +165,11 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use libcontainer::test_utils::TestCallbackError;
     use std::path::Path;
+
+    use libcontainer::test_utils::TestCallbackError;
+
+    use super::*;
 
     #[test]
     fn test_detect_log_level() {

--- a/crates/youki/src/rootpath.rs
+++ b/crates/youki/src/rootpath.rs
@@ -1,11 +1,11 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+
 use anyhow::{bail, Result};
-use libcontainer::utils::create_dir_all_with_mode;
-use libcontainer::utils::rootless_required;
+use libcontainer::utils::{create_dir_all_with_mode, rootless_required};
 use nix::libc;
 use nix::sys::stat::Mode;
 use nix::unistd::getuid;
-use std::fs;
-use std::path::{Path, PathBuf};
 
 pub fn determine(root_path: Option<PathBuf>) -> Result<PathBuf> {
     let uid = getuid().as_raw();
@@ -77,14 +77,16 @@ fn get_default_rootless_path(uid: libc::uid_t) -> PathBuf {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use anyhow::{Context, Result};
-    use nix::sys::stat::Mode;
-    use nix::unistd::getuid;
     use std::fs;
     use std::fs::Permissions;
     use std::os::unix::fs::PermissionsExt;
     use std::path::PathBuf;
+
+    use anyhow::{Context, Result};
+    use nix::sys::stat::Mode;
+    use nix::unistd::getuid;
+
+    use super::*;
 
     #[test]
     fn test_user_specified() -> Result<()> {

--- a/crates/youki/src/workload/wasmedge.rs
+++ b/crates/youki/src/workload/wasmedge.rs
@@ -1,10 +1,7 @@
 use libcontainer::oci_spec::runtime::Spec;
-use wasmedge_sdk::{
-    config::{CommonConfigOptions, ConfigBuilder, HostRegistrationConfigOptions},
-    params, VmBuilder,
-};
-
 use libcontainer::workload::{Executor, ExecutorError, ExecutorValidationError};
+use wasmedge_sdk::config::{CommonConfigOptions, ConfigBuilder, HostRegistrationConfigOptions};
+use wasmedge_sdk::{params, VmBuilder};
 
 const EXECUTOR_NAME: &str = "wasmedge";
 

--- a/crates/youki/src/workload/wasmer.rs
+++ b/crates/youki/src/workload/wasmer.rs
@@ -1,8 +1,7 @@
 use libcontainer::oci_spec::runtime::Spec;
+use libcontainer::workload::{Executor, ExecutorError, ExecutorValidationError, EMPTY};
 use wasmer::{Instance, Module, Store};
 use wasmer_wasix::WasiEnv;
-
-use libcontainer::workload::{Executor, ExecutorError, ExecutorValidationError, EMPTY};
 
 const EXECUTOR_NAME: &str = "wasmer";
 
@@ -110,10 +109,12 @@ fn can_handle(spec: &Spec) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use std::collections::HashMap;
+
     use anyhow::{Context, Result};
     use libcontainer::oci_spec::runtime::SpecBuilder;
-    use std::collections::HashMap;
+
+    use super::*;
 
     #[test]
     fn test_can_handle_oci_handler() -> Result<()> {

--- a/crates/youki/src/workload/wasmtime.rs
+++ b/crates/youki/src/workload/wasmtime.rs
@@ -1,8 +1,7 @@
 use libcontainer::oci_spec::runtime::Spec;
+use libcontainer::workload::{Executor, ExecutorError, ExecutorValidationError, EMPTY};
 use wasi_common::sync::{add_to_linker, WasiCtxBuilder};
 use wasmtime::{Engine, Linker, Module, Store};
-
-use libcontainer::workload::{Executor, ExecutorError, ExecutorValidationError, EMPTY};
 
 const EXECUTOR_NAME: &str = "wasmtime";
 

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,6 @@
+newline_style = "Native"
+unstable_features = true # Cargo fmt now needs to be called with `cargo +nightly fmt`
+group_imports = "StdExternalCrate" # create three groups for std, external and local crates
+# Merge imports from the same module
+# See: https://rust-lang.github.io/rustfmt/?version=v1.4.38&search=#imports_granularity
+imports_granularity = "Module"

--- a/scripts/cargo.sh
+++ b/scripts/cargo.sh
@@ -48,6 +48,9 @@ if [ "$1" == "fmt" ]; then
     # running cargo fmt fails when run through cross
     # also cargo fmt is platform independent
     CARGO="cargo"
+
+    # Use nightly for `cargo fmt` as `rustfmt.toml` uses unstable features.
+    set -- "+nightly" "$@"
 fi
 
 if [ "$CARGO" == "cross" ]; then

--- a/tests/contest/contest/src/logger.rs
+++ b/tests/contest/contest/src/logger.rs
@@ -1,6 +1,7 @@
-use anyhow::{Context, Result};
 use std::borrow::Cow;
 use std::str::FromStr;
+
+use anyhow::{Context, Result};
 use tracing::metadata::LevelFilter;
 
 const LOG_LEVEL_ENV_NAME: &str = "YOUKI_INTEGRATION_LOG_LEVEL";

--- a/tests/contest/contest/src/main.rs
+++ b/tests/contest/contest/src/main.rs
@@ -1,6 +1,14 @@
 mod tests;
 mod utils;
 
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use clap::Parser;
+use contest::logger;
+use test_framework::TestManager;
+use tests::cgroups;
+
 use crate::tests::devices::get_devices_test;
 use crate::tests::domainname::get_domainname_tests;
 use crate::tests::example::get_example_test;
@@ -19,12 +27,6 @@ use crate::tests::seccomp_notify::get_seccomp_notify_test;
 use crate::tests::sysctl::get_sysctl_test;
 use crate::tests::tlb::get_tlb_test;
 use crate::utils::support::{set_runtime_path, set_runtimetest_path};
-use anyhow::{Context, Result};
-use clap::Parser;
-use contest::logger;
-use std::path::{Path, PathBuf};
-use test_framework::TestManager;
-use tests::cgroups;
 
 #[derive(Parser, Debug)]
 #[clap(version = "0.0.1", author = "youki team")]

--- a/tests/contest/contest/src/tests/cgroups/blkio.rs
+++ b/tests/contest/contest/src/tests/cgroups/blkio.rs
@@ -1,7 +1,5 @@
-use std::{
-    fs,
-    path::{Path, PathBuf},
-};
+use std::fs;
+use std::path::{Path, PathBuf};
 
 use anyhow::{bail, Context, Result};
 use oci_spec::runtime::{
@@ -10,10 +8,8 @@ use oci_spec::runtime::{
 };
 use test_framework::{test_result, ConditionalTest, TestGroup, TestResult};
 
-use crate::utils::{
-    test_outside_container,
-    test_utils::{check_container_created, CGROUP_ROOT},
-};
+use crate::utils::test_outside_container;
+use crate::utils::test_utils::{check_container_created, CGROUP_ROOT};
 
 // -----> README
 // for this test to work for all parameters, the kernel needs to be compiled with CFQ IO schedular

--- a/tests/contest/contest/src/tests/cgroups/cpu/mod.rs
+++ b/tests/contest/contest/src/tests/cgroups/cpu/mod.rs
@@ -1,6 +1,6 @@
-use anyhow::{Context, Result};
 use std::path::Path;
 
+use anyhow::{Context, Result};
 use oci_spec::runtime::{
     LinuxBuilder, LinuxCpu, LinuxCpuBuilder, LinuxResourcesBuilder, Spec, SpecBuilder,
 };

--- a/tests/contest/contest/src/tests/cgroups/cpu/v1.rs
+++ b/tests/contest/contest/src/tests/cgroups/cpu/v1.rs
@@ -4,9 +4,9 @@ use libcgroups::common;
 use num_cpus;
 use test_framework::{test_result, ConditionalTest, TestGroup, TestResult};
 
-use crate::utils::{test_outside_container, test_utils::check_container_created};
-
 use super::{create_cpu_spec, create_empty_spec, create_spec};
+use crate::utils::test_outside_container;
+use crate::utils::test_utils::check_container_created;
 
 const CPU_CGROUP_PREFIX: &str = "/sys/fs/cgroup/cpu,cpuacct";
 const DEFAULT_REALTIME_PERIOD: u64 = 1000000;

--- a/tests/contest/contest/src/tests/cgroups/cpu/v2.rs
+++ b/tests/contest/contest/src/tests/cgroups/cpu/v2.rs
@@ -1,26 +1,18 @@
-use std::{
-    fs,
-    path::{Path, PathBuf},
-};
+use std::fs;
+use std::path::{Path, PathBuf};
 
-use crate::{
-    tests::cgroups::attach_controller,
-    utils::{
-        test_outside_container,
-        test_utils::{check_container_created, CGROUP_ROOT},
-    },
-};
 use anyhow::{bail, Context, Result};
-use libcgroups::{
-    common::{self, CgroupSetup, DEFAULT_CGROUP_ROOT},
-    v2::controller_type::ControllerType,
-};
+use libcgroups::common::{self, CgroupSetup, DEFAULT_CGROUP_ROOT};
+use libcgroups::v2::controller_type::ControllerType;
 use libcontainer::utils::PathBufExt;
 use oci_spec::runtime::{LinuxCpuBuilder, Spec};
 use test_framework::{assert_result_eq, test_result, ConditionalTest, TestGroup, TestResult};
 use tracing::debug;
 
 use super::create_spec;
+use crate::tests::cgroups::attach_controller;
+use crate::utils::test_outside_container;
+use crate::utils::test_utils::{check_container_created, CGROUP_ROOT};
 
 const DEFAULT_PERIOD: u64 = 100_000;
 const CPU: &str = "cpu";

--- a/tests/contest/contest/src/tests/cgroups/memory.rs
+++ b/tests/contest/contest/src/tests/cgroups/memory.rs
@@ -6,7 +6,8 @@ use oci_spec::runtime::{
 };
 use test_framework::{test_result, ConditionalTest, TestGroup, TestResult};
 
-use crate::utils::{test_outside_container, test_utils::check_container_created};
+use crate::utils::test_outside_container;
+use crate::utils::test_utils::check_container_created;
 
 const CGROUP_MEMORY_LIMIT: &str = "/sys/fs/cgroup/memory/memory.limit_in_bytes";
 const CGROUP_MEMORY_SWAPPINESS: &str = "/sys/fs/cgroup/memory/memory.swappiness";

--- a/tests/contest/contest/src/tests/cgroups/mod.rs
+++ b/tests/contest/contest/src/tests/cgroups/mod.rs
@@ -1,8 +1,9 @@
-use std::path::{Component::RootDir, Path, PathBuf};
+use std::fs;
+use std::path::Component::RootDir;
+use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
 use procfs::process::Process;
-use std::fs;
 pub mod blkio;
 pub mod cpu;
 pub mod memory;

--- a/tests/contest/contest/src/tests/cgroups/network.rs
+++ b/tests/contest/contest/src/tests/cgroups/network.rs
@@ -1,15 +1,15 @@
 use std::path::Path;
 
 use anyhow::{anyhow, Context, Result};
-use pnet_datalink::interfaces;
-
 use oci_spec::runtime::{
     LinuxBuilder, LinuxInterfacePriorityBuilder, LinuxNamespace, LinuxNamespaceType,
     LinuxNetworkBuilder, LinuxResourcesBuilder, Spec, SpecBuilder,
 };
+use pnet_datalink::interfaces;
 use test_framework::{test_result, ConditionalTest, TestGroup, TestResult};
 
-use crate::utils::{test_outside_container, test_utils::check_container_created};
+use crate::utils::test_outside_container;
+use crate::utils::test_utils::check_container_created;
 
 fn create_spec(
     cgroup_name: &str,

--- a/tests/contest/contest/src/tests/cgroups/pids.rs
+++ b/tests/contest/contest/src/tests/cgroups/pids.rs
@@ -1,16 +1,12 @@
-use std::{
-    fs,
-    path::{Path, PathBuf},
-};
+use std::fs;
+use std::path::{Path, PathBuf};
 
 use anyhow::{bail, Context, Result};
 use oci_spec::runtime::{LinuxBuilder, LinuxPidsBuilder, LinuxResourcesBuilder, Spec, SpecBuilder};
 use test_framework::{test_result, ConditionalTest, TestGroup, TestResult};
 
-use crate::utils::{
-    test_outside_container,
-    test_utils::{check_container_created, CGROUP_ROOT},
-};
+use crate::utils::test_outside_container;
+use crate::utils::test_utils::{check_container_created, CGROUP_ROOT};
 
 // SPEC: The runtime spec does not specify what the behavior should be if the limit is
 // zero or negative. We assume that the number of pids should be unlimited in this case.

--- a/tests/contest/contest/src/tests/devices/devices_test.rs
+++ b/tests/contest/contest/src/tests/devices/devices_test.rs
@@ -1,9 +1,10 @@
-use crate::utils::test_inside_container;
 use anyhow::{Context, Ok, Result};
 use oci_spec::runtime::{
     LinuxBuilder, LinuxDeviceBuilder, LinuxDeviceType, ProcessBuilder, Spec, SpecBuilder,
 };
 use test_framework::{test_result, Test, TestGroup, TestResult};
+
+use crate::utils::test_inside_container;
 
 fn create_spec() -> Result<Spec> {
     let device1 = LinuxDeviceBuilder::default()

--- a/tests/contest/contest/src/tests/domainname/mod.rs
+++ b/tests/contest/contest/src/tests/domainname/mod.rs
@@ -1,6 +1,7 @@
-use crate::utils::{is_runtime_runc, test_inside_container};
 use oci_spec::runtime::{ProcessBuilder, Spec, SpecBuilder};
 use test_framework::{ConditionalTest, TestGroup, TestResult};
+
+use crate::utils::{is_runtime_runc, test_inside_container};
 
 fn get_spec(domainname: &str) -> Spec {
     SpecBuilder::default()

--- a/tests/contest/contest/src/tests/hooks/invoke.rs
+++ b/tests/contest/contest/src/tests/hooks/invoke.rs
@@ -1,12 +1,12 @@
+use std::fs::File;
+use std::io::Read;
+
 use anyhow::anyhow;
 use oci_spec::runtime::{Hook, HookBuilder, HooksBuilder, ProcessBuilder, Spec, SpecBuilder};
-use std::{fs::File, io::Read};
 use test_framework::{Test, TestGroup, TestResult};
 
-use crate::utils::{
-    create_container, delete_container, generate_uuid, prepare_bundle, set_config,
-    test_utils::start_container,
-};
+use crate::utils::test_utils::start_container;
+use crate::utils::{create_container, delete_container, generate_uuid, prepare_bundle, set_config};
 
 const HOOK_OUTPUT_FILE: &str = "output";
 

--- a/tests/contest/contest/src/tests/intel_rdt/intel_rdt_test.rs
+++ b/tests/contest/contest/src/tests/intel_rdt/intel_rdt_test.rs
@@ -1,10 +1,10 @@
 use anyhow::{Context, Result};
 use libcontainer::process::intel_rdt::find_resctrl_mount_point;
-
 use oci_spec::runtime::{LinuxBuilder, LinuxIntelRdt, Spec, SpecBuilder};
 use test_framework::{test_result, TestResult};
 
-use crate::utils::{test_outside_container, test_utils::check_container_created};
+use crate::utils::test_outside_container;
+use crate::utils::test_utils::check_container_created;
 
 fn create_spec(
     maybe_l3_cache: Option<&str>,

--- a/tests/contest/contest/src/tests/io_priority/io_priority_test.rs
+++ b/tests/contest/contest/src/tests/io_priority/io_priority_test.rs
@@ -1,9 +1,10 @@
-use crate::utils::{is_runtime_runc, test_inside_container};
 use anyhow::{Context, Result};
 use oci_spec::runtime::{
     IOPriorityClass, LinuxIOPriorityBuilder, ProcessBuilder, Spec, SpecBuilder,
 };
 use test_framework::{test_result, ConditionalTest, TestGroup, TestResult};
+
+use crate::utils::{is_runtime_runc, test_inside_container};
 
 fn create_spec(
     io_priority_class: IOPriorityClass,

--- a/tests/contest/contest/src/tests/lifecycle/checkpoint.rs
+++ b/tests/contest/contest/src/tests/lifecycle/checkpoint.rs
@@ -1,10 +1,12 @@
+use std::path::Path;
+use std::process::{Command, Stdio};
+
+use anyhow::anyhow;
+use test_framework::TestResult;
+
 use super::get_result_from_output;
 use crate::utils::get_runtime_path;
 use crate::utils::test_utils::State;
-use anyhow::anyhow;
-use std::path::Path;
-use std::process::{Command, Stdio};
-use test_framework::TestResult;
 
 // Simple function to figure out the PID of the first container process
 fn get_container_pid(project_path: &Path, id: &str) -> Result<i32, TestResult> {

--- a/tests/contest/contest/src/tests/lifecycle/container_create.rs
+++ b/tests/contest/contest/src/tests/lifecycle/container_create.rs
@@ -1,7 +1,8 @@
-use super::{create, delete, kill};
-use crate::utils::{generate_uuid, prepare_bundle};
 use tempfile::TempDir;
 use test_framework::{TestResult, TestableGroup};
+
+use super::{create, delete, kill};
+use crate::utils::{generate_uuid, prepare_bundle};
 
 pub struct ContainerCreate {
     project_path: TempDir,

--- a/tests/contest/contest/src/tests/lifecycle/container_lifecycle.rs
+++ b/tests/contest/contest/src/tests/lifecycle/container_lifecycle.rs
@@ -1,9 +1,11 @@
-use crate::utils::{generate_uuid, prepare_bundle};
 use std::thread::sleep;
 use std::time::Duration;
+
 use test_framework::{TestResult, TestableGroup};
 
-use super::{checkpoint, create, delete, exec, kill, start, state, util::criu_installed};
+use super::util::criu_installed;
+use super::{checkpoint, create, delete, exec, kill, start, state};
+use crate::utils::{generate_uuid, prepare_bundle};
 
 // By experimenting, somewhere around 50 is enough for youki process
 // to get the kill signal and shut down

--- a/tests/contest/contest/src/tests/lifecycle/create.rs
+++ b/tests/contest/contest/src/tests/lifecycle/create.rs
@@ -1,8 +1,10 @@
-use crate::utils::get_runtime_path;
-use anyhow::{bail, Result};
 use std::io;
 use std::path::Path;
 use std::process::{Command, Stdio};
+
+use anyhow::{bail, Result};
+
+use crate::utils::get_runtime_path;
 
 // There are still some issues here in case we put stdout and stderr as piped
 // the youki process created halts indefinitely which is why we pass null, and

--- a/tests/contest/contest/src/tests/lifecycle/delete.rs
+++ b/tests/contest/contest/src/tests/lifecycle/delete.rs
@@ -1,7 +1,9 @@
+use std::path::Path;
+
+use anyhow::Result;
+
 use super::get_result_from_output;
 use crate::utils::delete_container;
-use anyhow::Result;
-use std::path::Path;
 
 pub fn delete(project_path: &Path, id: &str) -> Result<()> {
     let res = delete_container(id, project_path)

--- a/tests/contest/contest/src/tests/lifecycle/exec.rs
+++ b/tests/contest/contest/src/tests/lifecycle/exec.rs
@@ -1,9 +1,11 @@
-use super::get_result_from_output;
-use crate::utils::get_runtime_path;
-use anyhow::Result;
 use std::path::Path;
 use std::process::{Command, Stdio};
+
+use anyhow::Result;
 use test_framework::assert_result_eq;
+
+use super::get_result_from_output;
+use crate::utils::get_runtime_path;
 
 pub fn exec(
     project_path: &Path,

--- a/tests/contest/contest/src/tests/lifecycle/kill.rs
+++ b/tests/contest/contest/src/tests/lifecycle/kill.rs
@@ -1,8 +1,9 @@
+use std::path::Path;
+
 use anyhow::Result;
 
 use super::get_result_from_output;
 use crate::utils::kill_container;
-use std::path::Path;
 
 pub fn kill(project_path: &Path, id: &str) -> Result<()> {
     let res = kill_container(id, project_path)

--- a/tests/contest/contest/src/tests/lifecycle/start.rs
+++ b/tests/contest/contest/src/tests/lifecycle/start.rs
@@ -1,7 +1,9 @@
+use std::path::Path;
+
+use anyhow::Result;
+
 use super::get_result_from_output;
 use crate::utils::test_utils::start_container;
-use anyhow::Result;
-use std::path::Path;
 
 pub fn start(project_path: &Path, id: &str) -> Result<()> {
     let res = start_container(id, project_path)

--- a/tests/contest/contest/src/tests/lifecycle/state.rs
+++ b/tests/contest/contest/src/tests/lifecycle/state.rs
@@ -1,6 +1,8 @@
-use crate::utils::get_state;
-use anyhow::{bail, Result};
 use std::path::Path;
+
+use anyhow::{bail, Result};
+
+use crate::utils::get_state;
 
 pub fn state(project_path: &Path, id: &str) -> Result<()> {
     match get_state(id, project_path) {

--- a/tests/contest/contest/src/tests/lifecycle/util.rs
+++ b/tests/contest/contest/src/tests/lifecycle/util.rs
@@ -1,5 +1,6 @@
-use anyhow::{bail, Result};
 use std::{io, process};
+
+use anyhow::{bail, Result};
 
 pub fn get_result_from_output(res: io::Result<process::Output>) -> Result<()> {
     match res {

--- a/tests/contest/contest/src/tests/linux_ns_itype/ns_itype_test.rs
+++ b/tests/contest/contest/src/tests/linux_ns_itype/ns_itype_test.rs
@@ -1,9 +1,9 @@
-use crate::utils::test_outside_container;
 use anyhow::anyhow;
-use oci_spec::runtime::LinuxBuilder;
-use oci_spec::runtime::{Spec, SpecBuilder};
+use oci_spec::runtime::{LinuxBuilder, Spec, SpecBuilder};
 use procfs::process::Process;
 use test_framework::{Test, TestGroup, TestResult};
+
+use crate::utils::test_outside_container;
 
 // get spec for the test
 fn get_spec() -> Spec {

--- a/tests/contest/contest/src/tests/mounts_recursive/mod.rs
+++ b/tests/contest/contest/src/tests/mounts_recursive/mod.rs
@@ -1,4 +1,11 @@
-use crate::utils::test_inside_container;
+use std::collections::hash_set::HashSet;
+use std::fs;
+use std::fs::File;
+use std::os::unix::fs::symlink;
+use std::os::unix::prelude::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::str::FromStr;
+
 use anyhow::Context;
 use nix::libc;
 use nix::mount::{mount, umount, MsFlags};
@@ -8,14 +15,9 @@ use oci_spec::runtime::{
     get_default_mounts, Capability, LinuxBuilder, LinuxCapabilitiesBuilder, Mount, ProcessBuilder,
     Spec, SpecBuilder,
 };
-use std::collections::hash_set::HashSet;
-use std::fs;
-use std::fs::File;
-use std::os::unix::fs::symlink;
-use std::os::unix::prelude::PermissionsExt;
-use std::path::{Path, PathBuf};
-use std::str::FromStr;
 use test_framework::{Test, TestGroup, TestResult};
+
+use crate::utils::test_inside_container;
 
 fn get_spec(added_mounts: Vec<Mount>, process_args: Vec<String>) -> Spec {
     let mut mounts = get_default_mounts();

--- a/tests/contest/contest/src/tests/pidfile/pidfile_test.rs
+++ b/tests/contest/contest/src/tests/pidfile/pidfile_test.rs
@@ -1,14 +1,14 @@
+use std::fs::File;
+use std::process::{Command, Stdio};
+
+use anyhow::anyhow;
+use test_framework::{Test, TestGroup, TestResult};
+use uuid::Uuid;
+
 use crate::utils::{
     delete_container, generate_uuid, get_runtime_path, get_state, kill_container, prepare_bundle,
     State,
 };
-use anyhow::anyhow;
-use std::{
-    fs::File,
-    process::{Command, Stdio},
-};
-use test_framework::{Test, TestGroup, TestResult};
-use uuid::Uuid;
 
 #[inline]
 fn cleanup(id: &Uuid, bundle: &tempfile::TempDir) {

--- a/tests/contest/contest/src/tests/readonly_paths/readonly_paths_tests.rs
+++ b/tests/contest/contest/src/tests/readonly_paths/readonly_paths_tests.rs
@@ -1,10 +1,11 @@
-use crate::utils::test_inside_container;
+use std::path::PathBuf;
+
 use anyhow::{anyhow, bail};
 use nix::sys::stat::SFlag;
-use oci_spec::runtime::LinuxBuilder;
-use oci_spec::runtime::{ProcessBuilder, Spec, SpecBuilder};
-use std::path::PathBuf;
+use oci_spec::runtime::{LinuxBuilder, ProcessBuilder, Spec, SpecBuilder};
 use test_framework::{Test, TestGroup, TestResult};
+
+use crate::utils::test_inside_container;
 
 fn get_spec(readonly_paths: Vec<String>) -> Spec {
     SpecBuilder::default()

--- a/tests/contest/contest/src/tests/seccomp_notify/mod.rs
+++ b/tests/contest/contest/src/tests/seccomp_notify/mod.rs
@@ -1,14 +1,14 @@
-use crate::utils::{get_runtime_path, test_outside_container};
+use std::path::PathBuf;
+use std::sync::mpsc::{self, Receiver, Sender};
+use std::thread;
+
 use anyhow::{anyhow, bail, Result};
 use oci_spec::runtime::{
     Arch, LinuxBuilder, LinuxSeccompAction, LinuxSeccompBuilder, LinuxSyscallBuilder, SpecBuilder,
 };
-use std::{
-    path::PathBuf,
-    sync::mpsc::{self, Receiver, Sender},
-    thread,
-};
 use test_framework::{Test, TestGroup, TestResult};
+
+use crate::utils::{get_runtime_path, test_outside_container};
 
 mod seccomp_agent;
 

--- a/tests/contest/contest/src/tests/seccomp_notify/seccomp_agent.rs
+++ b/tests/contest/contest/src/tests/seccomp_notify/seccomp_agent.rs
@@ -1,17 +1,12 @@
+use std::io::IoSliceMut;
+use std::os::fd::{AsFd, AsRawFd};
+use std::os::unix::prelude::RawFd;
+use std::path::Path;
+
 use anyhow::{bail, Context, Result};
 use libcontainer::container::ContainerProcessState;
-use nix::{
-    sys::socket::{self, UnixAddr},
-    unistd,
-};
-use std::{
-    io::IoSliceMut,
-    os::{
-        fd::{AsFd, AsRawFd},
-        unix::prelude::RawFd,
-    },
-    path::Path,
-};
+use nix::sys::socket::{self, UnixAddr};
+use nix::unistd;
 
 const DEFAULT_BUFFER_SIZE: usize = 4096;
 

--- a/tests/contest/contest/src/tests/tlb/tlb_test.rs
+++ b/tests/contest/contest/src/tests/tlb/tlb_test.rs
@@ -1,11 +1,13 @@
+use std::path::PathBuf;
+
+use anyhow::anyhow;
+use oci_spec::runtime::{
+    LinuxBuilder, LinuxHugepageLimitBuilder, LinuxResourcesBuilder, Spec, SpecBuilder,
+};
+use test_framework::{test_result, ConditionalTest, TestGroup, TestResult};
+
 use crate::utils::test_outside_container;
 use crate::utils::test_utils::check_container_created;
-use anyhow::anyhow;
-use oci_spec::runtime::LinuxBuilder;
-use oci_spec::runtime::{LinuxHugepageLimitBuilder, LinuxResourcesBuilder};
-use oci_spec::runtime::{Spec, SpecBuilder};
-use std::path::PathBuf;
-use test_framework::{test_result, ConditionalTest, TestGroup, TestResult};
 
 fn check_hugetlb() -> bool {
     PathBuf::from("/sys/fs/cgroup/hugetlb").exists()

--- a/tests/contest/contest/src/utils/support.rs
+++ b/tests/contest/contest/src/utils/support.rs
@@ -1,11 +1,12 @@
+use std::env;
+use std::fs::File;
+use std::path::{Path, PathBuf};
+
 use anyhow::{Context, Result};
 use flate2::read::GzDecoder;
 use oci_spec::runtime::{Process, Spec};
 use once_cell::sync::OnceCell;
 use rand::Rng;
-use std::env;
-use std::fs::File;
-use std::path::{Path, PathBuf};
 use tar::Archive;
 use tempfile::TempDir;
 use uuid::Uuid;

--- a/tests/contest/contest/src/utils/test_utils.rs
+++ b/tests/contest/contest/src/utils/test_utils.rs
@@ -1,16 +1,17 @@
 //! Contains utility functions for testing
 //! Similar to https://github.com/opencontainers/runtime-tools/blob/master/validation/util/test.go
-use super::{generate_uuid, prepare_bundle, set_config};
-use super::{get_runtime_path, get_runtimetest_path};
-use anyhow::{anyhow, bail, Context, Result};
-use oci_spec::runtime::Spec;
-use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, ExitStatus, Stdio};
 use std::thread::sleep;
 use std::time::Duration;
+
+use anyhow::{anyhow, bail, Context, Result};
+use oci_spec::runtime::Spec;
+use serde::{Deserialize, Serialize};
 use test_framework::{test_result, TestResult};
+
+use super::{generate_uuid, get_runtime_path, get_runtimetest_path, prepare_bundle, set_config};
 
 const SLEEP_TIME: Duration = Duration::from_millis(150);
 pub const CGROUP_ROOT: &str = "/sys/fs/cgroup";

--- a/tests/contest/runtimetest/src/main.rs
+++ b/tests/contest/runtimetest/src/main.rs
@@ -1,10 +1,11 @@
 mod tests;
 mod utils;
 
-use oci_spec::runtime::IOPriorityClass::{IoprioClassBe, IoprioClassIdle, IoprioClassRt};
-use oci_spec::runtime::Spec;
 use std::env;
 use std::path::PathBuf;
+
+use oci_spec::runtime::IOPriorityClass::{IoprioClassBe, IoprioClassIdle, IoprioClassRt};
+use oci_spec::runtime::Spec;
 
 const SPEC_PATH: &str = "/config.json";
 

--- a/tests/contest/runtimetest/src/tests.rs
+++ b/tests/contest/runtimetest/src/tests.rs
@@ -1,17 +1,18 @@
-use crate::utils::{self, test_read_access, test_write_access};
-use anyhow::{bail, Result};
-use nix::libc;
-use nix::{errno::Errno, sys::utsname, unistd::getcwd};
-use oci_spec::runtime::{
-    IOPriorityClass::{self, IoprioClassBe, IoprioClassIdle, IoprioClassRt},
-    LinuxSchedulerPolicy, Spec,
-};
-use oci_spec::runtime::{LinuxDevice, LinuxDeviceType};
 use std::fs::{self, read_dir};
 use std::mem;
 use std::os::linux::fs::MetadataExt;
 use std::os::unix::fs::{FileTypeExt, PermissionsExt};
 use std::path::Path;
+
+use anyhow::{bail, Result};
+use nix::errno::Errno;
+use nix::libc;
+use nix::sys::utsname;
+use nix::unistd::getcwd;
+use oci_spec::runtime::IOPriorityClass::{self, IoprioClassBe, IoprioClassIdle, IoprioClassRt};
+use oci_spec::runtime::{LinuxDevice, LinuxDeviceType, LinuxSchedulerPolicy, Spec};
+
+use crate::utils::{self, test_read_access, test_write_access};
 
 ////////// ANCHOR: example_hello_world
 pub fn hello_world(_spec: &Spec) {

--- a/tests/contest/runtimetest/src/utils.rs
+++ b/tests/contest/runtimetest/src/utils.rs
@@ -1,11 +1,10 @@
-use nix::sys::stat::stat;
-use nix::sys::stat::SFlag;
 use std::fs;
-use std::fs::metadata;
-use std::fs::symlink_metadata;
+use std::fs::{metadata, symlink_metadata};
 use std::os::unix::prelude::MetadataExt;
 use std::path::PathBuf;
 use std::process::Command;
+
+use nix::sys::stat::{stat, SFlag};
 
 fn test_file_read_access(path: &str) -> Result<(), std::io::Error> {
     let _ = std::fs::OpenOptions::new()

--- a/tests/contest/test_framework/src/test_group.rs
+++ b/tests/contest/test_framework/src/test_group.rs
@@ -1,7 +1,9 @@
 //! Contains structure for a test group
-use crate::testable::{TestResult, Testable, TestableGroup};
-use crossbeam::thread;
 use std::collections::BTreeMap;
+
+use crossbeam::thread;
+
+use crate::testable::{TestResult, Testable, TestableGroup};
 
 /// Stores tests belonging to a group
 pub struct TestGroup {

--- a/tests/contest/test_framework/src/test_manager.rs
+++ b/tests/contest/test_framework/src/test_manager.rs
@@ -1,8 +1,10 @@
 //! This exposes the main control wrapper to control the tests
-use crate::testable::{TestResult, TestableGroup};
+use std::collections::BTreeMap;
+
 use anyhow::Result;
 use crossbeam::thread;
-use std::collections::BTreeMap;
+
+use crate::testable::{TestResult, TestableGroup};
 
 type TestableGroupType = dyn TestableGroup + Sync + Send;
 


### PR DESCRIPTION
This PR adds a `rustfmt.toml` which configures rustfmt.
In particular, it specifies formatting for imports grouping:
```toml
group_imports = "StdExternalCrate" # create three groups for std, external and local crates
imports_granularity = "Module" # Merge imports from the same module
```

These options are still unstable, so they need to be run with `cargo +nightly fmt ...`.

For reviewing it's easier to review it by commit instead of as a whole.
* The first commit adds `rustfmt.toml` and updates the `cargo.sh` script to use nightly for `cargo fmt`.
* The second commit is the result of running `just format`.