### PR TITLE
Add new `setup_envs` method for the `Executor` trait

### DIFF
--- a/crates/libcontainer/src/process/container_init_process.rs
+++ b/crates/libcontainer/src/process/container_init_process.rs
@@ -589,7 +589,7 @@ pub fn container_init_process(
     }
 
     args.executor.validate(spec)?;
-    args.executor.set_envs(envs)?;
+    args.executor.setup_envs(envs)?;
 
     // Notify main process that the init process is ready to execute the
     // payload.  Note, because we are already inside the pid namespace, the pid

--- a/crates/libcontainer/src/process/container_init_process.rs
+++ b/crates/libcontainer/src/process/container_init_process.rs
@@ -73,6 +73,8 @@ pub enum InitProcessError {
     Workload(#[from] workload::ExecutorError),
     #[error(transparent)]
     WorkloadValidation(#[from] workload::ExecutorValidationError),
+    #[error(transparent)]
+    WorkloadSetEnvs(#[from] workload::ExecutorSetEnvsError),
     #[error("invalid io priority class: {0}")]
     IoPriorityClass(String),
     #[error("call exec sched_setattr error: {0}")]

--- a/crates/libcontainer/src/process/container_init_process.rs
+++ b/crates/libcontainer/src/process/container_init_process.rs
@@ -558,18 +558,6 @@ pub fn container_init_process(
         err
     })?;
 
-    // add HOME into envs if not exists
-    if !envs.contains_key("HOME") {
-        if let Some(dir_home) = utils::get_user_home(proc.user().uid()) {
-            envs.insert("HOME".to_owned(), dir_home.to_string_lossy().to_string());
-        }
-    }
-
-    // Reset the process env based on oci spec.
-    env::vars().for_each(|(key, _value)| env::remove_var(key));
-    envs.iter()
-        .for_each(|(key, value)| env::set_var(key, value));
-
     // Initialize seccomp profile right before we are ready to execute the
     // payload so as few syscalls will happen between here and payload exec. The
     // notify socket will still need network related syscalls.
@@ -591,7 +579,15 @@ pub fn container_init_process(
         tracing::warn!("seccomp not available, unable to set seccomp privileges!")
     }
 
+    // add HOME into envs if not exists
+    if !envs.contains_key("HOME") {
+        if let Some(dir_home) = utils::get_user_home(proc.user().uid()) {
+            envs.insert("HOME".to_owned(), dir_home.to_string_lossy().to_string());
+        }
+    }
+
     args.executor.validate(spec)?;
+    args.executor.set_envs(envs)?;
 
     // Notify main process that the init process is ready to execute the
     // payload.  Note, because we are already inside the pid namespace, the pid

--- a/crates/libcontainer/src/workload/default.rs
+++ b/crates/libcontainer/src/workload/default.rs
@@ -197,7 +197,7 @@ mod tests {
                 ("BAR".to_owned(), "fuga".to_owned()),
                 ("BAZ".to_owned(), "piyo".to_owned()),
             ]);
-            assert!(executor.set_envs(envs).is_ok());
+            assert!(executor.setup_envs(envs).is_ok());
 
             // Check if the environment variables are set correctly
             let current_envs = std::env::vars().collect::<HashMap<String, String>>();

--- a/crates/libcontainer/src/workload/mod.rs
+++ b/crates/libcontainer/src/workload/mod.rs
@@ -1,4 +1,5 @@
 use oci_spec::runtime::Spec;
+use std::{collections::HashMap, env};
 
 pub mod default;
 
@@ -60,6 +61,16 @@ pub trait Executor: CloneBoxExecutor {
     /// namespace and cgroups, and pivot_root into the rootfs. But this step
     /// runs before waiting for the container start signal.
     fn validate(&self, spec: &Spec) -> Result<(), ExecutorValidationError>;
+
+    /// Set environment variables for the container process to be executed.
+    fn set_envs(&self, envs: HashMap<String, String>) -> Result<(), ExecutorError> {
+        // Reset the process env based on oci spec.
+        env::vars().for_each(|(key, _value)| env::remove_var(key));
+        envs.iter()
+            .for_each(|(key, value)| env::set_var(key, value));
+
+        Ok(())
+    }
 }
 
 impl<T> CloneBoxExecutor for T

--- a/crates/libcontainer/src/workload/mod.rs
+++ b/crates/libcontainer/src/workload/mod.rs
@@ -73,7 +73,7 @@ pub trait Executor: CloneBoxExecutor {
     fn validate(&self, spec: &Spec) -> Result<(), ExecutorValidationError>;
 
     /// Set environment variables for the container process to be executed.
-    fn set_envs(&self, envs: HashMap<String, String>) -> Result<(), ExecutorSetEnvsError> {
+    fn setup_envs(&self, envs: HashMap<String, String>) -> Result<(), ExecutorSetEnvsError> {
         // Reset the process env based on oci spec.
         env::vars().for_each(|(key, _value)| env::remove_var(key));
         envs.iter()

--- a/crates/libcontainer/src/workload/mod.rs
+++ b/crates/libcontainer/src/workload/mod.rs
@@ -27,6 +27,14 @@ pub enum ExecutorValidationError {
     ArgValidationError(String),
 }
 
+#[derive(Debug, thiserror::Error)]
+pub enum ExecutorSetEnvsError {
+    #[error("failed to set envs")]
+    SetEnvs(#[from] Box<dyn std::error::Error + Send + Sync>),
+    #[error("{0}")]
+    Other(String),
+}
+
 // Here is an explanation about the complexity below regarding to
 // CloneBoxExecutor and Executor traits. This is one of the places rust actually
 // makes our life harder. The usecase for the executor is to allow users of
@@ -65,7 +73,7 @@ pub trait Executor: CloneBoxExecutor {
     fn validate(&self, spec: &Spec) -> Result<(), ExecutorValidationError>;
 
     /// Set environment variables for the container process to be executed.
-    fn set_envs(&self, envs: HashMap<String, String>) -> Result<(), ExecutorError> {
+    fn set_envs(&self, envs: HashMap<String, String>) -> Result<(), ExecutorSetEnvsError> {
         // Reset the process env based on oci spec.
         env::vars().for_each(|(key, _value)| env::remove_var(key));
         envs.iter()

--- a/crates/libcontainer/src/workload/mod.rs
+++ b/crates/libcontainer/src/workload/mod.rs
@@ -1,5 +1,7 @@
+use std::collections::HashMap;
+use std::env;
+
 use oci_spec::runtime::Spec;
-use std::{collections::HashMap, env};
 
 pub mod default;
 


### PR DESCRIPTION
fixes #2815 

This PR introduces a new `setup_envs` method for the `Executor` trait. It allows any implementors of the `Executor` trait to control how environment variables specified in the OCI spec are handled. The default implementation mirrors the behavior of the one implemented in the `container_init_process`, which involves removing existing environment variables and setting the ones specified in the OCI spec.

## TODO

- [x] Make consensus about the interface
- [x] Consider defining a dedicated error instead of `ExecutorError`
- [x] Add missing test cases