### PR TITLE
Update go version in podman CI and vagrantfile

### DIFF
--- a/.github/workflows/podman_tests.yaml
+++ b/.github/workflows/podman_tests.yaml
@@ -28,7 +28,7 @@ jobs:
       # setup go
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.20'
+          go-version: '1.22'
           cache: false
       
       # build skopeo
@@ -52,7 +52,7 @@ jobs:
         with:
           repository: containers/podman
       - name: Build podman
-        run: make binaries 
+        run: make binaries
       - name: Install tools
         run: make install.tools
       

--- a/Vagrantfile.podmane2e
+++ b/Vagrantfile.podmane2e
@@ -1,7 +1,7 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
-GO_VERSION = "1.20.12"
+GO_VERSION = "1.22.0"
 PODMAN_BRANCH = "main"
 SKOPEO_VERSION = "1.13.1"
 


### PR DESCRIPTION
Podman needs newer go version in order to compile correctly, and hence the podman CI was failing for some time. This updates the go version to 1.22 , making the tests run again.