### PR TITLE
docs: fix `with_executor` method description

### DIFF
--- a/crates/libcontainer/src/container/builder.rs
+++ b/crates/libcontainer/src/container/builder.rs
@@ -238,8 +238,8 @@ impl ContainerBuilder {
         self.preserve_fds = preserved_fds;
         self
     }
-    /// Sets the number of additional file descriptors which will be passed into
-    /// the container process.
+
+    /// Sets the function that actually runs on the container init process.
     /// # Example
     ///
     /// ```no_run


### PR DESCRIPTION
This PR fixes a wrong copy & paste in the `with_executor` method description.