### PR TITLE
Fix/dbus call issue

### DIFF
--- a/crates/libcgroups/src/systemd/dbus_native/message.rs
+++ b/crates/libcgroups/src/systemd/dbus_native/message.rs
@@ -54,7 +54,7 @@ impl HeaderSignature {
 }
 
 /// Type of message
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum MessageType {
     MethodCall,
     MethodReturn,

--- a/crates/libcgroups/src/systemd/dbus_native/proxy.rs
+++ b/crates/libcgroups/src/systemd/dbus_native/proxy.rs
@@ -47,6 +47,7 @@ impl<'conn> Proxy<'conn> {
         member: &str,
         body: Option<Body>,
     ) -> Result<Output> {
+        tracing::trace!("dbus call at interface {} member {}", interface, member);
         let mut headers = Vec::with_capacity(4);
 
         // create necessary headers
@@ -114,9 +115,10 @@ impl<'conn> Proxy<'conn> {
         // we are only going to consider first reply, cause... so.
         // realistically there should only be at most one method return type of message
         // for a method call
-        let reply = reply.first().ok_or(DbusError::MethodCallErr(
-            "expected to get a reply for method call, didn't get any".into(),
-        ))?;
+        let reply = reply.first().ok_or(DbusError::MethodCallErr(format!(
+            "expected to get a reply for method call, got {:?} instead",
+            reply_messages
+        )))?;
 
         let headers = &reply.headers;
         let expected_signature = Output::get_signature();

--- a/crates/libcontainer/src/container/builder_impl.rs
+++ b/crates/libcontainer/src/container/builder_impl.rs
@@ -159,7 +159,7 @@ impl ContainerBuilderImpl {
         let (init_pid, need_to_clean_up_intel_rdt_dir) =
             process::container_main_process::container_main_process(&container_args).map_err(
                 |err| {
-                    tracing::error!(?err, "failed to run container process");
+                    tracing::error!("failed to run container process {}", err);
                     LibcontainerError::MainProcess(err)
                 },
             )?;

--- a/crates/libcontainer/src/process/container_main_process.rs
+++ b/crates/libcontainer/src/process/container_main_process.rs
@@ -62,7 +62,17 @@ pub fn container_main_process(container_args: &ContainerArgs) -> Result<(Pid, bo
             ) {
                 Ok(_) => 0,
                 Err(err) => {
-                    tracing::error!(?err, "failed to run intermediate process");
+                    tracing::error!("failed to run intermediate process {}", err);
+                    match main_sender.send_error(err.to_string()) {
+                        Ok(_) => {}
+                        Err(e) => {
+                            tracing::error!(
+                                "error in sending intermediate error message {} to main: {}",
+                                err,
+                                e
+                            )
+                        }
+                    }
                     -1
                 }
             }

--- a/crates/libcontainer/src/process/message.rs
+++ b/crates/libcontainer/src/process/message.rs
@@ -12,6 +12,7 @@ pub enum Message {
     SeccompNotify,
     SeccompNotifyDone,
     ExecFailed(String),
+    OtherError(String),
 }
 
 impl fmt::Display for Message {
@@ -24,6 +25,7 @@ impl fmt::Display for Message {
             Message::SeccompNotify => write!(f, "SeccompNotify"),
             Message::SeccompNotifyDone => write!(f, "SeccompNotifyDone"),
             Message::ExecFailed(s) => write!(f, "ExecFailed({})", s),
+            Message::OtherError(s) => write!(f, "OtherError({})", s),
         }
     }
 }


### PR DESCRIPTION
This fixes the issues with dbus method call not receiving reply. The RC was that the current implementation stopped after receiving one message, and did not continue.  Thus in some cases the signal type message would be returned, and we would discard it as its not the method reply type. As we did not look for further messages, it seemed that there was no reply from dbus. Now if the sent message was of type method call, we keep looping until we get either a method reply or method error type of message. Ideally the correct way would be to keep collecting messages in a stateful buffer and return when we get a message corresponding to the serial number we sent, but it can be tricky to implement that correctly, and at least for now we do not need that.

This should still be considered WIP, I needed review so opened this, but I need to add some related shell scripts I used for future needs. 

Apart from that this also has fix for when intermediate process would error and leave a broken socket, without any error. Now it properly attempts to send the error message over the socket so that main process can correctly identify and report it.