### PR TITLE
Install nightly for running linter inside devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -34,6 +34,8 @@ COPY <<EOF /etc/docker/daemon.json
 EOF
 
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y 
+# nightly build is required for `cargo fmt` as `rustfmt.toml` uses unstable features.
+RUN rustup install nightly
 RUN rustup component add rustfmt
 RUN rustup component add clippy 
 


### PR DESCRIPTION
Nightly release is required for running formatter and linter as [`rustfmt.toml` uses unstable features](https://github.com/containers/youki/blob/aaa1590b564ad102832edd948ea8dbe462e24914/rustfmt.toml#L2C1-L2C86), however devcontainer only installs stable release. This PR adds a line to the devcontainer's Dockerfile to install nightly along with stable release.