### PR TITLE
chore(deps): update oci-spec to v0.6.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2377,15 +2377,17 @@ dependencies = [
 
 [[package]]
 name = "oci-spec"
-version = "0.6.5"
+version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e423c4f827362c0d8d8da4b1f571270f389ebde73bcd3240a3d23c6d6f61d0f0"
+checksum = "bdf88ddc01cc6bccbe1044adb6a29057333f523deadcb4953c011a73158cfa5e"
 dependencies = [
  "derive_builder 0.20.0",
  "getset",
  "quickcheck",
  "serde",
  "serde_json",
+ "strum",
+ "strum_macros",
  "thiserror",
 ]
 
@@ -3714,6 +3716,25 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.58",
+]
 
 [[package]]
 name = "syn"

--- a/crates/libcgroups/src/v1/devices.rs
+++ b/crates/libcgroups/src/v1/devices.rs
@@ -73,7 +73,7 @@ mod tests {
             set_fixture(tmp.path(), "devices.deny", "").expect("create denied devices list");
 
             Devices::apply_device(d, tmp.path()).expect("Apply default device");
-            println!("Device: {}", d.to_string());
+            println!("Device: {}", d);
             if d.allow() {
                 let allowed_content =
                     read_to_string(tmp.path().join("devices.allow")).expect("read to string");
@@ -125,7 +125,7 @@ mod tests {
             set_fixture(tmp.path(), "devices.deny", "").expect("create denied devices list");
 
             Devices::apply_device(d, tmp.path()).expect("Apply default device");
-            println!("Device: {}", d.to_string());
+            println!("Device: {}", d);
             if d.allow() {
                 let allowed_content =
                     read_to_string(tmp.path().join("devices.allow")).expect("read to string");

--- a/crates/libcontainer/Cargo.toml
+++ b/crates/libcontainer/Cargo.toml
@@ -39,7 +39,7 @@ nix = { version = "0.28.0", features = [
     "term",
     "hostname",
 ] }
-oci-spec = { version = "~0.6.4", features = ["runtime"] }
+oci-spec = { version = "0.6.7", features = ["runtime"] }
 once_cell = "1.19.0"
 procfs = "0.16.0"
 prctl = "1.0.0"

--- a/crates/libcontainer/src/syscall/linux.rs
+++ b/crates/libcontainer/src/syscall/linux.rs
@@ -18,7 +18,7 @@ use nix::mount::{mount, umount2, MntFlags, MsFlags};
 use nix::sched::{unshare, CloneFlags};
 use nix::sys::stat::{mknod, Mode, SFlag};
 use nix::unistd::{chown, chroot, fchdir, pivot_root, sethostname, Gid, Uid};
-use oci_spec::runtime::LinuxRlimit;
+use oci_spec::runtime::PosixRlimit;
 
 use super::{Result, Syscall, SyscallError};
 use crate::{capabilities, utils};
@@ -386,7 +386,7 @@ impl Syscall for LinuxSyscall {
     }
 
     /// Sets resource limit for process
-    fn set_rlimit(&self, rlimit: &LinuxRlimit) -> Result<()> {
+    fn set_rlimit(&self, rlimit: &PosixRlimit) -> Result<()> {
         let rlim = &libc::rlimit {
             rlim_cur: rlimit.soft(),
             rlim_max: rlimit.hard(),

--- a/crates/libcontainer/src/syscall/syscall.rs
+++ b/crates/libcontainer/src/syscall/syscall.rs
@@ -12,7 +12,7 @@ use nix::mount::MsFlags;
 use nix::sched::CloneFlags;
 use nix::sys::stat::{Mode, SFlag};
 use nix::unistd::{Gid, Uid};
-use oci_spec::runtime::LinuxRlimit;
+use oci_spec::runtime::PosixRlimit;
 
 use crate::syscall::linux::{LinuxSyscall, MountAttr};
 use crate::syscall::test::TestHelperSyscall;
@@ -30,7 +30,7 @@ pub trait Syscall {
     fn set_capability(&self, cset: CapSet, value: &CapsHashSet) -> Result<()>;
     fn set_hostname(&self, hostname: &str) -> Result<()>;
     fn set_domainname(&self, domainname: &str) -> Result<()>;
-    fn set_rlimit(&self, rlimit: &LinuxRlimit) -> Result<()>;
+    fn set_rlimit(&self, rlimit: &PosixRlimit) -> Result<()>;
     fn get_pwuid(&self, uid: u32) -> Option<Arc<OsStr>>;
     fn mount(
         &self,

--- a/crates/libcontainer/src/syscall/test.rs
+++ b/crates/libcontainer/src/syscall/test.rs
@@ -10,7 +10,7 @@ use nix::mount::MsFlags;
 use nix::sched::CloneFlags;
 use nix::sys::stat::{Mode, SFlag};
 use nix::unistd::{Gid, Uid};
-use oci_spec::runtime::LinuxRlimit;
+use oci_spec::runtime::PosixRlimit;
 
 use super::{linux, Result, Syscall};
 
@@ -173,7 +173,7 @@ impl Syscall for TestHelperSyscall {
             .act(ArgName::Domainname, Box::new(domainname.to_owned()))
     }
 
-    fn set_rlimit(&self, _rlimit: &LinuxRlimit) -> Result<()> {
+    fn set_rlimit(&self, _rlimit: &PosixRlimit) -> Result<()> {
         todo!()
     }
 


### PR DESCRIPTION
there is a breaking change in the public API of the oci-spec crate. This commit fixes the issue.