### PR TITLE
Bump oci-spec

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2377,13 +2377,15 @@ dependencies = [
 
 [[package]]
 name = "oci-spec"
-version = "0.6.7"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdf88ddc01cc6bccbe1044adb6a29057333f523deadcb4953c011a73158cfa5e"
+checksum = "3f5a3fe998d50101ae009351fec56d88a69f4ed182e11000e711068c2f5abf72"
 dependencies = [
  "derive_builder 0.20.0",
  "getset",
+ "once_cell",
  "quickcheck",
+ "regex",
  "serde",
  "serde_json",
  "strum",

--- a/crates/libcgroups/Cargo.toml
+++ b/crates/libcgroups/Cargo.toml
@@ -22,7 +22,7 @@ cgroupsv2_devices = ["rbpf", "libbpf-sys", "errno", "libc", "nix/dir"]
 [dependencies]
 nix = { version = "0.28.0", features = ["signal", "user", "fs"] }
 procfs = "0.16.0"
-oci-spec = { version = "~0.6.4", features = ["runtime"] }
+oci-spec = { version = "~0.6.8", features = ["runtime"] }
 fixedbitset = "0.5.7"
 serde = { version = "1.0", features = ["derive"] }
 rbpf = { version = "0.2.0", optional = true }
@@ -34,7 +34,7 @@ tracing = { version = "0.1.40", features = ["attributes"] }
 
 [dev-dependencies]
 anyhow = "1.0"
-oci-spec = { version = "~0.6.4", features = ["proptests", "runtime"] }
+oci-spec = { version = "~0.6.8", features = ["proptests", "runtime"] }
 quickcheck = "1"
 mockall = { version = "0.12.1", features = [] }
 clap = "4.1.6"

--- a/crates/libcontainer/Cargo.toml
+++ b/crates/libcontainer/Cargo.toml
@@ -39,7 +39,7 @@ nix = { version = "0.28.0", features = [
     "term",
     "hostname",
 ] }
-oci-spec = { version = "0.6.7", features = ["runtime"] }
+oci-spec = { version = "0.6.8", features = ["runtime"] }
 once_cell = "1.19.0"
 procfs = "0.16.0"
 prctl = "1.0.0"
@@ -56,7 +56,7 @@ safe-path = "0.1.0"
 nc = "0.8.21"
 
 [dev-dependencies]
-oci-spec = { version = "~0.6.4", features = ["proptests", "runtime"] }
+oci-spec = { version = "~0.6.8", features = ["proptests", "runtime"] }
 quickcheck = "1"
 serial_test = "3.1.1"
 tempfile = "3"

--- a/tests/contest/runtimetest/Cargo.toml
+++ b/tests/contest/runtimetest/Cargo.toml
@@ -4,9 +4,8 @@ version = "0.0.1"
 edition = "2021"
 
 [dependencies]
-oci-spec = { version = "0.6.4", features = ["runtime"] }
+oci-spec = { version = "0.6.8", features = ["runtime"] }
 nix = "0.28.0"
 anyhow = "1.0"
 libc = "0.2.155" # TODO (YJDoc2) upgrade to latest
 nc = "0.8.21"
-


### PR DESCRIPTION
Enable to use `ExecCPUAffinity` which was introduced https://github.com/containers/oci-spec-rs/pull/174 and https://github.com/containers/oci-spec-rs/pull/178 to solve https://github.com/containers/youki/issues/2795.