### PR TITLE
Update nc dependency to 0.9.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -383,12 +383,13 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.1.6"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2aba8f4e9906c7ce3c73463f62a7f0c65183ada1a2d47e397cc8810827f9694f"
+checksum = "72db2f7947ecee9b03b510377e8bb9077afa27176fdbff55c51027e976fdcc48"
 dependencies = [
  "jobserver",
  "libc",
+ "shlex",
 ]
 
 [[package]]
@@ -2259,9 +2260,9 @@ dependencies = [
 
 [[package]]
 name = "nc"
-version = "0.8.23"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44b24115ea9683b6fd45d99c7e83002a739601faea67908edb02737497fabdd3"
+checksum = "34c069e5680f6e9c5cfbd428822fda91adf12fd6cf8dd84de00709efa50a84db"
 dependencies = [
  "cc",
 ]

--- a/crates/libcontainer/Cargo.toml
+++ b/crates/libcontainer/Cargo.toml
@@ -53,7 +53,7 @@ regex = { version = "1.10.6", default-features = false, features = ["std", "unic
 thiserror = "1.0.63"
 tracing = { version = "0.1.40", features = ["attributes"] }
 safe-path = "0.1.0"
-nc = "0.8.23"
+nc = "0.9.2"
 
 [dev-dependencies]
 oci-spec = { version = "~0.6.8", features = ["proptests", "runtime"] }

--- a/tests/contest/runtimetest/Cargo.toml
+++ b/tests/contest/runtimetest/Cargo.toml
@@ -7,5 +7,5 @@ edition = "2021"
 oci-spec = { version = "0.6.8", features = ["runtime"] }
 nix = "0.28.0"
 anyhow = "1.0"
-libc = "0.2.157" # TODO (YJDoc2) upgrade to latest
+libc = "0.2.158" # TODO (YJDoc2) upgrade to latest
 nc = "0.9.2"

--- a/tests/contest/runtimetest/Cargo.toml
+++ b/tests/contest/runtimetest/Cargo.toml
@@ -8,4 +8,4 @@ oci-spec = { version = "0.6.8", features = ["runtime"] }
 nix = "0.28.0"
 anyhow = "1.0"
 libc = "0.2.157" # TODO (YJDoc2) upgrade to latest
-nc = "0.8.23"
+nc = "0.9.2"

--- a/tests/contest/runtimetest/src/tests.rs
+++ b/tests/contest/runtimetest/src/tests.rs
@@ -1,5 +1,4 @@
 use std::fs::{self, read_dir};
-use std::mem;
 use std::os::linux::fs::MetadataExt;
 use std::os::unix::fs::{FileTypeExt, PermissionsExt};
 use std::path::Path;
@@ -340,7 +339,6 @@ pub fn validate_scheduler_policy(spec: &Spec) {
     let proc = spec.process().as_ref().unwrap();
     let sc = proc.scheduler().as_ref().unwrap();
     println!("schedule is {:?}", spec);
-    let size = mem::size_of::<nc::sched_attr_t>().try_into().unwrap();
     let mut get_sched_attr = nc::sched_attr_t {
         size: 0,
         sched_policy: 0,
@@ -354,7 +352,7 @@ pub fn validate_scheduler_policy(spec: &Spec) {
         sched_util_max: 0,
     };
     unsafe {
-        match nc::sched_getattr(0, &mut get_sched_attr, size, 0) {
+        match nc::sched_getattr(0, &mut get_sched_attr, 0) {
             Ok(_) => {
                 println!("sched_getattr get success");
             }


### PR DESCRIPTION
Hi, new to youki here. Hope to start my contribution from a simple issue #2874. 

1. Instead of updating to 0.9.1, I update to 0.9.2
2. Since the `size` parameter is needless, I remove it.

Please let me know if I do anything wrong. Thank you and hope to do more contribution.