### PR TITLE
prepare for version 0.4.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1969,7 +1969,7 @@ checksum = "d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439"
 
 [[package]]
 name = "libcgroups"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -1994,7 +1994,7 @@ dependencies = [
 
 [[package]]
 name = "libcontainer"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "bitflags 2.6.0",
@@ -2043,7 +2043,7 @@ checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
 
 [[package]]
 name = "liboci-cli"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "clap",
 ]
@@ -5825,7 +5825,7 @@ dependencies = [
 
 [[package]]
 name = "youki"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "caps",

--- a/crates/libcgroups/Cargo.toml
+++ b/crates/libcgroups/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libcgroups"
-version = "0.4.0" # MARK: Version
+version = "0.4.1" # MARK: Version
 description = "Library for cgroup"
 license-file = "../../LICENSE"
 repository = "https://github.com/containers/youki"

--- a/crates/libcontainer/Cargo.toml
+++ b/crates/libcontainer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libcontainer"
-version = "0.4.0" # MARK: Version
+version = "0.4.1" # MARK: Version
 description = "Library for container control"
 license-file = "../../LICENSE"
 repository = "https://github.com/containers/youki"
@@ -43,7 +43,7 @@ oci-spec = { version = "0.6.8", features = ["runtime"] }
 once_cell = "1.19.0"
 procfs = "0.16.0"
 prctl = "1.0.0"
-libcgroups = { path = "../libcgroups", default-features = false, version = "0.4.0" } # MARK: Version
+libcgroups = { path = "../libcgroups", default-features = false, version = "0.4.1" } # MARK: Version
 libseccomp = { version = "0.3.0", optional = true }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/crates/liboci-cli/Cargo.toml
+++ b/crates/liboci-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "liboci-cli"
-version = "0.4.0" # MARK: Version
+version = "0.4.1" # MARK: Version
 description = "Parse command line arguments for OCI container runtimes"
 license-file = "../../LICENSE"
 repository = "https://github.com/containers/youki"

--- a/crates/youki/Cargo.toml
+++ b/crates/youki/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "youki"
-version = "0.4.0" # MARK: Version
+version = "0.4.1" # MARK: Version
 description = "A container runtime written in Rust"
 license-file = "../../LICENSE"
 repository = "https://github.com/containers/youki"
@@ -29,9 +29,9 @@ features = ["std", "suggestions", "derive", "cargo", "help", "usage", "error-con
 [dependencies]
 anyhow = "1.0.86"
 chrono = { version = "0.4", default-features = false, features = ["clock", "serde"] }
-libcgroups = { path = "../libcgroups", default-features = false, version = "0.4.0" } # MARK: Version
-libcontainer = { path = "../libcontainer", default-features = false, version = "0.4.0" } # MARK: Version
-liboci-cli = { path = "../liboci-cli", version = "0.4.0" } # MARK: Version
+libcgroups = { path = "../libcgroups", default-features = false, version = "0.4.1" } # MARK: Version
+libcontainer = { path = "../libcontainer", default-features = false, version = "0.4.1" } # MARK: Version
+liboci-cli = { path = "../liboci-cli", version = "0.4.1" } # MARK: Version
 nix = "0.28.0"
 once_cell = "1.19.0"
 pentacle = "1.0.0"

--- a/docs/src/user/basic_setup.md
+++ b/docs/src/user/basic_setup.md
@@ -83,7 +83,7 @@ Install from the GitHub release as root:
 
 <!--youki release begin-->
 ```console
-# curl -sSfL https://github.com/containers/youki/releases/download/v0.4.0/youki-0.4.0-$(uname -m)-musl.tar.gz | tar -xzvC /usr/bin/ youki
+# curl -sSfL https://github.com/containers/youki/releases/download/v0.4.1/youki-0.4.1-$(uname -m)-musl.tar.gz | tar -xzvC /usr/bin/ youki
 ```
 <!--youki release end-->
 


### PR DESCRIPTION
This uptick is primarily due to https://github.com/containers/youki/issues/2894 , our nc update in last release broke musl builds, which was them fixed by updating to nc's latest patch releases which fix the issues. As this is just a dep update and no breaking changes, only need to change minor version.