### PR TITLE
Fixed ENAMETOOLONG error in setup_console_socket

### DIFF
--- a/crates/libcontainer/src/tty.rs
+++ b/crates/libcontainer/src/tty.rs
@@ -77,6 +77,7 @@ pub fn setup_console_socket(
     socket_name: &str,
 ) -> Result<RawFd> {
     // Move into the container directory to avoid sun family conflicts with long socket path names.
+    // ref: https://github.com/containers/youki/issues/2910
 
     let prev_dir = env::current_dir().unwrap();
     let _ = env::set_current_dir(container_dir);


### PR DESCRIPTION
In reference to the error found here: https://github.com/containers/youki/issues/2910

sun_path has a max length of 108 bytes: https://man7.org/linux/man-pages/man7/unix.7.html

And including the absolute path name can make the resulting address of the socket path too long for sun_path.

Quick solution, move to the container_dir first, that way the sun_path is always just as long as the name "console-socket" itself, and doesn't break depending on the length of the runtime filepath.

I also wrapped this update in code that saves the previous directory and moves back to it afterwords. I personally doubt this is necessary and may simply be wasted clock cycles. Since we tend to use absolute path names in general, both to navigate and to access specific links. Nevertheless, I didn't want to make that call. If repositioning the directory afterwards is not necessary that could certainly be cleaned out. Cargo test passes in either case.