### PR TITLE
ci: update action versions to fix deprecation warnings

### DIFF
--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -16,7 +16,7 @@ jobs:
     outputs:
       any_modified: ${{ steps.filter.outputs.any_modified }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: tj-actions/changed-files@v41
         id: filter
         with:
@@ -40,7 +40,7 @@ jobs:
         arch: [ "x86_64", "aarch64" ]
         libc: [ "gnu", "musl" ]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup Rust toolchain and cache
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
@@ -70,7 +70,7 @@ jobs:
         arch: [ "x86_64" ]
         libc: [ "gnu", "musl" ]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup Rust toolchain and cache
         uses: actions-rust-lang/setup-rust-toolchain@v1
       - name: Install just
@@ -86,31 +86,34 @@ jobs:
       - name: Run feature tests
         run: just test-features
 
-  coverage:
-    needs: [changes]
-    if: needs.changes.outputs.any_modified == 'true'
-    runs-on: ubuntu-22.04
-    timeout-minutes: 20
-    name: Run test coverage
-    steps:
-      - uses: actions/checkout@v3
-      - name: Setup Rust toolchain and cache
-        uses: actions-rust-lang/setup-rust-toolchain@v1.3.7
-      - name: Install llvm-tools-preview
-        run: rustup component add llvm-tools-preview
-      - name: install cargo-llvm-cov
-        uses: taiki-e/install-action@v1
-        with:
-          tool: cargo-llvm-cov@0.4.0
-      - uses: taiki-e/install-action@just
-      - name: Install requirements
-        run: sudo env PATH=$PATH just ci-prepare
-      - name: Run Test Coverage for youki
-        run: |
-          cargo llvm-cov clean --workspace
-          cargo llvm-cov --no-report -- --test-threads=1
-          cargo llvm-cov --no-run --lcov --output-path ./coverage.lcov
-      - name: Upload Youki Code Coverage Results
-        uses: codecov/codecov-action@v3
-        with:
-          file: ./coverage.lcov
+  # We do not yet enforce some minimum coverage, and there were come codecov issues
+  # so commenting this out for now. When we are ready to enforce coverage, uncomment 
+  # and check this works or not.
+  # coverage:
+  #   needs: [changes]
+  #   if: needs.changes.outputs.any_modified == 'true'
+  #   runs-on: ubuntu-22.04
+  #   timeout-minutes: 20
+  #   name: Run test coverage
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #     - name: Setup Rust toolchain and cache
+  #       uses: actions-rust-lang/setup-rust-toolchain@v1.3.7
+  #     - name: Install llvm-tools-preview
+  #       run: rustup component add llvm-tools-preview
+  #     - name: install cargo-llvm-cov
+  #       uses: taiki-e/install-action@v2
+  #       with:
+  #         tool: cargo-llvm-cov@0.4.0
+  #     - uses: taiki-e/install-action@just
+  #     - name: Install requirements
+  #       run: sudo env PATH=$PATH just ci-prepare
+  #     - name: Run Test Coverage for youki
+  #       run: |
+  #         cargo llvm-cov clean --workspace
+  #         cargo llvm-cov --no-report -- --test-threads=1
+  #         cargo llvm-cov --no-run --lcov --output-path ./coverage.lcov
+  #     - name: Upload Youki Code Coverage Results
+  #       uses: codecov/codecov-action@v4
+  #       with:
+  #         file: ./coverage.lcov

--- a/.github/workflows/benchmark_execution_time.yml
+++ b/.github/workflows/benchmark_execution_time.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout to PR branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install requirements
         run: sudo ./.github/scripts/dependency.sh
@@ -27,7 +27,7 @@ jobs:
         run: just youki-release
 
       - name: Uploading PR build to artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: pr-youki
           path: ./youki
@@ -39,7 +39,7 @@ jobs:
 
     steps:
       - name: Checkout to main branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: main
 
@@ -55,7 +55,7 @@ jobs:
         run: just youki-release
 
       - name: Uploading main build to artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: main-youki
           path: ./youki
@@ -75,16 +75,16 @@ jobs:
           sudo apt install jq podman
 
       - name: Checkout to PR branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Downloading PR build from artifact
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: pr-youki
           path: ./pr_youki
 
       - name: Downloading main build from artifact
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: main-youki
           path: ./main_youki

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -12,7 +12,7 @@ jobs:
     outputs:
       dirs: ${{ steps.filter.outputs.changes }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: dorny/paths-filter@v2
         id: filter
         with:
@@ -26,7 +26,7 @@ jobs:
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup mdBook
         uses: peaceiris/actions-mdbook@v1
         with:

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -17,7 +17,7 @@ jobs:
         arch: [ "x86_64", "aarch64" ]
         libc: [ "gnu", "musl" ]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup Rust toolchain and cache
         uses: actions-rust-lang/setup-rust-toolchain@v1.3.7
         env:
@@ -34,7 +34,7 @@ jobs:
         run: just youki-release
       - name: Upload youki binary
         if: ${{ matrix.arch == 'x86_64' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: youki-${{ matrix.arch }}-${{ matrix.libc }}
           path: youki
@@ -48,11 +48,11 @@ jobs:
         arch: [ "x86_64" ]
         libc: [ "gnu", "musl" ]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           repository: containerd/containerd
           ref: v1.7.11
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@v5
         with:
           go-version: '1.20.12'
           cache: true
@@ -66,7 +66,7 @@ jobs:
           ./script/setup/install-cni
           ./script/setup/install-critools
       - name: Download youki binary
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: youki-${{ matrix.arch }}-${{ matrix.libc }}
       - name: Replace runc to youki
@@ -87,9 +87,9 @@ jobs:
         arch: [ "x86_64" ]
         libc: [ "gnu", "musl" ]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Download youki binary
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: youki-${{ matrix.arch }}-${{ matrix.libc }}
       - name: Add the permission to run
@@ -108,20 +108,20 @@ jobs:
         arch: [ "x86_64" ]
         libc: [ "gnu", "musl" ]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
       - name: Setup Rust toolchain and cache
         uses: actions-rust-lang/setup-rust-toolchain@v1
       - name: Install just
         uses: taiki-e/install-action@just
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@v5
         with:
           go-version: '1.20'
           cache: true
           cache-dependency-path: tests/oci-runtime-tests/src/github.com/opencontainers/runtime-tools/go.sum
       - name: Download youki binary
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: youki-${{ matrix.arch }}-${{ matrix.libc }}
       - name: Add the permission to run
@@ -138,7 +138,7 @@ jobs:
         arch: [ "x86_64" ]
         libc: [ "gnu", "musl" ]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
       - name: Setup Rust toolchain and cache
@@ -148,7 +148,7 @@ jobs:
       - name: Install requirements
         run: sudo env PATH=$PATH just ci-prepare
       - name: Download youki binary
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: youki-${{ matrix.arch }}-${{ matrix.libc }}
       - name: Add the permission to run
@@ -165,7 +165,7 @@ jobs:
         arch: [ "x86_64" ]
         libc: [ "gnu", "musl" ]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
       - name: Setup Rust toolchain and cache
@@ -175,7 +175,7 @@ jobs:
       - name: Install requirements
         run: sudo env PATH=$PATH just ci-prepare
       - name: Download youki binary
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: youki-${{ matrix.arch }}-${{ matrix.libc }}
       - name: Add the permission to run
@@ -193,11 +193,11 @@ jobs:
         # ubuntu 22.04 has cgroups-v2
         os: [ "ubuntu-22.04", "ubuntu-20.04" ]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install just
         uses: taiki-e/install-action@just
       - name: Download youki binary
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: youki-x86_64-musl
       - name: Add the permission to run

--- a/.github/workflows/integration_tests_validation.yaml
+++ b/.github/workflows/integration_tests_validation.yaml
@@ -16,7 +16,7 @@ jobs:
     outputs:
       any_modified: ${{ steps.filter.outputs.any_modified }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: tj-actions/changed-files@v41
         id: filter
         with:
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-20.04
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup Rust toolchain and cache
         uses: actions-rust-lang/setup-rust-toolchain@v1.3.7
       - name: Install just

--- a/.github/workflows/podman_tests.yaml
+++ b/.github/workflows/podman_tests.yaml
@@ -48,7 +48,7 @@ jobs:
 
       # build podman
       - name: Clone podman repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: containers/podman
       - name: Build podman

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,7 +26,7 @@ jobs:
         arch: [ "x86_64", "aarch64" ]
         libc: [ "gnu", "musl" ]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
       - name: Setup Rust toolchain and cache
@@ -53,7 +53,7 @@ jobs:
       - name: Create artifact
         run: tar -zcvf youki-${{ needs.parse.outputs.version }}-${{ matrix.arch }}-${{ matrix.libc }}.tar.gz youki README.md LICENSE
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: youki-${{ matrix.arch }}-${{ matrix.libc }}
           path: youki-${{ needs.parse.outputs.version }}-${{ matrix.arch }}-${{ matrix.libc }}.tar.gz
@@ -69,11 +69,11 @@ jobs:
       - parse
       - build
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Create artifacts directory
         run: mkdir -p artifacts
       - name: Download artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           path: artifacts
       - name: Show artifacts
@@ -98,7 +98,7 @@ jobs:
     env:
       CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup Rust toolchain and cache
         uses: actions-rust-lang/setup-rust-toolchain@v1
       - name: Publish libcgroups

--- a/.github/workflows/tagpr.yaml
+++ b/.github/workflows/tagpr.yaml
@@ -7,7 +7,7 @@ jobs:
   tagpr:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Install just

--- a/.github/workflows/update_version_config.yaml
+++ b/.github/workflows/update_version_config.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Update tagpr config


### PR DESCRIPTION
Updates the action versions to fix deprecation warnings.

Also have removed the branch protection requirement for `Run test Coverage` as that CI is commented out for now.