### PR TITLE
Cargo.toml: remove unused dependnecies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -543,9 +543,7 @@ name = "contest"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "chrono",
  "clap",
- "clap_derive",
  "flate2",
  "libcgroups",
  "libcontainer",
@@ -1417,7 +1415,6 @@ dependencies = [
  "futures-core",
  "futures-task",
  "futures-util",
- "num_cpus",
 ]
 
 [[package]]
@@ -1991,11 +1988,9 @@ name = "libcontainer"
 version = "0.4.1"
 dependencies = [
  "anyhow",
- "bitflags 2.6.0",
  "caps",
  "chrono",
  "fastrand",
- "futures",
  "libc",
  "libcgroups",
  "libseccomp",
@@ -2005,7 +2000,6 @@ dependencies = [
  "once_cell",
  "prctl",
  "procfs",
- "protobuf",
  "quickcheck",
  "rand",
  "regex",
@@ -5830,11 +5824,9 @@ dependencies = [
  "libcontainer",
  "liboci-cli",
  "nix 0.28.0",
- "once_cell",
  "pentacle",
  "procfs",
  "scopeguard",
- "serde",
  "serde_json",
  "serial_test",
  "tabwriter",

--- a/crates/libcontainer/Cargo.toml
+++ b/crates/libcontainer/Cargo.toml
@@ -20,14 +20,12 @@ v1 = ["libcgroups/v1"]
 cgroupsv2_devices = ["libcgroups/cgroupsv2_devices"]
 
 [dependencies]
-bitflags = "2.6.0"
 caps = "0.5.5"
 chrono = { version = "0.4", default-features = false, features = [
     "clock",
     "serde",
 ] }
 fastrand = "^2.1.1"
-futures = { version = "0.3", features = ["thread-pool"] }
 libc = "0.2.158"
 nix = { version = "0.28.0", features = [
     "socket",
@@ -48,7 +46,6 @@ libseccomp = { version = "0.3.0", optional = true }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 rust-criu = "0.4.0"
-protobuf = "= 3.2.0" # https://github.com/checkpoint-restore/rust-criu/issues/19
 regex = { version = "1.10.6", default-features = false, features = ["std", "unicode-perl"] }
 thiserror = "1.0.63"
 tracing = { version = "0.1.40", features = ["attributes"] }

--- a/crates/youki/Cargo.toml
+++ b/crates/youki/Cargo.toml
@@ -33,10 +33,8 @@ libcgroups = { path = "../libcgroups", default-features = false, version = "0.4.
 libcontainer = { path = "../libcontainer", default-features = false, version = "0.4.1" } # MARK: Version
 liboci-cli = { path = "../liboci-cli", version = "0.4.1" } # MARK: Version
 nix = "0.28.0"
-once_cell = "1.19.0"
 pentacle = "1.0.0"
 procfs = "0.16.0"
-serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tabwriter = "1"
 clap_complete = "4.1.3"

--- a/tests/contest/contest/Cargo.toml
+++ b/tests/contest/contest/Cargo.toml
@@ -5,7 +5,6 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0"
-chrono = { version = "0.4", default-features = false, features = ["clock"] }
 flate2 = "1.0"
 libcgroups = { path = "../../../crates/libcgroups" }
 libcontainer = { path = "../../../crates/libcontainer" }
@@ -32,6 +31,3 @@ version = "4.1.6"
 default-features = false
 features = ["std", "suggestions", "derive", "cargo", "help", "usage", "error-context"]
 
-[dependencies.clap_derive]
-version = "4.0.21"
-default-features = true


### PR DESCRIPTION
remove unused deps in youki, found by running `cargo machete` 

question: perhaps we should consider adding [this](https://github.com/bnjbvr/cargo-machete?tab=readme-ov-file#cargo-machete-action) to the CI?