### PR TITLE
fix(libcontainer): no_pivot args is not used

### DIFF
--- a/crates/libcontainer/src/container/builder_impl.rs
+++ b/crates/libcontainer/src/container/builder_impl.rs
@@ -49,6 +49,8 @@ pub(super) struct ContainerBuilderImpl {
     pub detached: bool,
     /// Default executes the specified execution of a generic command
     pub executor: Box<dyn Executor>,
+    /// If the container is to be run with no pivot
+    pub no_pivot: bool,
 }
 
 impl ContainerBuilderImpl {
@@ -154,6 +156,7 @@ impl ContainerBuilderImpl {
             cgroup_config,
             detached: self.detached,
             executor: self.executor.clone(),
+            no_pivot: self.no_pivot,
         };
 
         let (init_pid, need_to_clean_up_intel_rdt_dir) =

--- a/crates/libcontainer/src/container/init_builder.rs
+++ b/crates/libcontainer/src/container/init_builder.rs
@@ -20,6 +20,7 @@ pub struct InitContainerBuilder {
     bundle: PathBuf,
     use_systemd: bool,
     detached: bool,
+    no_pivot: bool,
 }
 
 impl InitContainerBuilder {
@@ -31,6 +32,7 @@ impl InitContainerBuilder {
             bundle,
             use_systemd: true,
             detached: true,
+            no_pivot: false,
         }
     }
 
@@ -42,6 +44,11 @@ impl InitContainerBuilder {
 
     pub fn with_detach(mut self, detached: bool) -> Self {
         self.detached = detached;
+        self
+    }
+
+    pub fn with_no_pivot(mut self, no_pivot: bool) -> Self {
+        self.no_pivot = no_pivot;
         self
     }
 
@@ -95,6 +102,7 @@ impl InitContainerBuilder {
             preserve_fds: self.base.preserve_fds,
             detached: self.detached,
             executor: self.base.executor,
+            no_pivot: self.no_pivot,
         };
 
         builder_impl.create()?;

--- a/crates/libcontainer/src/container/tenant_builder.rs
+++ b/crates/libcontainer/src/container/tenant_builder.rs
@@ -142,6 +142,7 @@ impl TenantContainerBuilder {
             preserve_fds: self.base.preserve_fds,
             detached: self.detached,
             executor: self.base.executor,
+            no_pivot: false,
         };
 
         let pid = builder_impl.create()?;

--- a/crates/libcontainer/src/process/args.rs
+++ b/crates/libcontainer/src/process/args.rs
@@ -42,4 +42,6 @@ pub struct ContainerArgs {
     pub detached: bool,
     /// Manage the functions that actually run on the container
     pub executor: Box<dyn Executor>,
+    /// If the container is to be run with no pivot
+    pub no_pivot: bool,
 }

--- a/crates/youki/src/commands/run.rs
+++ b/crates/youki/src/commands/run.rs
@@ -22,6 +22,7 @@ pub fn run(args: Run, root_path: PathBuf, systemd_cgroup: bool) -> Result<i32> {
         .as_init(&args.bundle)
         .with_systemd(systemd_cgroup)
         .with_detach(args.detach)
+        .with_no_pivot(args.no_pivot)
         .build()?;
 
     container

--- a/experiment/selinux/README.md
+++ b/experiment/selinux/README.md
@@ -10,3 +10,9 @@ Please import and use this project.
 ```console
 $ cargo run
 ```
+
+You can create an selinux environment via the Vagrantfile.
+
+```console
+$ vagrant up
+```

--- a/experiment/selinux/Vagrantfile
+++ b/experiment/selinux/Vagrantfile
@@ -2,7 +2,7 @@
 # vi: set ft=ruby :
 
 Vagrant.configure("2") do |config|
-    config.vm.box = "centos/8"
+    config.vm.box = "generic/centos8"
     config.vm.synced_folder '.', '/vagrant/youki', disabled: false
 
     config.vm.provider "virtualbox" do |v|
@@ -14,7 +14,6 @@ Vagrant.configure("2") do |config|
       curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
       . "$HOME/.cargo/env"
       sudo sed -i -e 's|^mirrorlist|#mirrorlist|g' -e 's|^#baseurl=http://mirror|baseurl=http://vault|g' /etc/yum.repos.d/CentOS-*repo
-      sudo yum -y install gcc curl-devel expat-devel gettext-devel openssl-devel zlib-devel perl-ExtUtils-MakeMaker autoconf wget make git
-      git clone https://github.com/containers/youki
+      sudo yum -y install gcc curl-devel expat-devel gettext-devel openssl-devel zlib-devel perl-ExtUtils-MakeMaker autoconf wget make
     SHELL
 end

--- a/experiment/selinux/Vagrantfile
+++ b/experiment/selinux/Vagrantfile
@@ -1,0 +1,20 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure("2") do |config|
+    config.vm.box = "centos/8"
+    config.vm.synced_folder '.', '/vagrant/youki', disabled: false
+
+    config.vm.provider "virtualbox" do |v|
+      v.memory = 4096
+      v.cpus = 4
+    end
+
+    config.vm.provision "shell", privileged: false, inline: <<-SHELL
+      curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+      . "$HOME/.cargo/env"
+      sudo sed -i -e 's|^mirrorlist|#mirrorlist|g' -e 's|^#baseurl=http://mirror|baseurl=http://vault|g' /etc/yum.repos.d/CentOS-*repo
+      sudo yum -y install gcc curl-devel expat-devel gettext-devel openssl-devel zlib-devel perl-ExtUtils-MakeMaker autoconf wget make git
+      git clone https://github.com/containers/youki
+    SHELL
+end

--- a/experiment/selinux/src/main.rs
+++ b/experiment/selinux/src/main.rs
@@ -34,7 +34,7 @@ fn main() -> Result<()> {
     let file_path = Path::new("./test_file.txt");
     let _file = File::create(file_path)?;
     let selinux_label =
-        SELinuxLabel::try_from("unconfined_u:object_r:public_content_t:s1".to_string())?;
+        SELinuxLabel::try_from("system_u:object_r:public_content_t:s0".to_string())?;
     SELinux::set_file_label(file_path, selinux_label)?;
     let current_label = SELinux::file_label(file_path)?;
     println!("file label is {}", current_label);

--- a/experiment/selinux/src/tools/xattr.rs
+++ b/experiment/selinux/src/tools/xattr.rs
@@ -34,7 +34,7 @@ where
     // set_xattr sets extended attributes on a file specified by its path.
     fn set_xattr(&self, attr: &str, data: &[u8]) -> Result<(), XattrError> {
         let path = self.as_ref();
-        match rfs::setxattr(path, attr, data, rfs::XattrFlags::CREATE) {
+        match rfs::setxattr(path, attr, data, rfs::XattrFlags::REPLACE) {
             Ok(_) => Ok(()),
             Err(e) => {
                 let errno = e.raw_os_error();
@@ -50,7 +50,7 @@ where
     // lset_xattr sets extended attributes on a symbolic link.
     fn lset_xattr(&self, attr: &str, data: &[u8]) -> Result<(), XattrError> {
         let path = self.as_ref();
-        match rfs::lsetxattr(path, attr, data, rfs::XattrFlags::CREATE) {
+        match rfs::lsetxattr(path, attr, data, rfs::XattrFlags::REPLACE) {
             Ok(_) => Ok(()),
             Err(e) => {
                 let errno = e.raw_os_error();


### PR DESCRIPTION
fix the problem that no_pivot args is not used when create container 
when we prepare rootfs with chroot, we should move_mount the rootfs before chroot, otherwise we will not able to use the new rootfs when exec into the container