### PR TITLE
Bump oci-spec to 0.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2459,13 +2459,12 @@ dependencies = [
 
 [[package]]
 name = "oci-spec"
-version = "0.6.8"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f5a3fe998d50101ae009351fec56d88a69f4ed182e11000e711068c2f5abf72"
+checksum = "5cee185ce7cf1cce45e194e34cd87c0bad7ff0aa2e8917009a2da4f7b31fb363"
 dependencies = [
  "derive_builder 0.20.1",
  "getset",
- "once_cell",
  "quickcheck",
  "regex",
  "serde",

--- a/crates/libcgroups/Cargo.toml
+++ b/crates/libcgroups/Cargo.toml
@@ -22,7 +22,7 @@ cgroupsv2_devices = ["rbpf", "libbpf-sys", "errno", "libc", "nix/dir"]
 [dependencies]
 nix = { version = "0.28.0", features = ["signal", "user", "fs"] }
 procfs = "0.16.0"
-oci-spec = { version = "~0.6.8", features = ["runtime"] }
+oci-spec = { version = "~0.7.0", features = ["runtime"] }
 fixedbitset = "0.5.7"
 serde = { version = "1.0", features = ["derive"] }
 rbpf = { version = "0.3.0", optional = true }
@@ -34,7 +34,7 @@ tracing = { version = "0.1.40", features = ["attributes"] }
 
 [dev-dependencies]
 anyhow = "1.0"
-oci-spec = { version = "~0.6.8", features = ["proptests", "runtime"] }
+oci-spec = { version = "~0.7.0", features = ["proptests", "runtime"] }
 quickcheck = "1"
 mockall = { version = "0.13.0", features = [] }
 clap = "4.1.6"

--- a/crates/libcontainer/Cargo.toml
+++ b/crates/libcontainer/Cargo.toml
@@ -37,7 +37,7 @@ nix = { version = "0.28.0", features = [
     "term",
     "hostname",
 ] }
-oci-spec = { version = "0.6.8", features = ["runtime"] }
+oci-spec = { version = "0.7.0", features = ["runtime"] }
 once_cell = "1.19.0"
 procfs = "0.16.0"
 prctl = "1.0.0"
@@ -53,7 +53,7 @@ safe-path = "0.1.0"
 nc = "0.9.3"
 
 [dev-dependencies]
-oci-spec = { version = "~0.6.8", features = ["proptests", "runtime"] }
+oci-spec = { version = "~0.7.0", features = ["proptests", "runtime"] }
 quickcheck = "1"
 serial_test = "3.1.1"
 tempfile = "3"

--- a/crates/libcontainer/src/seccomp/mod.rs
+++ b/crates/libcontainer/src/seccomp/mod.rs
@@ -70,6 +70,7 @@ fn translate_arch(arch: Arch) -> ScmpArch {
         Arch::ScmpArchPpc64le => ScmpArch::Ppc64Le,
         Arch::ScmpArchS390 => ScmpArch::S390,
         Arch::ScmpArchS390x => ScmpArch::S390X,
+        Arch::ScmpArchRiscv64 => ScmpArch::Riscv64,
     }
 }
 
@@ -89,6 +90,7 @@ fn translate_action(action: LinuxSeccompAction, errno: Option<u32>) -> Result<Sc
         LinuxSeccompAction::ScmpActKillProcess => ScmpAction::KillProcess,
         LinuxSeccompAction::ScmpActNotify => ScmpAction::Notify,
         LinuxSeccompAction::ScmpActLog => ScmpAction::Log,
+        LinuxSeccompAction::ScmpActKillThread => ScmpAction::KillThread,
     };
 
     tracing::trace!(?action, "translated action");

--- a/tests/contest/contest/Cargo.toml
+++ b/tests/contest/contest/Cargo.toml
@@ -10,7 +10,7 @@ libcgroups = { path = "../../../crates/libcgroups" }
 libcontainer = { path = "../../../crates/libcontainer" }
 nix = "0.28.0"
 num_cpus = "1.16"
-oci-spec = { version = "0.6.4", features = ["runtime"] }
+oci-spec = { version = "0.7.0", features = ["runtime"] }
 once_cell = "1.19.0"
 pnet_datalink = "0.35.0"
 procfs = "0.16.0"

--- a/tests/contest/runtimetest/Cargo.toml
+++ b/tests/contest/runtimetest/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.1"
 edition = "2021"
 
 [dependencies]
-oci-spec = { version = "0.6.8", features = ["runtime"] }
+oci-spec = { version = "0.7.0", features = ["runtime"] }
 nix = "0.28.0"
 anyhow = "1.0"
 libc = "0.2.159" # TODO (YJDoc2) upgrade to latest


### PR DESCRIPTION
Related  #2912  #2920
Add match arms for enum added by upgrading oci-spec to version 0.7.0.