### PR TITLE
remove incorrect dependency in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,6 @@ $ sudo apt-get install    \
       libelf-dev          \
       libseccomp-dev      \
       libclang-dev        \
-      glibc-static        \
       libssl-dev
 ```
 


### PR DESCRIPTION
fixes #2903 
This removes glibc-static dep from debian setup instructions, as that package is not valid. The glibc-static package is in fedora/rpm , but I don't think we need a static link of glibc for building on fedora. Someone who uses fedora for dev can confirm. 