### PR TITLE
Introducing youki Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![GitHub contributors](https://img.shields.io/github/contributors/containers/youki)](https://github.com/containers/youki/graphs/contributors)
 [![Github CI](https://github.com/containers/youki/actions/workflows/basic.yml/badge.svg?branch=main)](https://github.com/containers/youki/actions)
 [![codecov](https://codecov.io/gh/containers/youki/branch/main/graph/badge.svg)](https://codecov.io/gh/containers/youki)
+[![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20youki%20Guru-006BFF)](https://gurubase.io/g/youki)
 
 <p align="center">
   <img src="docs/youki.png" width="450">


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [youki Guru](https://gurubase.io/g/youki) to Gurubase. youki Guru uses the data from this repo and data from the [docs](https://youki-dev.github.io/youki/) to answer questions by leveraging the LLM.

In this PR, I showcased the "youki Guru", which highlights that youki now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable youki Guru in Gurubase, just let me know that's totally fine.
