### PR TITLE
Adding Discord link to docs 

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -20,7 +20,7 @@
     - [Maintainer](./community/maintainer.md)
     - [Governance](./community/governance.md)
     - [Contributing](./community/contributing.md)
-    - [Discord](./community/discord.md)
+    - [Chat](./community/chat.md)
 
 ---
 

--- a/docs/src/community/chat.md
+++ b/docs/src/community/chat.md
@@ -1,0 +1,3 @@
+# Chat
+Please join our chat find help or discuss issues:
+- [Discord invite](https://discord.gg/zHnyXKSQFD)

--- a/docs/src/community/discord.md
+++ b/docs/src/community/discord.md
@@ -1,3 +1,0 @@
-# Discord
-Please join our Discord community to find help or discuss issues.
-- [Discord invite](https://discord.gg/zHnyXKSQFD)

--- a/docs/src/community/introduction.md
+++ b/docs/src/community/introduction.md
@@ -3,4 +3,4 @@
 - [Maintainer](./maintainer.md)
 - [Governance](./goversance.md)
 - [Contributing](./contributing.md)
-- [Discord](./discord.md)
+- [Chat](./chat.md)


### PR DESCRIPTION
Howdy folks,

I was reading through the docs and found no mention of the Discord. I found the link on a tiny icon on the README. I think it would be good to add to the docs for more visibility. Please let me know what you think(i.e., different wording or don't want a whole page and just a link on the sidebar).

Bonus: found an old `containers.github.io/youki/` link in the code of conduct. Addresses #2967
