### PR TITLE
Installing kubectl in dev container.

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -33,6 +33,10 @@ apt-get install -y \
 
 curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | bash -s -- --to /usr/bin
 
+curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
+chmod +x kubectl
+mv ./kubectl /usr/bin/kubectl
+
 # nightly build is required for `cargo fmt` as `rustfmt.toml` uses unstable features.
 curl https://sh.rustup.rs -sSf | sh -s -- -y
 rustup install nightly


### PR DESCRIPTION
## Description
This makes it a little easier to run `just test-kind` in the dev container to make sure the Kubernetes tests are working as intended.

## Type of Change
<!-- Mark the appropriate option with an [x] -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test updates
- [ ] CI/CD related changes
- [X] Other (please describe):
Developer Tooling

## Testing
<!-- Describe the tests you ran and/or added to verify your changes -->
- [ ] Added new unit tests
- [ ] Added new integration tests
- [ ] Ran existing test suite
- [X] Tested manually (please provide steps)
Ran test container then ran `just youki-dev` and `just test-kind` and didn't have an issue starting and completing tests.

## Related Issues
<!-- Link any related issues using the GitHub issue syntax: #issue-number
If there is no open issue for this, please add details of the problem or open a new issue. -->

## Additional Context
<!-- Add any other context about the pull request here -->
