### PR TITLE
Handle frozen cgroup properly when creating container

### DIFF
--- a/crates/libcgroups/src/common.rs
+++ b/crates/libcgroups/src/common.rs
@@ -51,6 +51,9 @@ pub trait CgroupManager {
 
     /// Gets the PIDs inside the cgroup
     fn get_all_pids(&self) -> Result<Vec<Pid>, Self::Error>;
+
+    /// Gets the current FreezerState of the cgroup.
+    fn get_freezer_state(&self) -> Result<FreezerState, Self::Error>;
 }
 
 #[derive(thiserror::Error, Debug)]
@@ -118,6 +121,14 @@ impl CgroupManager for AnyCgroupManager {
             AnyCgroupManager::Systemd(m) => Ok(m.get_all_pids()?),
             AnyCgroupManager::V1(m) => Ok(m.get_all_pids()?),
             AnyCgroupManager::V2(m) => Ok(m.get_all_pids()?),
+        }
+    }
+
+    fn get_freezer_state(&self) -> Result<FreezerState, Self::Error> {
+        match self {
+            AnyCgroupManager::Systemd(m) => Ok(m.get_freezer_state()?),
+            AnyCgroupManager::V1(m) => Ok(m.get_freezer_state()?),
+            AnyCgroupManager::V2(m) => Ok(m.get_freezer_state()?),
         }
     }
 }

--- a/crates/libcgroups/src/stub/systemd/manager.rs
+++ b/crates/libcgroups/src/stub/systemd/manager.rs
@@ -33,6 +33,10 @@ impl CgroupManager for Manager {
         Err(SystemdManagerError::NotEnabled)
     }
 
+    fn get_freezer_state(&self) -> Result<crate::common::FreezerState, Self::Error> {
+        Err(SystemdManagerError::NotEnabled)
+    }
+
     fn stats(&self) -> Result<crate::stats::Stats, Self::Error> {
         Err(SystemdManagerError::NotEnabled)
     }

--- a/crates/libcgroups/src/stub/v1/manager.rs
+++ b/crates/libcgroups/src/stub/v1/manager.rs
@@ -33,6 +33,10 @@ impl CgroupManager for Manager {
         Err(V1ManagerError::NotEnabled)
     }
 
+    fn get_freezer_state(&self) -> Result<crate::common::FreezerState, Self::Error> {
+        Err(V1ManagerError::NotEnabled)
+    }
+
     fn stats(&self) -> Result<crate::stats::Stats, Self::Error> {
         Err(V1ManagerError::NotEnabled)
     }

--- a/crates/libcgroups/src/stub/v2/manager.rs
+++ b/crates/libcgroups/src/stub/v2/manager.rs
@@ -33,6 +33,10 @@ impl CgroupManager for Manager {
         Err(V2ManagerError::NotEnabled)
     }
 
+    fn get_freezer_state(&self) -> Result<crate::common::FreezerState, Self::Error> {
+        Err(V2ManagerError::NotEnabled)
+    }
+
     fn stats(&self) -> Result<crate::stats::Stats, Self::Error> {
         Err(V2ManagerError::NotEnabled)
     }

--- a/crates/libcgroups/src/systemd/manager.rs
+++ b/crates/libcgroups/src/systemd/manager.rs
@@ -420,6 +420,10 @@ impl CgroupManager for Manager {
         Ok(self.fs_manager.freeze(state)?)
     }
 
+    fn get_freezer_state(&self) -> Result<FreezerState, Self::Error> {
+        Ok(self.fs_manager.get_freezer_state()?)
+    }
+
     fn stats(&self) -> Result<Stats, Self::Error> {
         Ok(self.fs_manager.stats()?)
     }

--- a/crates/libcgroups/src/test_manager.rs
+++ b/crates/libcgroups/src/test_manager.rs
@@ -43,6 +43,10 @@ impl CgroupManager for TestManager {
         unimplemented!()
     }
 
+    fn get_freezer_state(&self) -> Result<FreezerState, Self::Error> {
+        unimplemented!()
+    }
+
     fn stats(&self) -> Result<Stats, Infallible> {
         unimplemented!()
     }

--- a/crates/libcgroups/src/v1/freezer.rs
+++ b/crates/libcgroups/src/v1/freezer.rs
@@ -1,5 +1,4 @@
-use std::fs::OpenOptions;
-use std::fs::read_to_string;
+use std::fs::{OpenOptions, read_to_string};
 use std::io::Read;
 use std::path::Path;
 use std::{thread, time};
@@ -101,7 +100,9 @@ impl Freezer {
                             }
                             _ => {
                                 // should not reach here.
-                                return Err(V1FreezerControllerError::UnexpectedState { state: state });
+                                return Err(V1FreezerControllerError::UnexpectedState {
+                                    state: state,
+                                });
                             }
                         }
                     }

--- a/crates/libcgroups/src/v1/freezer.rs
+++ b/crates/libcgroups/src/v1/freezer.rs
@@ -100,9 +100,7 @@ impl Freezer {
                             }
                             _ => {
                                 // should not reach here.
-                                return Err(V1FreezerControllerError::UnexpectedState {
-                                    state: state,
-                                });
+                                return Err(V1FreezerControllerError::UnexpectedState { state });
                             }
                         }
                     }

--- a/crates/libcgroups/src/v1/manager.rs
+++ b/crates/libcgroups/src/v1/manager.rs
@@ -252,6 +252,14 @@ impl CgroupManager for Manager {
         )?)
     }
 
+    fn get_freezer_state(&self) -> Result<FreezerState, Self::Error> {
+        Ok(Freezer::read_freezer_state(
+            self.subsystems
+                .get(&CtrlType::Freezer)
+                .ok_or(V1ManagerError::SubsystemDoesNotExist)?,
+        ))
+    }
+
     fn stats(&self) -> Result<Stats, Self::Error> {
         let mut stats = Stats::default();
 

--- a/crates/libcgroups/src/v2/manager.rs
+++ b/crates/libcgroups/src/v2/manager.rs
@@ -217,6 +217,10 @@ impl CgroupManager for Manager {
         Ok(Freezer::apply(&controller_opt, &self.full_path)?)
     }
 
+    fn get_freezer_state(&self) -> Result<FreezerState, Self::Error> {
+        Ok(Freezer::read_freezer_state(&self.full_path)?)
+    }
+
     fn stats(&self) -> Result<Stats, Self::Error> {
         let mut stats = Stats::default();
 


### PR DESCRIPTION
## Description
- Added `get_freezer_state` in `CgroupManager` trait. Similar to `GetFreezerState` in https://github.com/opencontainers/cgroups/blob/6a793b6ea778415b3c0f7a3d2efdb70c786fad92/cgroups.go#L76
- Implemented `get_freezer_state` for `v1/v2/systemd` in `libcgroups` crate.
  - For `v2/systemd`, reused the existing `read_freezer_state` function with some small change.
  - For `v1`, it's a little bit tricky. I referenced the implementation from https://github.com/opencontainers/cgroups/blob/6a793b6ea778415b3c0f7a3d2efdb70c786fad92/fs/freezer.go#L114.
- Added cgroup frozen check in `container_intermediate_process`.

## Type of Change
<!-- Mark the appropriate option with an [x] -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test updates
- [ ] CI/CD related changes
- [ ] Other (please describe):

## Testing
<!-- Describe the tests you ran and/or added to verify your changes -->
- [ ] Added new unit tests
- [ ] Added new integration tests
- [x] Ran existing test suite
I have run unit tests locally.
- [x] Tested manually (please provide steps)
Tested using the reproduce steps mentioned in the issue(#3233).
```
$ sudo ./youki run -b tutorial/ container
ERROR libcontainer::process::container_main_process: failed to run intermediate process cgroup error: container's cgroup unexpectedly frozen
ERROR libcontainer::container::builder_impl: failed to run container process intermediate process error cgroup error: container's cgroup unexpectedly frozen
ERROR youki: error in executing command: failed to create container: intermediate process error cgroup error: container's cgroup unexpectedly frozen
run failed : failed to create container: intermediate process error cgroup error: container's cgroup unexpectedly frozen
```

## Related Issues
<!-- Link any related issues using the GitHub issue syntax: #issue-number
If there is no open issue for this, please add details of the problem or open a new issue. -->
Fixes #3233

## Additional Context
<!-- Add any other context about the pull request here -->
