### PR TITLE
chore: fix docs mdbook toml

### DIFF
--- a/docs/book.toml
+++ b/docs/book.toml
@@ -1,6 +1,5 @@
 [book]
-authors = ["Yashodhan Joshi"]
+authors = ["Youki Contributors"]
 language = "en"
-multilingual = false
 src = "src"
 title = "Youki User and Developer Documentation"


### PR DESCRIPTION
## Description
Mdbook recently removed one of the keys in their config, because of which our docs deploy CI fails. That field was not used anywhere, so I simply removed it. Also changed the authors key to `Youki Contributors` .

## Type of Change
<!-- Mark the appropriate option with an [x] -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test updates
- [ ] CI/CD related changes
- [ ] Other (please describe):

## Testing
<!-- Describe the tests you ran and/or added to verify your changes -->
- [ ] Added new unit tests
- [ ] Added new integration tests
- [ ] Ran existing test suite
- [x] Tested manually : build mdbook locally with latest mdbook binary

## Related Issues
<!-- Link any related issues using the GitHub issue syntax: #issue-number
If there is no open issue for this, please add details of the problem or open a new issue. -->
N/A

## Additional Context
<!-- Add any other context about the pull request here -->
One of the recent doc deploy CI failed because of the issue - https://github.com/youki-dev/youki/actions/runs/19819634983
