### PR TITLE
Implement mount destination validation to ensure absolute paths in OCI Runtime Spec

### DIFF
--- a/crates/libcontainer/src/container/init_builder.rs
+++ b/crates/libcontainer/src/container/init_builder.rs
@@ -208,6 +208,10 @@ impl InitContainerBuilder {
             }
         }
 
+        if let Some(mounts) = spec.mounts() {
+            utils::validate_mount_options(mounts)?;
+        }
+
         let syscall = create_syscall();
         utils::validate_spec_for_new_user_ns(spec, &*syscall)?;
         utils::validate_spec_for_net_devices(spec, &*syscall)

--- a/crates/libcontainer/src/container/tenant_builder.rs
+++ b/crates/libcontainer/src/container/tenant_builder.rs
@@ -425,6 +425,10 @@ impl TenantContainerBuilder {
             }
         }
 
+        if let Some(mounts) = spec.mounts() {
+            utils::validate_mount_options(mounts)?;
+        }
+
         let syscall = create_syscall();
         utils::validate_spec_for_new_user_ns(spec, &*syscall)?;
         utils::validate_spec_for_net_devices(spec, &*syscall)

--- a/crates/libcontainer/src/utils.rs
+++ b/crates/libcontainer/src/utils.rs
@@ -347,6 +347,27 @@ pub fn validate_spec_for_net_devices(
     Ok(())
 }
 
+/// Validates mount destinations and warns about deprecated relative paths.
+/// Follows the OCI Runtime Spec requirement that mount destinations SHOULD be absolute.
+/// Relative paths are deprecated but still accepted for backward compatibility.
+pub fn validate_mount_options(
+    mounts: &[oci_spec::runtime::Mount],
+) -> Result<(), LibcontainerError> {
+    mounts
+        .iter()
+        .filter(|mount| !mount.destination().is_absolute())
+        .for_each(|mount| {
+            tracing::warn!(
+                "mount destination {:?} is not absolute. \
+                Relative paths are deprecated in OCI Runtime Spec and may not be supported in future versions. \
+                The path will be interpreted as relative to '/'.",
+                mount.destination()
+            );
+        });
+
+    Ok(())
+}
+
 // https://elixir.bootlin.com/linux/v6.12/source/net/core/dev.c#L1066
 fn dev_valid_name(name: &str) -> bool {
     if name.is_empty() || name.len() > IFNAMSIZ {


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of your changes -->
The OCI specification states that relative paths should be deprecated, and `runc` also performs validation for this. Therefore, we will introduce the same validation in `youki`.

- [Related OCI specification PR](https://github.com/opencontainers/runtime-spec/pull/1225)
- [Related runc source code](https://github.com/opencontainers/runc/blob/main/libcontainer/configs/validate/validator.go#L409-L416)

## Type of Change
<!-- Mark the appropriate option with an [x] -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test updates
- [ ] CI/CD related changes
- [ ] Other (please describe):

## Testing
<!-- Describe the tests you ran and/or added to verify your changes -->
- [ ] Added new unit tests
- [ ] Added new integration tests
- [ ] Ran existing test suite
- [x] Tested manually (please provide steps)

1. Modified config.json to set mounts[].destination to a relative path such as "tmp".
2. Ran `youki create <container-id>`.
3. Checked stdout and confirmed that `youki` printed the expected warning message about deprecated relative paths.

## Related Issues
<!-- Link any related issues using the GitHub issue syntax: #issue-number
If there is no open issue for this, please add details of the problem or open a new issue. -->
part of #3314 

## Additional Context
<!-- Add any other context about the pull request here -->

/kind cleanup
