### PR TITLE
fix(libcgroups): set `sz` field in `bpf_prog_load_opts`

### DIFF
--- a/crates/libcgroups/src/v2/devices/bpf.rs
+++ b/crates/libcgroups/src/v2/devices/bpf.rs
@@ -41,6 +41,7 @@ pub mod prog {
         let insns_cnt = insns.len() / std::mem::size_of::<bpf_insn>();
         let insns = insns as *const _ as *const bpf_insn;
         let mut opts = libbpf_sys::bpf_prog_load_opts {
+            sz: std::mem::size_of::<libbpf_sys::bpf_prog_load_opts>() as libbpf_sys::size_t,
             kern_version: 0,
             log_buf: ptr::null_mut::<::std::os::raw::c_char>(),
             log_size: 0,


### PR DESCRIPTION
## Description

Fix `bpf_prog_load_opts` initialization by setting the required `sz` field.

### Problem

When using the `cgroupsv2_devices` feature, BPF program loading fails with:

```
libbpf: bpf_prog_load_opts size (0) is too small
cgroup error: bpf error: Invalid argument
```

### Root Cause

The `sz` field of `bpf_prog_load_opts` was not being set. In libbpf, all opts structures require the `sz` field to be set to the struct size for forward/backward compatibility.

In C, the `LIBBPF_OPTS` macro handles this automatically:

```c
#define LIBBPF_OPTS(TYPE, NAME, ...)                    \
    struct TYPE NAME = ({                               \
        memset(&NAME, 0, sizeof(struct TYPE));          \
        (struct TYPE) {                                 \
            .sz = sizeof(struct TYPE),                  \
            __VA_ARGS__                                 \
        };                                              \
    })
```

However, in Rust when using `..Default::default()`, the `sz` field defaults to 0, which causes libbpf to reject the options struct.

### Solution

Explicitly set the `sz` field to the struct size:

```rust
let mut opts = libbpf_sys::bpf_prog_load_opts {
    sz: std::mem::size_of::<libbpf_sys::bpf_prog_load_opts>() as libbpf_sys::size_t,
    kern_version: 0,
    log_buf: ptr::null_mut::<::std::os::raw::c_char>(),
    log_size: 0,
    ..Default::default()
};
```

## Type of Change
<!-- Mark the appropriate option with an [x] -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test updates
- [ ] CI/CD related changes
- [ ] Other (please describe):

## Testing
<!-- Describe the tests you ran and/or added to verify your changes -->
- [ ] Added new unit tests
- [ ] Added new integration tests
- [x] Ran existing test suite
- [x] Tested manually (please provide steps)

### Manual Testing Steps

Tested with `cgroupsv2_devices` feature enabled on Linux:

1. Build youki and contest with the `cgroupsv2_devices` feature:

```bash
./scripts/build.sh -o . -r -f cgroupsv2_devices -c youki
./scripts/build.sh -o . -r -f cgroupsv2_devices -c contest
```

2. Run the devices integration test:

```bash
sudo ./contest run --runtime ./youki --runtimetest ./runtimetest --tests devices
```

Without fix:

```text
libbpf: bpf_prog_load_opts size (0) is too small
ERROR libcontainer::process::container_intermediate_process: failed to apply cgroup
  err=V2(DevicesController(Bpf(Errno(Errno { code: 22, description: Some("Invalid argument") }))))
```

With fix:

```text
ERROR libcontainer::process::container_intermediate_process: failed to apply cgroup
  err=V2(DevicesController(Nix(ENOENT)))
```

The `ENOENT` error is a separate pre-existing issue unrelated to this fix - it indicates the BPF program loaded successfully and the code proceeded to the next stage (cgroup directory operations).

## Related Issues

Fixes #(none - discovered during cgroup v2 device support testing)

## Additional Context

### References

- [libbpf LIBBPF_OPTS macro](https://github.com/libbpf/libbpf/blob/master/src/libbpf_common.h) - Shows `sz` is set to `sizeof(struct TYPE)`
- [libbpf-rs tests](https://github.com/libbpf/libbpf-rs/blob/master/libbpf-rs/tests/test.rs) - Rust pattern for setting `sz` field
- [Journey to libbpf 1.0](https://nakryiko.com/posts/libbpf-v1/) - Explains OPTS framework for compatibility

