### PR TITLE
test: output contest logs to stdout

### DIFF
--- a/scripts/contest.sh
+++ b/scripts/contest.sh
@@ -24,13 +24,12 @@ fi
 touch ${LOGFILE}
 
 if [ $# -gt 0 ]; then
-    ${ROOT}/contest run --runtime "$RUNTIME" --runtimetest "${ROOT}/runtimetest" -t "$@" > "$LOGFILE"
+    ${ROOT}/contest run --runtime "$RUNTIME" --runtimetest "${ROOT}/runtimetest" -t "$@" 2>&1 | tee "$LOGFILE"
 else
-    ${ROOT}/contest run --runtime "$RUNTIME" --runtimetest "${ROOT}/runtimetest" > "$LOGFILE"
+    ${ROOT}/contest run --runtime "$RUNTIME" --runtimetest "${ROOT}/runtimetest" 2>&1 | tee "$LOGFILE"
 fi
 
 if [ 0 -ne $(grep "not ok" $LOGFILE | wc -l ) ]; then
-    cat $LOGFILE
     exit 1
 fi
 


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of your changes -->

Recently, we’ve been seeing intermittent timeouts in the tests.
When a timeout happens, no logs are shown, so it’s hard to identify the cause.
I’ll update the integration tests so that errors/logs are printed when they fail (including on timeout).

https://github.com/youki-dev/youki/actions?query=is%3Acancelled


## Type of Change
<!-- Mark the appropriate option with an [x] -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test updates
- [ ] CI/CD related changes
- [ ] Other (please describe):

## Testing
<!-- Describe the tests you ran and/or added to verify your changes -->
- [ ] Added new unit tests
- [ ] Added new integration tests
- [ ] Ran existing test suite
- [x] Tested manually (please provide steps)

## Related Issues
<!-- Link any related issues using the GitHub issue syntax: #issue-number
If there is no open issue for this, please add details of the problem or open a new issue. -->
Fixes #

## Additional Context
<!-- Add any other context about the pull request here -->

This test’s CI result is shown below:
https://github.com/youki-dev/youki/actions/runs/20689091030/job/59394557880?pr=3349
