### PR TITLE
feat(libcgroups): ensure user-defined device cgroup rules take precedence over defaults

### DIFF
--- a/crates/libcgroups/src/common.rs
+++ b/crates/libcgroups/src/common.rs
@@ -731,3 +731,8 @@ impl Display for MustBePowerOfTwo {
         f.write_str("page size must be in the format of 2^(integer)")
     }
 }
+
+/// Returns true if cgroupsv2_devices feature is enabled.
+pub fn is_cgroupsv2_devices_available() -> bool {
+    cfg!(feature = "cgroupsv2_devices")
+}

--- a/tests/contest/contest/src/tests/devices/devices_test.rs
+++ b/tests/contest/contest/src/tests/devices/devices_test.rs
@@ -1,9 +1,13 @@
 use anyhow::{Context, Ok, Result};
+use libcgroups::common::{self as cgroup_common, CgroupSetup, is_cgroupsv2_devices_available};
 use oci_spec::runtime::{
-    LinuxBuilder, LinuxDeviceBuilder, LinuxDeviceType, ProcessBuilder, Spec, SpecBuilder,
+    LinuxBuilder, LinuxDeviceBuilder, LinuxDeviceCgroupBuilder, LinuxDeviceType,
+    LinuxResourcesBuilder, ProcessBuilder, Spec, SpecBuilder,
 };
-use test_framework::{Test, TestGroup, TestResult, test_result};
+use test_framework::{ConditionalTest, Test, TestGroup, TestResult, test_result};
+use tracing::debug;
 
+use crate::utils::support::is_runtime_runc;
 use crate::utils::test_inside_container;
 use crate::utils::test_utils::CreateOptions;
 
@@ -94,6 +98,73 @@ fn devices_default_permissions_test() -> TestResult {
     test_inside_container(&spec, &CreateOptions::default(), &|_| Ok(()))
 }
 
+/// Check if cgroup v2 devices test can run.
+/// This test requires cgroupsv2_devices feature and cgroup v2.
+fn can_run_cgroup_v2_devices() -> bool {
+    // Skip if cgroupsv2_devices feature is not enabled
+    if !is_cgroupsv2_devices_available() {
+        debug!("cgroupsv2_devices feature is not enabled");
+        return false;
+    }
+    // Skip for runc (this test is specific to youki's implementation)
+    if is_runtime_runc() {
+        debug!("skipping test for runc runtime");
+        return false;
+    }
+    let setup_result = cgroup_common::get_cgroup_setup();
+    if !matches!(setup_result, std::result::Result::Ok(CgroupSetup::Unified)) {
+        debug!("cgroup setup is not v2, was {:?}", setup_result);
+        return false;
+    }
+    true
+}
+
+/// Create spec for testing device cgroup rule precedence.
+/// This spec sets a rule to deny write access to /dev/zero.
+fn create_spec_cgroup_rule_precedence() -> Result<Spec> {
+    // Deny write access to /dev/zero (major: 1, minor: 5)
+    let deny_zero_write = LinuxDeviceCgroupBuilder::default()
+        .allow(false)
+        .typ(LinuxDeviceType::C)
+        .major(1i64)
+        .minor(5i64)
+        .access("w")
+        .build()
+        .context("failed to create device cgroup rule")?;
+
+    let resources = LinuxResourcesBuilder::default()
+        .devices(vec![deny_zero_write])
+        .build()
+        .context("failed to build linux resources")?;
+
+    let spec = SpecBuilder::default()
+        .process(
+            ProcessBuilder::default()
+                .args(vec![
+                    "runtimetest".to_string(),
+                    "devices_cgroup_rule_precedence".to_string(),
+                ])
+                .build()
+                .expect("error in creating process config"),
+        )
+        .linux(
+            LinuxBuilder::default()
+                .resources(resources)
+                .build()
+                .context("failed to build linux spec")?,
+        )
+        .build()
+        .context("failed to build spec")?;
+
+    Ok(spec)
+}
+
+/// Test that user-defined device cgroup rules take precedence over defaults.
+fn devices_cgroup_rule_precedence_test() -> TestResult {
+    let spec = test_result!(create_spec_cgroup_rule_precedence());
+    test_inside_container(&spec, &CreateOptions::default(), &|_| Ok(()))
+}
+
 pub fn get_devices_test() -> TestGroup {
     let mut device_test_group = TestGroup::new("devices");
 
@@ -103,7 +174,14 @@ pub fn get_devices_test() -> TestGroup {
         Box::new(devices_default_permissions_test),
     );
 
+    let test_cgroup_rule_precedence = ConditionalTest::new(
+        "cgroup_rule_precedence",
+        Box::new(can_run_cgroup_v2_devices),
+        Box::new(devices_cgroup_rule_precedence_test),
+    );
+
     device_test_group.add(vec![Box::new(test), Box::new(test_default_permissions)]);
+    device_test_group.add(vec![Box::new(test_cgroup_rule_precedence)]);
 
     device_test_group
 }

--- a/tests/contest/runtimetest/src/main.rs
+++ b/tests/contest/runtimetest/src/main.rs
@@ -57,6 +57,7 @@ fn main() {
         "rootfs_propagation" => tests::validate_rootfs_propagation(&spec),
         "uid_mappings" => tests::validate_uid_mappings(&spec),
         "net_devices" => tests::validate_net_devices(&spec),
+        "devices_cgroup_rule_precedence" => tests::validate_devices_cgroup_rule_precedence(),
         _ => eprintln!("error due to unexpected execute test name: {execute_test}"),
     }
 }


### PR DESCRIPTION
## Summary

- Fix device cgroup rule ordering so user-defined rules take precedence over defaults
- Add integration test (`cgroup_rule_precedence`) to verify the fix

## Description
User-defined device cgroup rules in cgroupsv2 were being ignored because default rules were added to the emulator after user rules. Since the BPF program checks rules in reverse order (last added = first checked), default rules took precedence.

### Investigation of Other Runtimes

OCI Runtime Spec:
> "The runtime MUST apply entries in the listed order."

ref: https://specs.opencontainers.org/runtime-spec/config-linux/?v=v1.3.0#RUNTIME-SPEC-CONFIG-LINUX-62

crun ([`src/libcrun/cgroup-resources.c`](https://github.com/containers/crun/blob/main/src/libcrun/cgroup-resources.c)):
- Adds default devices first (reverse iteration)
- Then adds user-specified devices (reverse iteration)
- Default rules are at the start of BPF program → checked first → default rules take precedence

runc ([`vendor/github.com/opencontainers/cgroups/devices/devicefilter.go`](https://github.com/opencontainers/runc/blob/main/vendor/github.com/opencontainers/cgroups/devices/devicefilter.go)):
- Based on crun's ebpf.c implementation
- Uses emulator to optimize/merge rules before BPF generation
- First matching rule wins after emulator processing

youki (`crates/libcgroups/src/v2/devices/program.rs`):
- Uses `rules.iter().rev()` when generating BPF bytecode
- Rules added last to emulator are checked first by BPF

## Type of Change
<!-- Mark the appropriate option with an [x] -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test updates
- [ ] CI/CD related changes
- [ ] Other (please describe):

## Testing
<!-- Describe the tests you ran and/or added to verify your changes -->
- [ ] Added new unit tests
- [x] Added new integration tests
- [x] Ran existing test suite
- [x] Tested manually (please provide steps)

## Related Issues
<!-- Link any related issues using the GitHub issue syntax: #issue-number
If there is no open issue for this, please add details of the problem or open a new issue. -->
Fixes #

### Manual Testing Steps

Prerequisites:
- Linux environment with cgroup v2 (unified hierarchy)
- youki built with `cgroupsv2_devices` feature

Build:
```bash
cargo build --release --features "v2,cgroupsv2_devices"
```

1. Create test bundle:
```bash
mkdir -p /tmp/test-device-rule/rootfs/bin
cp /bin/busybox /tmp/test-device-rule/rootfs/busybox
ln -s /busybox /tmp/test-device-rule/rootfs/bin/sh
cd /tmp/test-device-rule
youki spec
```

2. Modify config.json:
```bash
# Add device rule to deny write to /dev/zero
cat config.json | jq '
.process.args = ["/busybox", "sh", "-c", "echo test > /dev/zero 2>&1 && echo write_success || echo write_failed"] |
.root.readonly = false |
.linux.resources.devices = [{ "allow": false, "type": "c", "major": 1, "minor": 5, "access": "w" }]
' > config_new.json
mv config_new.json config.json
```

3. Run container:
```bash
sudo youki run test-device-rule
```

Expected result:
- Before fix: `write_success` (user rule ignored, default allows write)
- After fix: `write_failed` (user rule properly denies write)

4. Run integration tests:
```bash
sudo ./scripts/contest.sh ./target/release/youki devices
```

Expected result:
```
# Start group devices
1 / 3 : cgroup_rule_precedence : ok
2 / 3 : device_default_permissions : ok
3 / 3 : device_test : ok
# End group devices
```

## Additional Context

The BPF device filter (`program.rs`) iterates rules in reverse order when generating bytecode:
```rust
for rule in rules.iter().rev() {
    prog.add_rule(rule)?;
}
```
This means rules added last to the emulator are checked first by the BPF program.
The fix ensures user-defined rules are added last, giving them priority over defaults.

### The Fix

This PR aligns youki with crun's approach: add default rules first, then user rules,
so user-defined rules take precedence in BPF's LIFO evaluation.

## Note on Integration Test

The `cgroup_rule_precedence` integration test requires the `cgroupsv2_devices` feature to be enabled.
Since CI does not currently build with this feature, the test is automatically skipped.

To run this test locally:
```bash
cargo build --release --features "v2,cgroupsv2_devices"
sudo ./scripts/contest.sh ./target/release/youki devices
```

Enabling cgroupsv2_devices in CI is tracked as a separate issue.

