### PR TITLE
Pass State directly to `run_hooks` instead of Container reference

### DIFF
--- a/crates/libcontainer/src/container/container_delete.rs
+++ b/crates/libcontainer/src/container/container_delete.rs
@@ -98,16 +98,11 @@ impl Container {
                     })?;
 
                     if let Some(hooks) = config.hooks.as_ref() {
-                        hooks::run_hooks(
-                            hooks.poststop().as_ref(),
-                            Some(self.state.clone()),
-                            None,
-                            None,
-                        )
-                        .map_err(|err| {
-                            tracing::error!(err = ?err, "failed to run post stop hooks");
-                            err
-                        })?;
+                        hooks::run_hooks(hooks.poststop().as_ref(), Some(&self.state), None, None)
+                            .map_err(|err| {
+                                tracing::error!(err = ?err, "failed to run post stop hooks");
+                                err
+                            })?;
                     }
                 }
                 Err(err) => {

--- a/crates/libcontainer/src/container/container_start.rs
+++ b/crates/libcontainer/src/container/container_start.rs
@@ -56,7 +56,7 @@ impl Container {
         if let Some(hooks) = config.hooks.as_ref() {
             hooks::run_hooks(
                 hooks.poststart().as_ref(),
-                Some(self.state.clone()),
+                Some(&self.state),
                 Some(&self.root),
                 None,
             )

--- a/crates/libcontainer/src/container/state.rs
+++ b/crates/libcontainer/src/container/state.rs
@@ -247,25 +247,25 @@ pub enum StateConversionError {
     InvalidStatus(ContainerStatus),
 }
 
-/// Convert internal State to OCI-compliant State (by value, no cloning).
+/// Convert internal State to OCI-compliant State (by reference, cloning necessary fields).
 ///
 /// Based on runc's implementation:
 /// https://github.com/opencontainers/runc/blob/v2.2.1/libcontainer/container_linux.go#L961
-impl TryFrom<State> for OciState {
+impl TryFrom<&State> for OciState {
     type Error = StateConversionError;
 
-    fn try_from(state: State) -> std::result::Result<Self, Self::Error> {
+    fn try_from(state: &State) -> std::result::Result<Self, Self::Error> {
         let status = OciContainerState::try_from(state.status)?;
 
         let mut builder = OciStateBuilder::default()
-            .version(state.oci_version)
-            .id(state.id)
+            .version(state.oci_version.clone())
+            .id(state.id.clone())
             .status(status)
-            .bundle(state.bundle);
+            .bundle(state.bundle.clone());
 
         // Preserve None vs empty map distinction per OCI spec
-        if let Some(annotations) = state.annotations {
-            builder = builder.annotations(annotations);
+        if let Some(annotations) = &state.annotations {
+            builder = builder.annotations(annotations.clone());
         }
         if let Some(pid) = state.pid {
             builder = builder.pid(pid);

--- a/crates/libcontainer/src/hooks.rs
+++ b/crates/libcontainer/src/hooks.rs
@@ -35,7 +35,7 @@ type Result<T> = std::result::Result<T, HookError>;
 
 pub fn run_hooks(
     hooks: Option<&Vec<Hook>>,
-    state: Option<State>,
+    state: Option<&State>,
     // TODO: Remove the following parameters. To comply with the OCI State, hooks should only depend on structures defined in oci-spec-rs. Cleaning these up ensures proper functional isolation.
     cwd: Option<&Path>,
     pid: Option<Pid>,
@@ -195,7 +195,7 @@ mod test {
     fn test_run_hook() -> Result<()> {
         {
             let default_container: Container = Default::default();
-            run_hooks(None, Some(default_container.state.clone()), None, None)
+            run_hooks(None, Some(&default_container.state), None, None)
                 .context("Failed simple test")?;
         }
 
@@ -205,13 +205,8 @@ mod test {
 
             let hook = HookBuilder::default().path("true").build()?;
             let hooks = Some(vec![hook]);
-            run_hooks(
-                hooks.as_ref(),
-                Some(default_container.state.clone()),
-                None,
-                None,
-            )
-            .context("Failed true")?;
+            run_hooks(hooks.as_ref(), Some(&default_container.state), None, None)
+                .context("Failed true")?;
         }
 
         {
@@ -231,13 +226,8 @@ mod test {
                 .env(vec![String::from("key=value")])
                 .build()?;
             let hooks = Some(vec![hook]);
-            run_hooks(
-                hooks.as_ref(),
-                Some(default_container.state.clone()),
-                None,
-                None,
-            )
-            .context("Failed printenv test")?;
+            run_hooks(hooks.as_ref(), Some(&default_container.state), None, None)
+                .context("Failed printenv test")?;
         }
 
         {
@@ -257,7 +247,7 @@ mod test {
             let hooks = Some(vec![hook]);
             run_hooks(
                 hooks.as_ref(),
-                Some(default_container.state.clone()),
+                Some(&default_container.state),
                 Some(tmp.path()),
                 None,
             )
@@ -279,7 +269,7 @@ mod test {
             let hooks = Some(vec![hook]);
             run_hooks(
                 hooks.as_ref(),
-                Some(default_container.state.clone()),
+                Some(&default_container.state),
                 None,
                 Some(expected_pid),
             )
@@ -306,12 +296,7 @@ mod test {
             .timeout(1)
             .build()?;
         let hooks = Some(vec![hook]);
-        match run_hooks(
-            hooks.as_ref(),
-            Some(default_container.state.clone()),
-            None,
-            None,
-        ) {
+        match run_hooks(hooks.as_ref(), Some(&default_container.state), None, None) {
             Ok(_) => {
                 bail!(
                     "The test expects the hook to error out with timeout. Should not execute cleanly"

--- a/crates/libcontainer/src/process/container_main_process.rs
+++ b/crates/libcontainer/src/process/container_main_process.rs
@@ -158,7 +158,7 @@ pub fn container_main_process(container_args: &ContainerArgs) -> Result<(Pid, bo
             if let Some(container_for_hooks) = &container_args.container {
                 hooks::run_hooks(
                     hooks.prestart().as_ref(),
-                    Some(container_for_hooks.state.clone()),
+                    Some(&container_for_hooks.state),
                     None,
                     Some(init_pid),
                 )
@@ -169,7 +169,7 @@ pub fn container_main_process(container_args: &ContainerArgs) -> Result<(Pid, bo
 
                 hooks::run_hooks(
                     hooks.create_runtime().as_ref(),
-                    Some(container_for_hooks.state.clone()),
+                    Some(&container_for_hooks.state),
                     None,
                     Some(init_pid),
                 )

--- a/crates/libcontainer/src/process/init/process.rs
+++ b/crates/libcontainer/src/process/init/process.rs
@@ -110,7 +110,7 @@ pub fn container_init_process(
             // before pivot_root is called. This runs in the container namespaces.
             hooks::run_hooks(
                 hooks.create_container().as_ref(),
-                ctx.container.map(|c| c.state.clone()),
+                ctx.container.map(|c| &c.state),
                 None,
                 None,
             )
@@ -436,7 +436,7 @@ pub fn container_init_process(
         if let Some(hooks) = ctx.hooks {
             hooks::run_hooks(
                 hooks.start_container().as_ref(),
-                ctx.container.map(|c| c.state.clone()),
+                ctx.container.map(|c| &c.state),
                 None,
                 None,
             )


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of your changes -->
Refactor `run_hooks` to pass `State` directly instead of `&Container`.

/kind cleanup

## Type of Change
<!-- Mark the appropriate option with an [x] -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test updates
- [ ] CI/CD related changes
- [ ] Other (please describe):

## Testing
<!-- Describe the tests you ran and/or added to verify your changes -->
- [ ] Added new unit tests
- [ ] Added new integration tests
- [x] Ran existing test suite
- [ ] Tested manually (please provide steps)

## Related Issues
<!-- Link any related issues using the GitHub issue syntax: #issue-number
If there is no open issue for this, please add details of the problem or open a new issue. -->
Fixes #3351 

## Additional Context
<!-- Add any other context about the pull request here -->
