### PR TITLE
Batch running the test groups in test_framework

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4478,6 +4478,7 @@ version = "0.0.1"
 dependencies = [
  "anyhow",
  "crossbeam",
+ "num_cpus",
 ]
 
 [[package]]

--- a/tests/contest/test_framework/Cargo.toml
+++ b/tests/contest/test_framework/Cargo.toml
@@ -8,3 +8,4 @@ edition = "2024"
 [dependencies]
 anyhow = "1.0.100"
 crossbeam = "0.8.4"
+num_cpus = "1.17"


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of your changes -->
This change is part of the fix for the flaky issue reported in #3007. Currently, multiple test groups are processed in parallel, resulting in up to nearly 50 threads, which caused hang issues on computers with fewer cores. This change reduces flakiness by executing tests during badge processing.
## Type of Change
<!-- Mark the appropriate option with an [x] -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test updates
- [ ] CI/CD related changes
- [ ] Other (please describe):

## Testing
<!-- Describe the tests you ran and/or added to verify your changes -->
- [ ] Added new unit tests
- [ ] Added new integration tests
- [x] Ran existing test suite
- [x] Tested manually (please provide steps)
  - After running the script that repeatedly executes `just validate-contest-runc`, the timeout issue disappeared.

## Related Issues
<!-- Link any related issues using the GitHub issue syntax: #issue-number
If there is no open issue for this, please add details of the problem or open a new issue. -->

https://github.com/youki-dev/youki/issues/3007

## Additional Context
<!-- Add any other context about the pull request here -->
