### PR TITLE
Fix startContainer hook to inherit container environment

### DIFF
--- a/crates/libcontainer/src/container/container_delete.rs
+++ b/crates/libcontainer/src/container/container_delete.rs
@@ -98,7 +98,7 @@ impl Container {
                     })?;
 
                     if let Some(hooks) = config.hooks.as_ref() {
-                        hooks::run_hooks(hooks.poststop().as_ref(), Some(&self.state), None, None)
+                        hooks::run_hooks(hooks.poststop().as_ref(), Some(&self.state), None, None, None)
                             .map_err(|err| {
                                 tracing::error!(err = ?err, "failed to run post stop hooks");
                                 err

--- a/crates/libcontainer/src/container/container_start.rs
+++ b/crates/libcontainer/src/container/container_start.rs
@@ -59,6 +59,7 @@ impl Container {
                 Some(&self.state),
                 Some(&self.root),
                 None,
+                None,
             )
             .map_err(|err| {
                 tracing::error!("failed to run post start hooks: {}", err);

--- a/crates/libcontainer/src/process/container_main_process.rs
+++ b/crates/libcontainer/src/process/container_main_process.rs
@@ -161,6 +161,7 @@ pub fn container_main_process(container_args: &ContainerArgs) -> Result<(Pid, bo
                     Some(&container_for_hooks.state),
                     None,
                     Some(init_pid),
+                    None,
                 )
                 .map_err(|err| {
                     tracing::error!("failed to run prestart hooks: {}", err);
@@ -172,6 +173,7 @@ pub fn container_main_process(container_args: &ContainerArgs) -> Result<(Pid, bo
                     Some(&container_for_hooks.state),
                     None,
                     Some(init_pid),
+                    None,
                 )
                 .map_err(|err| {
                     tracing::error!("failed to run create runtime hooks: {}", err);

--- a/crates/libcontainer/src/process/init/process.rs
+++ b/crates/libcontainer/src/process/init/process.rs
@@ -108,6 +108,7 @@ pub fn container_init_process(
                 ctx.container.map(|c| &c.state),
                 None,
                 None,
+                None,
             )
             .map_err(|err| {
                 tracing::error!(?err, "failed to run create container hooks");
@@ -445,6 +446,7 @@ pub fn container_init_process(
                 ctx.container.map(|c| &c.state),
                 None,
                 None,
+                Some(&ctx.envs),
             )
             .map_err(|err| {
                 tracing::error!(?err, "failed to run start container hooks");


### PR DESCRIPTION
## Summary

Resolves #3380 by implementing runc-compatible environment inheritance for startContainer hooks.

## Changes

- Modified `run_hooks()` to accept an optional `default_env` parameter
- When a hook doesn't specify an explicit env, it now inherits from `default_env`
- StartContainer hooks receive the container process environment (`ctx.envs`)
- Other hook types continue to use empty env when unspecified (backward compatible)

## Behavior

**Before**: StartContainer hooks with no explicit env received an empty environment  
**After**: StartContainer hooks with no explicit env inherit the container init process environment

This matches runc's behavior as documented in the issue and referenced in opencontainers/runc code.

## Testing

The issue provides a test case that can be used to verify the fix works as expected.

Fixes #3380