### PR TITLE
Add prestart hook test

### DIFF
--- a/tests/contest/contest/src/main.rs
+++ b/tests/contest/contest/src/main.rs
@@ -34,6 +34,7 @@ use crate::tests::pidfile::get_pidfile_test;
 use crate::tests::poststart::get_poststart_tests;
 use crate::tests::poststart_fail::get_poststart_fail_tests;
 use crate::tests::poststop::get_poststop_tests;
+use crate::tests::prestart::get_prestart_tests;
 use crate::tests::process::get_process_test;
 use crate::tests::process_capabilities_fail::get_process_capabilities_fail_test;
 use crate::tests::process_oom_score_adj::get_process_oom_score_adj_test;
@@ -123,6 +124,7 @@ fn main() -> Result<()> {
     let poststart = get_poststart_tests();
     let poststop = get_poststop_tests();
     let poststart_fail = get_poststart_fail_tests();
+    let prestart = get_prestart_tests();
     let cgroup_v1_pids = cgroups::pids::get_test_group();
     let cgroup_v1_cpu = cgroups::cpu::v1::get_test_group();
     let cgroup_v2_cpu = cgroups::cpu::v2::get_test_group();
@@ -172,6 +174,7 @@ fn main() -> Result<()> {
     tm.add_test_group(Box::new(poststart));
     tm.add_test_group(Box::new(poststart_fail));
     tm.add_test_group(Box::new(poststop));
+    tm.add_test_group(Box::new(prestart));
     tm.add_test_group(Box::new(cgroup_v1_pids));
     tm.add_test_group(Box::new(cgroup_v1_cpu));
     tm.add_test_group(Box::new(cgroup_v2_cpu));

--- a/tests/contest/contest/src/tests/mod.rs
+++ b/tests/contest/contest/src/tests/mod.rs
@@ -24,6 +24,7 @@ pub mod pidfile;
 pub mod poststart;
 pub mod poststart_fail;
 pub mod poststop;
+pub mod prestart;
 pub mod process;
 pub mod process_capabilities_fail;
 pub mod process_oom_score_adj;

--- a/tests/contest/contest/src/tests/prestart/mod.rs
+++ b/tests/contest/contest/src/tests/prestart/mod.rs
@@ -1,0 +1,119 @@
+use std::fs;
+use std::path::PathBuf;
+
+use anyhow::anyhow;
+use oci_spec::runtime::{
+    HookBuilder, HooksBuilder, ProcessBuilder, RootBuilder, Spec, SpecBuilder,
+};
+use test_framework::{Test, TestGroup, TestResult};
+
+use crate::utils::test_utils::CreateOptions;
+use crate::utils::{create_container, delete_container, generate_uuid, prepare_bundle, set_config};
+
+const HOOK_OUTPUT_FILE: &str = "output";
+
+fn get_output_file_path(bundle: &tempfile::TempDir) -> PathBuf {
+    bundle
+        .as_ref()
+        .join("bundle")
+        .join("rootfs")
+        .join(HOOK_OUTPUT_FILE)
+}
+
+fn delete_output_file(path: &PathBuf) {
+    if path.exists() {
+        fs::remove_file(path).expect("failed to remove output file");
+    }
+}
+
+fn write_prestart_hook(host_output_file: &str) -> oci_spec::runtime::Hook {
+    HookBuilder::default()
+        .path("/bin/sh")
+        .args(vec![
+            "sh".to_string(),
+            "-c".to_string(),
+            format!("echo 'pre-start called' >> {host_output_file}"),
+        ])
+        .build()
+        .expect("could not build hook")
+}
+
+fn get_spec(host_output_file: &str) -> Spec {
+    SpecBuilder::default()
+        .root(
+            RootBuilder::default()
+                .path("rootfs")
+                .readonly(false)
+                .build()
+                .expect("failed to create root"),
+        )
+        .process(
+            ProcessBuilder::default()
+                .args(vec![
+                    "/bin/sh".to_string(),
+                    "-c".to_string(),
+                    "true".to_string(),
+                ])
+                .build()
+                .unwrap(),
+        )
+        .hooks(
+            HooksBuilder::default()
+                .prestart(vec![write_prestart_hook(host_output_file)])
+                .build()
+                .expect("could not build hooks"),
+        )
+        .build()
+        .unwrap()
+}
+
+/// Tests that the prestart hook executes during the create operation.
+/// According to the OCI spec, prestart hooks MUST be invoked by the runtime
+/// after the container has been created but before the user-specified program
+/// is executed (which happens during start).
+fn get_test(test_name: &'static str) -> Test {
+    Test::new(
+        test_name,
+        Box::new(move || {
+            let id = generate_uuid().to_string();
+            let bundle = prepare_bundle().unwrap();
+
+            let host_output_file = get_output_file_path(&bundle);
+
+            let spec = get_spec(host_output_file.to_str().unwrap());
+            set_config(&bundle, &spec).unwrap();
+
+            create_container(&id, &bundle, &CreateOptions::default())
+                .unwrap()
+                .wait()
+                .unwrap();
+
+            let result = if !host_output_file.exists() {
+                TestResult::Failed(anyhow!(
+                    "prestart hook did not create output file during create operation"
+                ))
+            } else {
+                let content = fs::read_to_string(&host_output_file)
+                    .expect("failed to read output file after create");
+
+                if content.contains("pre-start called") {
+                    TestResult::Passed
+                } else {
+                    TestResult::Failed(anyhow!(
+                        "the runtime MUST run the pre-start hooks during create. Got: '{content}'"
+                    ))
+                }
+            };
+
+            let _ = delete_container(&id, &bundle);
+            delete_output_file(&host_output_file);
+            result
+        }),
+    )
+}
+
+pub fn get_prestart_tests() -> TestGroup {
+    let mut tg = TestGroup::new("prestart");
+    tg.add(vec![Box::new(get_test("prestart"))]);
+    tg
+}


### PR DESCRIPTION
## Description
This implements a test similar to https://github.com/opencontainers/runtime-tools/blob/master/validation/prestart/prestart.go as a part of the https://github.com/youki-dev/youki/issues/361

## Type of Change
<!-- Mark the appropriate option with an [x] -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test updates
- [ ] CI/CD related changes
- [ ] Other (please describe):

## Testing
<!-- Describe the tests you ran and/or added to verify your changes -->
- [ ] Added new unit tests
- [x] Added new integration tests
- [ ] Ran existing test suite
- [ ] Tested manually (please provide steps)

## Related Issues
<!-- Link any related issues using the GitHub issue syntax: #issue-number
If there is no open issue for this, please add details of the problem or open a new issue. -->
https://github.com/youki-dev/youki/issues/361

## Additional Context
<!-- Add any other context about the pull request here -->
The original test in go suite does quite a lot more than just running this hook. The prestart hook according to the [spec](https://github.com/opencontainers/runtime-spec/blob/main/runtime.md#lifecycle) should run in the create stage, so before start is even invoked. However, in go suite they also run start and then check that the prestart hook is invoked before the process start, which is guaranteed anyway, because the process doesn't start at the create stage. So in my opinion we don't want to test the start behaviour here. The only thing we want to test is that the hook is called during the create stage.