### PR TITLE
Add create_runtime hook test

### DIFF
--- a/tests/contest/contest/src/main.rs
+++ b/tests/contest/contest/src/main.rs
@@ -9,6 +9,7 @@ use contest::logger;
 use test_framework::TestManager;
 use tests::cgroups;
 
+use crate::tests::create_runtime::get_create_runtime_tests;
 use crate::tests::delete::get_delete_test;
 use crate::tests::devices::get_devices_test;
 use crate::tests::domainname::get_domainname_tests;
@@ -125,6 +126,7 @@ fn main() -> Result<()> {
     let poststop = get_poststop_tests();
     let poststart_fail = get_poststart_fail_tests();
     let prestart = get_prestart_tests();
+    let create_runtime = get_create_runtime_tests();
     let cgroup_v1_pids = cgroups::pids::get_test_group();
     let cgroup_v1_cpu = cgroups::cpu::v1::get_test_group();
     let cgroup_v2_cpu = cgroups::cpu::v2::get_test_group();
@@ -175,6 +177,7 @@ fn main() -> Result<()> {
     tm.add_test_group(Box::new(poststart_fail));
     tm.add_test_group(Box::new(poststop));
     tm.add_test_group(Box::new(prestart));
+    tm.add_test_group(Box::new(create_runtime));
     tm.add_test_group(Box::new(cgroup_v1_pids));
     tm.add_test_group(Box::new(cgroup_v1_cpu));
     tm.add_test_group(Box::new(cgroup_v2_cpu));

--- a/tests/contest/contest/src/tests/create_runtime/mod.rs
+++ b/tests/contest/contest/src/tests/create_runtime/mod.rs
@@ -1,0 +1,119 @@
+use std::fs;
+use std::path::PathBuf;
+
+use anyhow::anyhow;
+use oci_spec::runtime::{
+    HookBuilder, HooksBuilder, ProcessBuilder, RootBuilder, Spec, SpecBuilder,
+};
+use test_framework::{Test, TestGroup, TestResult};
+
+use crate::utils::test_utils::CreateOptions;
+use crate::utils::{create_container, delete_container, generate_uuid, prepare_bundle, set_config};
+
+const HOOK_OUTPUT_FILE: &str = "output";
+
+fn get_output_file_path(bundle: &tempfile::TempDir) -> PathBuf {
+    bundle
+        .as_ref()
+        .join("bundle")
+        .join("rootfs")
+        .join(HOOK_OUTPUT_FILE)
+}
+
+fn delete_output_file(path: &PathBuf) {
+    if path.exists() {
+        fs::remove_file(path).expect("failed to remove output file");
+    }
+}
+
+fn build_log_hook(host_output_file: &str) -> oci_spec::runtime::Hook {
+    HookBuilder::default()
+        .path("/bin/sh")
+        .args(vec![
+            "sh".to_string(),
+            "-c".to_string(),
+            format!("echo 'create-runtime called' >> {host_output_file}"),
+        ])
+        .build()
+        .expect("could not build hook")
+}
+
+fn get_spec(host_output_file: &str) -> Spec {
+    SpecBuilder::default()
+        .root(
+            RootBuilder::default()
+                .path("rootfs")
+                .readonly(false)
+                .build()
+                .expect("failed to create root"),
+        )
+        .process(
+            ProcessBuilder::default()
+                .args(vec![
+                    "/bin/sh".to_string(),
+                    "-c".to_string(),
+                    "true".to_string(),
+                ])
+                .build()
+                .unwrap(),
+        )
+        .hooks(
+            HooksBuilder::default()
+                .create_runtime(vec![build_log_hook(host_output_file)])
+                .build()
+                .expect("could not build hooks"),
+        )
+        .build()
+        .unwrap()
+}
+
+/// Tests that the createRuntime hook executes during the create operation.
+/// According to the OCI spec, createRuntime hooks MUST be invoked by the runtime
+/// after the container runtime environment has been created but before pivot_root
+/// has been executed. The createRuntime hooks are called in the runtime namespace.
+fn get_test(test_name: &'static str) -> Test {
+    Test::new(
+        test_name,
+        Box::new(move || {
+            let id = generate_uuid().to_string();
+            let bundle = prepare_bundle().unwrap();
+
+            let host_output_file = get_output_file_path(&bundle);
+
+            let spec = get_spec(host_output_file.to_str().unwrap());
+            set_config(&bundle, &spec).unwrap();
+
+            create_container(&id, &bundle, &CreateOptions::default())
+                .unwrap()
+                .wait()
+                .unwrap();
+
+            let result = if !host_output_file.exists() {
+                TestResult::Failed(anyhow!(
+                    "createRuntime hook did not create output file during create operation"
+                ))
+            } else {
+                let content = fs::read_to_string(&host_output_file)
+                    .expect("failed to read output file after create");
+
+                if content.contains("create-runtime called") {
+                    TestResult::Passed
+                } else {
+                    TestResult::Failed(anyhow!(
+                        "the runtime MUST run the createRuntime hooks during create. Got: '{content}'"
+                    ))
+                }
+            };
+
+            let _ = delete_container(&id, &bundle);
+            delete_output_file(&host_output_file);
+            result
+        }),
+    )
+}
+
+pub fn get_create_runtime_tests() -> TestGroup {
+    let mut tg = TestGroup::new("create_runtime");
+    tg.add(vec![Box::new(get_test("create_runtime"))]);
+    tg
+}

--- a/tests/contest/contest/src/tests/mod.rs
+++ b/tests/contest/contest/src/tests/mod.rs
@@ -1,4 +1,5 @@
 pub mod cgroups;
+pub mod create_runtime;
 pub mod delete;
 pub mod devices;
 pub mod domainname;


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of your changes -->
This implements a test similar to a test for a deprecated `prestart` hook test https://github.com/youki-dev/youki/pull/3382

## Type of Change
<!-- Mark the appropriate option with an [x] -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test updates
- [ ] CI/CD related changes
- [ ] Other (please describe):

## Testing
<!-- Describe the tests you ran and/or added to verify your changes -->
- [ ] Added new unit tests
- [x] Added new integration tests
- [ ] Ran existing test suite
- [ ] Tested manually (please provide steps)

## Related Issues
<!-- Link any related issues using the GitHub issue syntax: #issue-number
If there is no open issue for this, please add details of the problem or open a new issue. -->
https://github.com/youki-dev/youki/issues/361

## Additional Context
In https://github.com/youki-dev/youki/pull/3382 it was requested to also create a test  for a `create_runtime` hook in addition to the derecated `prestart` hook.
