### PR TITLE
Add poststop_fail hook test

### DIFF
--- a/tests/contest/contest/src/main.rs
+++ b/tests/contest/contest/src/main.rs
@@ -38,6 +38,7 @@ use crate::tests::pidfile::get_pidfile_test;
 use crate::tests::poststart::get_poststart_tests;
 use crate::tests::poststart_fail::get_poststart_fail_tests;
 use crate::tests::poststop::get_poststop_tests;
+use crate::tests::poststop_fail::get_poststop_fail_tests;
 use crate::tests::prestart::get_prestart_tests;
 use crate::tests::prestart_fail::get_prestart_fail_tests;
 use crate::tests::process::get_process_test;
@@ -129,6 +130,7 @@ fn main() -> Result<()> {
     let poststart = get_poststart_tests();
     let poststop = get_poststop_tests();
     let poststart_fail = get_poststart_fail_tests();
+    let poststop_fail = get_poststop_fail_tests();
     let prestart = get_prestart_tests();
     let create_runtime = get_create_runtime_tests();
     let prestart_fail = get_prestart_fail_tests();
@@ -184,6 +186,7 @@ fn main() -> Result<()> {
     tm.add_test_group(Box::new(poststart));
     tm.add_test_group(Box::new(poststart_fail));
     tm.add_test_group(Box::new(poststop));
+    tm.add_test_group(Box::new(poststop_fail));
     tm.add_test_group(Box::new(prestart));
     tm.add_test_group(Box::new(create_runtime));
     tm.add_test_group(Box::new(prestart_fail));

--- a/tests/contest/contest/src/tests/mod.rs
+++ b/tests/contest/contest/src/tests/mod.rs
@@ -28,6 +28,7 @@ pub mod pidfile;
 pub mod poststart;
 pub mod poststart_fail;
 pub mod poststop;
+pub mod poststop_fail;
 pub mod prestart;
 pub mod prestart_fail;
 pub mod process;

--- a/tests/contest/contest/src/tests/poststop_fail/mod.rs
+++ b/tests/contest/contest/src/tests/poststop_fail/mod.rs
@@ -1,0 +1,132 @@
+use std::fs;
+
+use anyhow::anyhow;
+use oci_spec::runtime::{
+    HookBuilder, HooksBuilder, ProcessBuilder, RootBuilder, Spec, SpecBuilder,
+};
+use test_framework::{Test, TestGroup, TestResult};
+
+use crate::tests::hooks::{delete_hook_output_file, get_hook_output_path, write_log_hook};
+use crate::utils::test_utils::CreateOptions;
+use crate::utils::{
+    create_container, delete_container, generate_uuid, prepare_bundle, set_config, start_container,
+};
+
+fn get_spec(host_output_file: &str) -> Spec {
+    SpecBuilder::default()
+        .root(
+            RootBuilder::default()
+                .path("rootfs")
+                .readonly(false)
+                .build()
+                .expect("failed to create root"),
+        )
+        .process(
+            ProcessBuilder::default()
+                .args(vec![
+                    "/bin/sh".to_string(),
+                    "-c".to_string(),
+                    "true".to_string(),
+                ])
+                .cwd("/")
+                .build()
+                .unwrap(),
+        )
+        .hooks(
+            HooksBuilder::default()
+                .poststop(vec![
+                    write_log_hook("hook_1 called", host_output_file),
+                    HookBuilder::default()
+                        .path("/bin/sh")
+                        .args(vec![
+                            "sh".to_string(),
+                            "-c".to_string(),
+                            format!("echo 'hook_2 called' >> {host_output_file}; exit 1"),
+                        ])
+                        .build()
+                        .expect("could not build hook"),
+                    write_log_hook("hook_3 called", host_output_file),
+                ])
+                .build()
+                .expect("could not build hooks"),
+        )
+        .build()
+        .unwrap()
+}
+
+/// Tests the current behavior when a poststop hook fails.
+///
+/// TODO: This test currently validates youki's existing behavior, which differs from the OCI spec.
+/// According to the spec: "If any poststop hook fails, the runtime MUST log a warning, but the
+/// remaining hooks and lifecycle continue as if the hook had succeeded."
+///
+/// Current youki behavior (non-spec compliant):
+/// - When a poststop hook fails, subsequent hooks are NOT executed
+/// - The delete operation fails
+///
+/// Expected spec-compliant behavior:
+/// - All hooks should execute even if one fails
+/// - The delete operation should succeed (only log a warning)
+///
+/// This test should be updated once either youki is fixed to follow the spec or the spec itself is
+/// updated: https://github.com/opencontainers/runtime-spec/issues/1309
+fn get_test(test_name: &'static str) -> Test {
+    Test::new(
+        test_name,
+        Box::new(move || {
+            let id = generate_uuid().to_string();
+            let bundle = prepare_bundle().unwrap();
+
+            let host_output_file = get_hook_output_path(&bundle);
+
+            let spec = get_spec(host_output_file.to_str().unwrap());
+            set_config(&bundle, &spec).unwrap();
+
+            create_container(&id, &bundle, &CreateOptions::default())
+                .unwrap()
+                .wait()
+                .unwrap();
+
+            start_container(&id, &bundle).unwrap().wait().unwrap();
+
+            let delete_result = delete_container(&id, &bundle).map(|mut cmd| cmd.wait());
+
+            let delete_failed = match delete_result {
+                Err(_) => true,
+                Ok(Ok(status)) if !status.success() => true,
+                _ => false,
+            };
+
+            if !delete_failed {
+                delete_hook_output_file(&host_output_file).unwrap();
+                return TestResult::Failed(anyhow!(
+                    "delete operation should fail when poststop hook fails (current non-spec behavior)"
+                ));
+            }
+
+            let result = if !host_output_file.exists() {
+                TestResult::Failed(anyhow!("no poststop hooks ran (output file doesn't exist)"))
+            } else {
+                let content =
+                    fs::read_to_string(&host_output_file).expect("failed to read output file");
+
+                let lines: Vec<&str> = content.lines().collect();
+                let expected = vec!["hook_1 called", "hook_2 called"];
+                if lines != expected {
+                    TestResult::Failed(anyhow!("expected hooks output {expected:?}, got {lines:?}"))
+                } else {
+                    TestResult::Passed
+                }
+            };
+
+            delete_hook_output_file(&host_output_file).unwrap();
+            result
+        }),
+    )
+}
+
+pub fn get_poststop_fail_tests() -> TestGroup {
+    let mut tg = TestGroup::new("poststop_fail");
+    tg.add(vec![Box::new(get_test("poststop_fail"))]);
+    tg
+}


### PR DESCRIPTION
## Description
This implements a test similar to https://github.com/opencontainers/runtime-tools/blob/master/validation/poststop_fail/poststop_fail.go as a part of the https://github.com/youki-dev/youki/issues/361

NOTE: I believe that the current behaviour is incorrect. See "Additional Context" section for more details. I have left TODOs in the code to highlight the problem.

## Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test updates
- [ ] CI/CD related changes
- [ ] Other (please describe):

## Testing
- [ ] Added new unit tests
- [x] Added new integration tests
- [ ] Ran existing test suite
- [ ] Tested manually (please provide steps)

## Related Issues
https://github.com/youki-dev/youki/issues/361

## Additional Context

When a poststop hook exits with a non-zero status, youki stops executing subsequent hooks and propagates the error, causing the delete operation to fail. This contradicts the OCI runtime spec.

The spec (https://github.com/opencontainers/runtime-spec/blob/main/runtime.md#lifecycle) states:

> The [poststop hooks](https://github.com/opencontainers/runtime-spec/blob/main/config.md#poststop) MUST be invoked by the runtime. If any poststop hook fails, the runtime MUST [log a warning](https://github.com/opencontainers/runtime-spec/blob/main/runtime.md#warnings), but the remaining hooks and lifecycle continue as if the hook had succeeded.

Where https://github.com/opencontainers/runtime-spec/blob/main/runtime.md#warnings is defined as:

> logging a warning does not change the flow of the operation; it MUST continue as if the warning had not been logged.

Note that poststop is the only hook type with this "warn and continue" requirement. All other hooks (prestart, createRuntime, createContainer, startContainer, poststart) require generating an error on failure.

Current behavior:

Given three poststop hooks where the second one exits with status 1:
  - Hook 1 runs successfully
  - Hook 2 runs, fails with exit code 1
  - Hook 3 never runs
  - delete returns an error

Expected behavior:

  - All three hooks run regardless of individual failures
  - Failures are logged as warnings
  - delete succeeds

Bug: https://github.com/youki-dev/youki/blob/d541c752/crates/libcontainer/src/hooks.rs#L149-L156 uses ? at the end of the match block inside the loop, which returns immediately on the first hook failure:

The caller in https://github.com/youki-dev/youki/blob/d541c752/crates/libcontainer/src/container/container_delete.rs#L100-L106 then propagates the error, failing the delete.

This bug (or rather divergence from the spec) exists in `runc` as well. So maybe the spec instead should be aligned to the actual behaviour?