### PR TITLE
[Bug]: Duplicate error and chain printing

### DIFF
--- a/crates/youki/src/main.rs
+++ b/crates/youki/src/main.rs
@@ -117,7 +117,6 @@ fn main() -> Result<()> {
                 Ok(exit_code) => std::process::exit(exit_code),
                 Err(e) => {
                     tracing::error!("error in executing command: {:?}", e);
-                    eprintln!("exec failed : {e}");
                     std::process::exit(-1);
                 }
             },
@@ -130,7 +129,6 @@ fn main() -> Result<()> {
                 Ok(exit_code) => std::process::exit(exit_code),
                 Err(e) => {
                     tracing::error!("error in executing command: {:?}", e);
-                    eprintln!("run failed : {e}");
                     std::process::exit(-1);
                 }
             },
@@ -149,7 +147,6 @@ fn main() -> Result<()> {
 
     if let Err(ref e) = cmd_result {
         tracing::error!("error in executing command: {:?}", e);
-        eprintln!("error in executing command: {:?}", e);
     }
     cmd_result
 }


### PR DESCRIPTION
## Description
Errors and their chains are duplicated and printed to the terminal multiple times making error deciphering difficult.

- Kept `tracing::error!()` for both observability and user specific error output. 
- Remove `eprintln!` from youki/main.rs
```rust
    if let Err(ref e) = cmd_result {
        tracing::error!("error in executing command: {:?}", e);
    }
    cmd_result
```
### Before
```bash
ERROR libcontainer::container::container_delete: delete requires the container state to be stopped or created id="tutorial_container" status=Running
ERROR youki: error in executing command: failed to delete container tutorial_container

Caused by:
    failed operation due to incompatible container status: `Running`
error in executing command: failed to delete container tutorial_container

Caused by:
    failed operation due to incompatible container status: `Running`
Error: failed to delete container tutorial_container

Caused by:
    failed operation due to incompatible container status: `Running`
```
### After
```bash
ERROR libcontainer::container::container_delete: delete requires the container state to be stopped or created id="tutorial_container" status=Running
ERROR youki: error in executing command: failed to delete container tutorial_container

Caused by:
    failed operation due to incompatible container status: `Running`
Error: failed to delete container tutorial_container

Caused by:
    failed operation due to incompatible container status: `Running`
```

## Type of Change
<!-- Mark the appropriate option with an [x] -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test updates
- [ ] CI/CD related changes
- [ ] Other (please describe):

## Testing
<!-- Describe the tests you ran and/or added to verify your changes -->
- [ ] Added new unit tests
- [ ] Added new integration tests
- [x] Ran existing test suite
- [x] Tested manually (please provide steps)

Ran existing test suite: cargo test -p youki 

Tested manually: I created a container, and while running attempted to delete it without the force flag. The error message has gone from 3 to 2 outputs.
```bash
ERROR libcontainer::container::container_delete: delete requires the container state to be stopped or created id="tutorial_container" status=Running
ERROR youki: error in executing command: failed to delete container tutorial_container

Caused by:
    failed operation due to incompatible container status: `Running`
Error: failed to delete container tutorial_container

Caused by:
    failed operation due to incompatible container status: `Running`
```


## Related Issues
Fixes #3418

## Additional Context
n/a