### PR TITLE
fix duplicate mount entries on exec

### DIFF
--- a/tests/contest/contest/src/main.rs
+++ b/tests/contest/contest/src/main.rs
@@ -14,6 +14,7 @@ use crate::tests::delete::get_delete_test;
 use crate::tests::devices::get_devices_test;
 use crate::tests::domainname::get_domainname_tests;
 use crate::tests::example::get_example_test;
+use crate::tests::exec::get_exec_test;
 use crate::tests::exec_cpu_affinity::get_exec_cpu_affinity_test;
 use crate::tests::fd_control::get_fd_control_test;
 use crate::tests::hooks::get_hooks_tests;
@@ -165,6 +166,7 @@ fn main() -> Result<()> {
     let process_capabilities_fail = get_process_capabilities_fail_test();
     let uid_mappings = get_uid_mappings_test();
     let exec_cpu_affinity = get_exec_cpu_affinity_test();
+    let exec = get_exec_test();
     let personality = get_personality_test();
     let prohibit_symlink = get_prohibit_symlink_test();
     let net_devices = get_net_devices_test();
@@ -217,6 +219,7 @@ fn main() -> Result<()> {
     tm.add_test_group(Box::new(process_capabilities_fail));
     tm.add_test_group(Box::new(uid_mappings));
     tm.add_test_group(Box::new(exec_cpu_affinity));
+    tm.add_test_group(Box::new(exec));
     tm.add_test_group(Box::new(personality));
     tm.add_test_group(Box::new(prohibit_symlink));
     tm.add_test_group(Box::new(io_priority_test));

--- a/tests/contest/contest/src/tests/exec/mod.rs
+++ b/tests/contest/contest/src/tests/exec/mod.rs
@@ -1,0 +1,28 @@
+mod mount_test;
+
+use anyhow::{Context, Result};
+use oci_spec::runtime::{ProcessBuilder, RootBuilder, Spec, SpecBuilder};
+use test_framework::{Test, TestGroup};
+
+fn create_spec(process: Option<ProcessBuilder>) -> Result<Spec> {
+    let p = process.unwrap_or_default().args(
+        ["sleep", "1000"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect::<Vec<String>>(),
+    );
+    SpecBuilder::default()
+        .root(RootBuilder::default().readonly(true).build().unwrap())
+        .process(p.build()?)
+        .build()
+        .context("failed to create spec")
+}
+
+pub fn get_exec_test() -> TestGroup {
+    let mut test_group = TestGroup::new("exec");
+    let mount_test = Test::new("mount_test", Box::new(mount_test::get_mount_test));
+
+    test_group.add(vec![Box::new(mount_test)]);
+
+    test_group
+}

--- a/tests/contest/contest/src/tests/exec/mount_test.rs
+++ b/tests/contest/contest/src/tests/exec/mount_test.rs
@@ -1,0 +1,77 @@
+use anyhow::anyhow;
+use oci_spec::runtime::ProcessBuilder;
+use test_framework::{TestResult, test_result};
+
+use crate::utils::test_utils::{
+    check_container_created, exec_container, start_container, test_outside_container,
+};
+
+// https://github.com/youki-dev/youki/issues/3431
+// In the issue above, we found that `exec` into a container could add duplicate mounts
+// due to `maskedPaths` and `readonlyPaths`. This is a regression test to ensure those mounts are not re-applied on `exec`.
+pub(crate) fn get_mount_test() -> TestResult {
+    let spec = test_result!(super::create_spec(Some(ProcessBuilder::default())));
+
+    test_outside_container(&spec, &|data| {
+        test_result!(check_container_created(&data));
+
+        let id = &data.id;
+        let dir = &data.bundle;
+
+        let start_result = start_container(id, dir).unwrap().wait().unwrap();
+        if !start_result.success() {
+            return TestResult::Failed(anyhow!("container start failed"));
+        }
+
+        let (stdout, _) =
+            exec_container(id, dir, &["cat", "/proc/self/mountinfo"], None).expect("exec failed");
+
+        let rootfs_lines: Vec<&str> = stdout
+            .lines()
+            .filter(|l| l.split_whitespace().nth(4) == Some("/"))
+            .collect();
+
+        // rootfs readonly test
+        let rootfs_is_ro = rootfs_lines.iter().any(|l| {
+            l.split_whitespace()
+                .nth(5) // mount options
+                .is_some_and(|opts| opts.split(',').any(|o| o == "ro"))
+        });
+
+        // maskedPaths test
+        // /proc/acpi is default maskedPath
+        let count_proc_acpi = stdout
+            .lines()
+            .filter(|l| l.split_whitespace().nth(4) == Some("/proc/acpi"))
+            .count();
+
+        // readonlyPaths test
+        // /proc/bus is default maskedPath
+        let count_proc_bus = stdout
+            .lines()
+            .filter(|l| l.split_whitespace().nth(4) == Some("/proc/bus"))
+            .count();
+
+        if !rootfs_is_ro {
+            return TestResult::Failed(anyhow!(
+                "expected root (/) to be mounted read-only; root mountinfo lines:{}",
+                rootfs_lines.join("\n")
+            ));
+        }
+
+        if count_proc_acpi != 1 {
+            return TestResult::Failed(anyhow!(
+                "expected exactly 1 mountinfo entry for /proc/acpi, got {}",
+                count_proc_acpi
+            ));
+        }
+        if count_proc_bus != 1 {
+            return TestResult::Failed(anyhow!(
+                "expected exactly 1 mountinfo entry for /proc/bus: {}",
+                count_proc_bus
+            ));
+        }
+
+        TestResult::Passed
+    })
+}

--- a/tests/contest/contest/src/tests/mod.rs
+++ b/tests/contest/contest/src/tests/mod.rs
@@ -4,6 +4,7 @@ pub mod delete;
 pub mod devices;
 pub mod domainname;
 pub mod example;
+pub mod exec;
 pub mod exec_cpu_affinity;
 pub mod fd_control;
 pub mod hooks;


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of your changes -->

In youki, when executing exec into a container, it currently runs mount-related setup based on `rootfs.readonly`, `maskedPaths`, and `readonlyPaths`. As a result, mounts like `/proc/bus` are added repeatedly and increase each time exec is invoked. This change updates the behavior so that these operations are performed only for `ContainerType::InitContainer.`

You can see this clearly by comparing runc’s [standard_init_linux.go](https://github.com/opencontainers/runc/blob/main/libcontainer/standard_init_linux.go#L51) and [setns_init_linux.go](https://github.com/opencontainers/runc/blob/main/libcontainer/setns_init_linux.go#L35).

When starting the initial container process, runc applies rootfs setup and mount hardening (e.g., readonly paths / masked paths) in `standard_init_linux.go`. In contrast, for `exec`, runc uses `setns_init_linux.go` and does not perform rootfs mount setup.

## Type of Change
<!-- Mark the appropriate option with an [x] -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test updates
- [ ] CI/CD related changes
- [ ] Other (please describe):

## Testing
<!-- Describe the tests you ran and/or added to verify your changes -->
- [ ] Added new unit tests
- [x] Added new integration tests
- [ ] Ran existing test suite
- [ ] Tested manually (please provide steps)

## Related Issues
<!-- Link any related issues using the GitHub issue syntax: #issue-number
If there is no open issue for this, please add details of the problem or open a new issue. -->
Fixes https://github.com/youki-dev/youki/issues/3431

## Additional Context
<!-- Add any other context about the pull request here -->
Operations prepare_rootfs(like `pivot_root`) are already not executed during `exec` in the current implementation.

https://github.com/youki-dev/youki/blob/main/crates/libcontainer/src/process/init/process.rs#L81

I wrote the e2e tests to be consistent with the following PR.

https://github.com/youki-dev/youki/pull/3210