### PR TITLE
Fix logging for dropping capabilities

### DIFF
--- a/crates/libcontainer/src/capabilities.rs
+++ b/crates/libcontainer/src/capabilities.rs
@@ -135,24 +135,28 @@ pub fn drop_privileges<S: Syscall + ?Sized>(
     cs: &LinuxCapabilities,
     syscall: &S,
 ) -> Result<(), SyscallError> {
-    tracing::debug!("dropping bounding capabilities to {:?}", cs.bounding());
     if let Some(bounding) = cs.bounding() {
+        tracing::debug!("dropping bounding capabilities to {:?}", bounding);
         syscall.set_capability(CapSet::Bounding, &to_set(bounding))?;
     }
 
     if let Some(effective) = cs.effective() {
+        tracing::debug!("dropping effective capabilities to {:?}", effective);
         syscall.set_capability(CapSet::Effective, &to_set(effective))?;
     }
 
     if let Some(permitted) = cs.permitted() {
+        tracing::debug!("dropping permitted capabilities to {:?}", permitted);
         syscall.set_capability(CapSet::Permitted, &to_set(permitted))?;
     }
 
     if let Some(inheritable) = cs.inheritable() {
+        tracing::debug!("dropping inheritable capabilities to {:?}", inheritable);
         syscall.set_capability(CapSet::Inheritable, &to_set(inheritable))?;
     }
 
     if let Some(ambient) = cs.ambient() {
+        tracing::debug!("dropping ambient capabilities to {:?}", ambient);
         syscall.set_capability(CapSet::Ambient, &to_set(ambient))?;
     }
 


### PR DESCRIPTION
## Description

Logging is incomplete. If syscall fails, logs does not show what failed.

## Type of Change
<!-- Mark the appropriate option with an [x] -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test updates
- [ ] CI/CD related changes
- [ ] Other (please describe):

## Testing
<!-- Describe the tests you ran and/or added to verify your changes -->
- [ ] Added new unit tests
- [ ] Added new integration tests
- [ ] Ran existing test suite
- [x] Tested manually (please provide steps)

```
DEBUG libcontainer::capabilities: reset all caps
DEBUG libcontainer::capabilities: dropping bounding capabilities to {}
DEBUG libcontainer::capabilities: dropping effective capabilities to {Setgid, IpcOwner, AuditWrite, Chown, Bpf, CheckpointRestore, BlockSuspend, NetRaw, Setfcap, SysPtrace, SysAdmin, NetAdmin, SysModule, MacOverride, DacReadSearch, Mknod, NetBroadcast, AuditControl, Setuid, IpcLock, Setpcap, Fowner, SysTime, SysNice, Syslog, SysBoot, Lease, SysRawio, SysPacct, LinuxImmutable, WakeAlarm, Kill, SysChroot, SysResource, AuditRead, SysTtyConfig, MacAdmin, Perfmon, NetBindService, Fsetid, DacOverride}
DEBUG libcontainer::capabilities: dropping permitted capabilities to {SysAdmin, NetBindService, AuditControl, SysTime, Fowner, CheckpointRestore, Bpf, Setuid, Lease, WakeAlarm, Chown, Mknod, IpcOwner, Fsetid, Setfcap, Setpcap, SysNice, SysChroot, DacReadSearch, Syslog, AuditRead, Setgid, SysRawio, Kill, IpcLock, SysBoot, SysPtrace, NetBroadcast, SysPacct, SysResource, LinuxImmutable, Perfmon, NetAdmin, SysTtyConfig, BlockSuspend, AuditWrite, SysModule, MacAdmin, MacOverride, NetRaw, DacOverride}
DEBUG libcontainer::capabilities: dropping inheritable capabilities to {BlockSuspend, SysTtyConfig, Chown, SysChroot, SysPacct, NetBindService, SysNice, DacOverride, Mknod, Syslog, Perfmon, Bpf, NetRaw, Setgid, NetAdmin, DacReadSearch, SysBoot, NetBroadcast, Fsetid, SysResource, Kill, IpcOwner, Lease, IpcLock, AuditRead, Setfcap, MacAdmin, SysModule, Fowner, Setpcap, Setuid, WakeAlarm, SysAdmin, SysPtrace, AuditControl, SysRawio, SysTime, CheckpointRestore, LinuxImmutable, AuditWrite, MacOverride}
ERROR libcontainer::process::init::process: failed to drop capabilities err=SetCaps(CapsError("capset failure: Operation not permitted (os error 1)"))
```

## Related Issues
<!-- Link any related issues using the GitHub issue syntax: #issue-number
If there is no open issue for this, please add details of the problem or open a new issue. -->

## Additional Context
<!-- Add any other context about the pull request here -->
