### PR TITLE
feat(checkpoint): add CRIU version validation as prerequisite for checkpoint/restore

### DIFF
--- a/crates/libcontainer/src/container/container_checkpoint.rs
+++ b/crates/libcontainer/src/container/container_checkpoint.rs
@@ -8,6 +8,7 @@ use libcgroups::common::CgroupSetup::{Hybrid, Legacy};
 use libcgroups::common::DEFAULT_CGROUP_ROOT;
 use oci_spec::runtime::Spec;
 
+use super::container_criu::{CRIU_VERSION_MINIMUM, check_criu_version};
 use super::{Container, ContainerStatus};
 use crate::container::container::CheckpointOptions;
 use crate::error::LibcontainerError;
@@ -32,6 +33,9 @@ impl Container {
             tracing::error!(status = ?self.status(), id = ?self.id(), "cannot checkpoint container because it is not running");
             return Err(LibcontainerError::IncorrectStatus(self.status()));
         }
+
+        // Require CRIU >= 3.15.0, matching crun's LIBCRIU_MIN_VERSION requirement.
+        check_criu_version(CRIU_VERSION_MINIMUM)?;
 
         // Create checkpoint image directory if it doesn't exist (mode 0o700 like crun).
         if let Err(err) = DirBuilder::new().mode(0o700).create(&opts.image_path) {

--- a/crates/libcontainer/src/container/container_criu.rs
+++ b/crates/libcontainer/src/container/container_criu.rs
@@ -1,0 +1,51 @@
+//! Common CRIU utilities for checkpoint and restore operations.
+//!
+//! This module provides shared functionality between container checkpoint and restore,
+//! following the patterns established by runc's CRIU integration.
+
+use crate::error::LibcontainerError;
+
+/// Minimum CRIU version required for checkpoint/restore functionality.
+/// This matches crun's LIBCRIU_MIN_VERSION requirement (3.15.0).
+/// Version format: MAJOR * 10000 + MINOR * 100 + PATCH
+pub const CRIU_VERSION_MINIMUM: u32 = 31500; // 3.15.0
+
+fn compare_criu_version(version: u32, min_version: u32) -> Result<(), LibcontainerError> {
+    if version < min_version {
+        return Err(LibcontainerError::Other(format!(
+            "CRIU version {} is below minimum required version {}",
+            version, min_version,
+        )));
+    }
+    Ok(())
+}
+
+/// Check if CRIU version is greater than or equal to min_version.
+pub fn check_criu_version(min_version: u32) -> Result<(), LibcontainerError> {
+    let mut criu = rust_criu::Criu::new()
+        .map_err(|e| LibcontainerError::Other(format!("failed to create CRIU instance: {}", e)))?;
+
+    let version = criu
+        .get_criu_version()
+        .map_err(|e| LibcontainerError::Other(format!("CRIU version check failed: {}", e)))?;
+
+    compare_criu_version(version, min_version)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_compare_criu_version_ok() {
+        assert!(compare_criu_version(31500, 31500).is_ok());
+        assert!(compare_criu_version(31600, 31500).is_ok());
+        assert!(compare_criu_version(40000, 31500).is_ok());
+    }
+
+    #[test]
+    fn test_compare_criu_version_too_low() {
+        assert!(compare_criu_version(31499, 31500).is_err());
+        assert!(compare_criu_version(30000, 31500).is_err());
+    }
+}

--- a/crates/libcontainer/src/container/mod.rs
+++ b/crates/libcontainer/src/container/mod.rs
@@ -9,6 +9,7 @@ mod builder_impl;
 #[allow(clippy::module_inception)]
 mod container;
 mod container_checkpoint;
+mod container_criu;
 mod container_delete;
 mod container_events;
 mod container_kill;


### PR DESCRIPTION
## Description
Add `check_criu_version()` to a new `container_criu` module as a prerequisite
validation before invoking CRIU operations. Before any checkpoint can proceed,
youki now verifies that the installed CRIU binary meets the minimum version
requirement (>= 3.15.0), matching crun's `LIBCRIU_MIN_VERSION`. This ensures
a clear and early failure with a descriptive error when the environment is not
suitable for CRIU-based checkpoint/restore, rather than encountering obscure
failures deep in the CRIU RPC flow.

This is part of the checkpoint feature split described in #3394.

## Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test updates
- [ ] CI/CD related changes
- [ ] Other (please describe):

## Testing
- [x] Added new unit tests
- [ ] Added new integration tests
- [x] Ran existing test suite
- [ ] Tested manually (please provide steps)

## Related Issues
Part of #3394

## Additional Context
This PR is intentionally scoped to the CRIU version validation only, split from
#3429 to avoid conflicts with the restore implementation. The `container_criu`
module will serve as the shared foundation for both checkpoint and restore CRIU
utilities in subsequent PRs.