### PR TITLE
chore(deps): upgrade rust-criu to 0.5.0 and protobuf to 3.7.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2657,7 +2657,6 @@ dependencies = [
  "pathrs",
  "prctl",
  "procfs",
- "protobuf",
  "quickcheck",
  "rand 0.10.0",
  "regex",

--- a/crates/libcontainer/Cargo.toml
+++ b/crates/libcontainer/Cargo.toml
@@ -41,7 +41,6 @@ nix = { version = "0.29.0", features = [
 oci-spec = { version = "0.9.0", features = ["runtime"] }
 procfs = "0.17.0"
 prctl = "1.0.0"
-protobuf = "= 3.7.2"
 libcgroups = { path = "../libcgroups", default-features = false, version = "0.6.0" } # MARK: Version
 libseccomp = { version = "0.4.0", optional = true }
 serde = { version = "1.0", features = ["derive"] }
@@ -68,6 +67,3 @@ tempfile = "3"
 anyhow = "1.0"
 rand = "0.10.0"
 scopeguard = "1"
-
-[package.metadata.cargo-machete]
-ignored = ["protobuf"]


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of your changes -->
upgrade rust-criu to 0.5.0 and protobuf to 3.7.2

## Type of Change
<!-- Mark the appropriate option with an [x] -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test updates
- [ ] CI/CD related changes
- [x] Other (please describe):
upgrade dependencies

## Testing
<!-- Describe the tests you ran and/or added to verify your changes -->
- [ ] Added new unit tests
- [ ] Added new integration tests
- [ ] Ran existing test suite
- [ ] Tested manually (please provide steps)

## Related Issues
<!-- Link any related issues using the GitHub issue syntax: #issue-number
If there is no open issue for this, please add details of the problem or open a new issue. -->
https://github.com/youki-dev/youki/issues/3394

## Additional Context
<!-- Add any other context about the pull request here -->
I'm working on implementing the checkpoint/restore feature in https://github.com/youki-dev/youki/issues/3394, which requires extensions introduced in v0.5.0.