### PR TITLE
contest: add checkpoint/restore integration tests

### DIFF
--- a/tests/contest/contest/src/main.rs
+++ b/tests/contest/contest/src/main.rs
@@ -9,6 +9,7 @@ use contest::logger;
 use test_framework::TestManager;
 use tests::cgroups;
 
+use crate::tests::checkpoint_restore::get_checkpoint_restore_tests;
 use crate::tests::create_runtime::get_create_runtime_tests;
 use crate::tests::delete::get_delete_test;
 use crate::tests::devices::get_devices_test;
@@ -172,6 +173,7 @@ fn main() -> Result<()> {
     let personality = get_personality_test();
     let prohibit_symlink = get_prohibit_symlink_test();
     let net_devices = get_net_devices_test();
+    let checkpoint_restore = get_checkpoint_restore_tests();
 
     tm.add_test_group(Box::new(cl));
     tm.add_test_group(Box::new(cc));
@@ -226,6 +228,7 @@ fn main() -> Result<()> {
     tm.add_test_group(Box::new(personality));
     tm.add_test_group(Box::new(prohibit_symlink));
     tm.add_test_group(Box::new(io_priority_test));
+    tm.add_test_group(Box::new(checkpoint_restore));
     tm.add_cleanup(Box::new(cgroups::cleanup_v1));
     tm.add_cleanup(Box::new(cgroups::cleanup_v2));
 

--- a/tests/contest/contest/src/tests/checkpoint_restore/mod.rs
+++ b/tests/contest/contest/src/tests/checkpoint_restore/mod.rs
@@ -1,0 +1,232 @@
+// Checkpoint and restore tests based on runc's tests/integration/checkpoint.bats.
+//
+// All tests are skipped when running with youki because checkpoint/restore is
+// not yet implemented in youki.  They are also skipped when CRIU is not
+// installed on the host.
+
+use std::os::unix::fs::symlink;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use anyhow::anyhow;
+use oci_spec::runtime::{LinuxNamespaceBuilder, LinuxNamespaceType, MountBuilder};
+use test_framework::{ConditionalTest, TestGroup, TestResult};
+
+use crate::utils::{
+    LifecycleStatus, WaitTarget, checkpoint_container, criu_installed, delete_container,
+    generate_uuid, is_runtime_youki, kill_container, prepare_bundle, restore_container,
+    run_container, set_config, wait_container_running, wait_for_state,
+};
+
+/// Used as check_fn for all ConditionalTests in this module:
+/// run only when the runtime is NOT youki and CRIU is installed.
+fn can_run() -> bool {
+    // TODO: remove this skip for youki once checkpoint/restore is supported.
+    !is_runtime_youki() && criu_installed()
+}
+
+fn is_cgroups_v1() -> bool {
+    Path::new("/sys/fs/cgroup/pids").exists()
+}
+
+fn has_cgroupns() -> bool {
+    Path::new("/proc/self/ns/cgroup").exists()
+}
+
+/// RAII guard that kills and deletes the container on drop.
+struct ContainerGuard<'a> {
+    bundle: &'a tempfile::TempDir,
+    id: &'a str,
+}
+
+impl Drop for ContainerGuard<'_> {
+    fn drop(&mut self) {
+        if let Ok(mut child) = kill_container(self.id, self.bundle) {
+            let _ = child.wait();
+        }
+        std::thread::sleep(Duration::from_millis(100));
+        if let Ok(mut child) = delete_container(self.id, self.bundle) {
+            let _ = child.wait();
+        }
+    }
+}
+
+/// Create image-dir and work-dir inside the bundle temp directory.
+fn make_cr_dirs(bundle_path: &Path) -> Result<(PathBuf, PathBuf), TestResult> {
+    let image_dir = bundle_path.join("image-dir");
+    let work_dir = bundle_path.join("work-dir");
+    std::fs::create_dir_all(&image_dir)
+        .map_err(|e| TestResult::Failed(anyhow!("mkdir image-dir: {e}")))?;
+    std::fs::create_dir_all(&work_dir)
+        .map_err(|e| TestResult::Failed(anyhow!("mkdir work-dir: {e}")))?;
+    Ok((image_dir, work_dir))
+}
+
+/// Full checkpoint+restore test: prepares a bundle, calls `setup` to allow the
+/// caller to customise the spec, then runs 2 checkpoint→restore cycles.
+/// The first cycle verifies a normal container can be checkpointed and restored;
+/// the second verifies the restored container can itself be checkpointed and
+/// restored again.
+fn simple_cr(
+    global_args: &[&str],
+    setup: impl Fn(&tempfile::TempDir, &mut oci_spec::runtime::Spec),
+) -> TestResult {
+    let id = generate_uuid().to_string();
+    let bundle = prepare_bundle().unwrap();
+
+    // Apply caller-specific spec customisations on top of the base spec
+    let mut spec = oci_spec::runtime::Spec::default();
+    let mut process = oci_spec::runtime::Process::default();
+    process.set_args(Some(vec!["sleep".into(), "10".into()]));
+    spec.set_process(Some(process));
+    setup(&bundle, &mut spec);
+    set_config(&bundle, &spec).unwrap();
+
+    let run_result = (|| -> anyhow::Result<()> {
+        let status = run_container(&id, &bundle)?.wait()?;
+        if !status.success() {
+            anyhow::bail!("run -d failed ({})", status);
+        }
+        wait_container_running(&id, &bundle)
+    })();
+    if let Err(e) = run_result {
+        return TestResult::Failed(anyhow!("container did not reach running state: {e}"));
+    }
+
+    // Container is running: guard ensures kill+delete on any return path.
+    let _guard = ContainerGuard {
+        bundle: &bundle,
+        id: &id,
+    };
+
+    let (image_dir, work_dir) = match make_cr_dirs(bundle.path()) {
+        Ok(d) => d,
+        Err(r) => return r,
+    };
+
+    for _ in 0..2 {
+        if let Err(e) =
+            checkpoint_container(bundle.path(), &id, &image_dir, Some(&work_dir), global_args)
+        {
+            return TestResult::Failed(anyhow!("checkpoint failed: {e}"));
+        }
+
+        // After a successful checkpoint the runtime must remove the container
+        // from its state, so `state <id>` should fail (exit code != 0).
+        // This mirrors runc's `testcontainer "$CT_ID" checkpointed` check.
+        if let Err(e) = wait_for_state(
+            &id,
+            &bundle,
+            WaitTarget::Deleted,
+            Duration::from_secs(5),
+            Duration::from_millis(100),
+        ) {
+            return TestResult::Failed(anyhow!(
+                "container state still accessible after checkpoint: {e}"
+            ));
+        }
+
+        if let Err(e) =
+            restore_container(bundle.path(), &id, &image_dir, Some(&work_dir), global_args)
+        {
+            return TestResult::Failed(anyhow!("restore failed: {e}"));
+        }
+
+        if let Err(e) = wait_for_state(
+            &id,
+            &bundle,
+            WaitTarget::Status(LifecycleStatus::Running),
+            Duration::from_secs(10),
+            Duration::from_millis(100),
+        ) {
+            return TestResult::Failed(anyhow!("not running after restore: {e}"));
+        }
+    }
+
+    TestResult::Passed
+}
+
+// Test: checkpoint and restore
+// (runc: @test "checkpoint and restore")
+fn checkpoint_and_restore() -> TestResult {
+    simple_cr(&[], |_, _| {})
+}
+
+// Test: checkpoint and restore (bind mount, destination is symlink)
+// (runc: @test "checkpoint and restore (bind mount, destination is symlink)")
+fn checkpoint_and_restore_bind_mount_symlink() -> TestResult {
+    simple_cr(&[], |bundle, spec| {
+        let rootfs = bundle.path().join("bundle").join("rootfs");
+        std::fs::create_dir_all(rootfs.join("real/conf")).unwrap();
+        symlink("/real/conf", rootfs.join("conf")).unwrap();
+        let bind_mount = MountBuilder::default()
+            .source(bundle.path().join("bundle"))
+            .destination("/conf")
+            .options(vec!["bind".to_string()])
+            .build()
+            .unwrap();
+        let mut mounts = spec.mounts().clone().unwrap_or_default();
+        mounts.push(bind_mount);
+        spec.set_mounts(Some(mounts));
+    })
+}
+
+// Test: checkpoint and restore (with --debug)
+// (runc: @test "checkpoint and restore (with --debug)")
+fn checkpoint_and_restore_with_debug() -> TestResult {
+    simple_cr(&["--debug"], |_, _| {})
+}
+
+// Test: checkpoint and restore (cgroupns)
+// (runc: @test "checkpoint and restore (cgroupns)")
+// Requires: cgroups v1 + cgroupns
+fn checkpoint_and_restore_cgroupns() -> TestResult {
+    // cgroupv2 already enables cgroupns, so only run on cgroups v1 with cgroupns
+    if !is_cgroups_v1() || !has_cgroupns() {
+        return TestResult::Skipped;
+    }
+    simple_cr(&[], |_, spec| {
+        if let Some(linux) = spec.linux_mut() {
+            let mut namespaces = linux.namespaces().clone().unwrap_or_default();
+            namespaces.push(
+                LinuxNamespaceBuilder::default()
+                    .typ(LinuxNamespaceType::Cgroup)
+                    .build()
+                    .unwrap(),
+            );
+            linux.set_namespaces(Some(namespaces));
+        }
+    })
+}
+
+pub fn get_checkpoint_restore_tests() -> TestGroup {
+    let mut tg = TestGroup::new("checkpoint_restore");
+    // Run sequentially: CRIU uses global kernel resources and parallel
+    // checkpoint/restore operations can interfere with each other.
+    tg.set_nonparallel();
+
+    macro_rules! cr_test {
+        ($name:expr, $fn:expr) => {
+            ConditionalTest::new($name, Box::new(can_run), Box::new($fn))
+        };
+    }
+
+    tg.add(vec![Box::new(cr_test!(
+        "checkpoint_and_restore",
+        checkpoint_and_restore
+    ))]);
+    tg.add(vec![Box::new(cr_test!(
+        "checkpoint_and_restore_bind_mount_symlink",
+        checkpoint_and_restore_bind_mount_symlink
+    ))]);
+    tg.add(vec![Box::new(cr_test!(
+        "checkpoint_and_restore_with_debug",
+        checkpoint_and_restore_with_debug
+    ))]);
+    tg.add(vec![Box::new(cr_test!(
+        "checkpoint_and_restore_cgroupns",
+        checkpoint_and_restore_cgroupns
+    ))]);
+
+    tg
+}

--- a/tests/contest/contest/src/tests/lifecycle/container_lifecycle.rs
+++ b/tests/contest/contest/src/tests/lifecycle/container_lifecycle.rs
@@ -5,9 +5,8 @@ use std::time::Duration;
 use oci_spec::runtime::Spec;
 use test_framework::{TestResult, TestableGroup};
 
-use super::util::criu_installed;
 use super::{checkpoint, create, delete, exec, kill, start, state};
-use crate::utils::{generate_uuid, prepare_bundle, set_config};
+use crate::utils::{criu_installed, generate_uuid, prepare_bundle, set_config};
 
 // By experimenting, somewhere around 50 is enough for youki process
 // to get the kill signal and shut down

--- a/tests/contest/contest/src/tests/lifecycle/util.rs
+++ b/tests/contest/contest/src/tests/lifecycle/util.rs
@@ -16,7 +16,3 @@ pub fn get_result_from_output(res: io::Result<process::Output>) -> Result<()> {
         io::Result::Err(e) => Err(anyhow::Error::new(e)),
     }
 }
-
-pub fn criu_installed() -> bool {
-    which::which("criu").is_ok()
-}

--- a/tests/contest/contest/src/tests/mod.rs
+++ b/tests/contest/contest/src/tests/mod.rs
@@ -1,4 +1,5 @@
 pub mod cgroups;
+pub mod checkpoint_restore;
 pub mod create_runtime;
 pub mod delete;
 pub mod devices;

--- a/tests/contest/contest/src/utils/mod.rs
+++ b/tests/contest/contest/src/utils/mod.rs
@@ -2,11 +2,12 @@ pub mod support;
 pub mod test_utils;
 
 pub use support::{
-    generate_uuid, get_runtime_path, get_runtimetest_path, is_runtime_runc, prepare_bundle,
-    set_config, wait_for_file_content,
+    generate_uuid, get_runtime_path, get_runtimetest_path, is_runtime_runc, is_runtime_youki,
+    prepare_bundle, set_config, wait_for_file_content,
 };
 pub use test_utils::{
-    CreateOptions, LifecycleStatus, State, WaitTarget, create_container, delete_container,
-    exec_container, get_state, kill_container, start_container, test_inside_container,
-    test_outside_container, wait_for_state,
+    CreateOptions, LifecycleStatus, State, WaitTarget, checkpoint_container, create_container,
+    criu_installed, delete_container, exec_container, get_state, kill_container, restore_container,
+    run_container, start_container, test_inside_container, test_outside_container,
+    wait_container_running, wait_for_state,
 };

--- a/tests/contest/contest/src/utils/support.rs
+++ b/tests/contest/contest/src/utils/support.rs
@@ -100,6 +100,13 @@ pub fn is_runtime_runc() -> bool {
     }
 }
 
+pub fn is_runtime_youki() -> bool {
+    match std::env::var("RUNTIME_KIND") {
+        Err(_) => true,
+        Ok(s) => s == "youki",
+    }
+}
+
 pub fn wait_for_file_content(
     file_path: &PathBuf,
     expected_content: &str,

--- a/tests/contest/contest/src/utils/test_utils.rs
+++ b/tests/contest/contest/src/utils/test_utils.rs
@@ -459,6 +459,123 @@ pub fn check_container_created(data: &ContainerData) -> Result<()> {
     }
 }
 
+/// Run a container with `run -d`.
+/// Uses `Stdio::null()` to avoid the detached child process inheriting
+/// pipe write-ends and blocking `wait()`.
+pub fn run_container<P: AsRef<Path>>(id: &str, dir: P) -> Result<Child> {
+    let res = Command::new(get_runtime_path())
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .arg("--root")
+        .arg(dir.as_ref().join("runtime"))
+        .arg("run")
+        .arg("-d")
+        .arg("--bundle")
+        .arg(dir.as_ref().join("bundle"))
+        .arg(id)
+        .spawn()
+        .context("could not run container")?;
+    Ok(res)
+}
+
+/// Wait until a container reaches `Running` state (10 s timeout).
+pub fn wait_container_running<P: AsRef<Path>>(id: &str, dir: P) -> Result<()> {
+    wait_for_state(
+        id,
+        dir,
+        WaitTarget::Status(LifecycleStatus::Running),
+        Duration::from_secs(10),
+        Duration::from_millis(100),
+    )
+}
+
+/// Checkpoint a running container into `image_dir`.
+/// `global_args` are passed before `--root` (e.g. `&["--debug"]`).
+pub fn checkpoint_container(
+    bundle_path: &Path,
+    id: &str,
+    image_dir: &Path,
+    work_dir: Option<&Path>,
+    global_args: &[&str],
+) -> Result<()> {
+    let mut args: Vec<std::ffi::OsString> = global_args.iter().map(Into::into).collect();
+    args.extend(["--root".into(), bundle_path.join("runtime").into()]);
+    args.extend(["checkpoint".into(), "--image-path".into(), image_dir.into()]);
+    if let Some(wp) = work_dir {
+        args.extend(["--work-path".into(), wp.into()]);
+    }
+    args.push(id.into());
+
+    let output = Command::new(get_runtime_path())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .args(&args)
+        .spawn()
+        .context("failed to spawn checkpoint")?
+        .wait_with_output()
+        .context("failed to wait for checkpoint")?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        bail!(
+            "checkpoint failed ({}): stdout={stdout}, stderr={stderr}",
+            output.status,
+        );
+    }
+
+    if !image_dir.join("inventory.img").exists() {
+        bail!("checkpoint incomplete: {image_dir:?}/inventory.img missing");
+    }
+
+    Ok(())
+}
+
+/// Restore a checkpointed container from `image_dir` using `restore -d`.
+/// `global_args` are passed before `--root` (e.g. `&["--debug"]`).
+pub fn restore_container(
+    bundle_path: &Path,
+    id: &str,
+    image_dir: &Path,
+    work_dir: Option<&Path>,
+    global_args: &[&str],
+) -> Result<()> {
+    let stderr_file = tempfile::NamedTempFile::new().context("failed to create temp file")?;
+
+    let mut args: Vec<std::ffi::OsString> = global_args.iter().map(Into::into).collect();
+    args.extend(["--root".into(), bundle_path.join("runtime").into()]);
+    args.extend(["restore".into(), "-d".into()]);
+    args.extend(["--bundle".into(), bundle_path.join("bundle").into()]);
+    args.extend(["--image-path".into(), image_dir.into()]);
+    if let Some(wp) = work_dir {
+        args.extend(["--work-path".into(), wp.into()]);
+    }
+    args.push(id.into());
+
+    let status = Command::new(get_runtime_path())
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(stderr_file.reopen().context("failed to reopen temp file")?)
+        .args(&args)
+        .spawn()
+        .context("failed to spawn restore")?
+        .wait()
+        .context("failed to wait for restore")?;
+
+    if !status.success() {
+        let stderr = std::fs::read_to_string(stderr_file.path()).unwrap_or_default();
+        bail!("restore failed ({}): {}", status, stderr);
+    }
+
+    Ok(())
+}
+
+/// Returns true if CRIU is installed on the host.
+pub fn criu_installed() -> bool {
+    which::which("criu").is_ok()
+}
+
 pub fn exec_container<P: AsRef<Path>>(
     id: &str,
     dir: P,


### PR DESCRIPTION
## Description
Add checkpoint/restore integration tests to the contest framework,
based on runc's `tests/integration/checkpoint.bats`.

Tests are skipped when running with youki (checkpoint/restore not yet
implemented) and when CRIU is not installed on the host.

The following 4 tests are implemented:
- checkpoint and restore
- checkpoint and restore (bind mount, destination is symlink)
- checkpoint and restore (with --debug)
- checkpoint and restore (cgroupns)

## Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test updates
- [ ] CI/CD related changes
- [ ] Other (please describe):

## Testing
- [ ] Added new unit tests
- [x] Added new integration tests
- [ ] Ran existing test suite
- [ ] Tested manually (please provide steps)

## Related Issues
Related #3447
Closed https://github.com/youki-dev/youki/issues/3444

## Additional Context
The remaining tests (pre-dump, lazy-pages, netdevice, etc.) will be added in follow-up PRs.