### PR TITLE
Support manage-cgroup-mode option for checkpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7360,6 +7360,7 @@ dependencies = [
  "pentacle",
  "pkg-config",
  "procfs",
+ "rust-criu",
  "scopeguard",
  "serde_json",
  "serial_test",

--- a/crates/libcontainer/src/container/container.rs
+++ b/crates/libcontainer/src/container/container.rs
@@ -223,6 +223,7 @@ pub struct CheckpointOptions {
     pub shell_job: bool,
     pub tcp_established: bool,
     pub work_path: Option<PathBuf>,
+    pub manage_cgroups_mode: rust_criu::CgMode,
 }
 
 #[cfg(test)]

--- a/crates/libcontainer/src/container/container_checkpoint.rs
+++ b/crates/libcontainer/src/container/container_checkpoint.rs
@@ -168,6 +168,7 @@ impl Container {
                 .into_string()
                 .unwrap(),
         );
+        criu.cgroups_mode(opts.manage_cgroups_mode.clone());
 
         criu.dump().map_err(|err| {
             tracing::error!(?err, id = ?self.id(), logfile = ?opts.image_path.join(CRIU_CHECKPOINT_LOG_FILE), "checkpointing container failed");

--- a/crates/liboci-cli/src/checkpoint.rs
+++ b/crates/liboci-cli/src/checkpoint.rs
@@ -49,16 +49,14 @@ pub struct Checkpoint {
     // TODO: Do a pre-dump
     // #[clap(long)]
     // pub pre_dump: bool,
-    // TODO: Cgroups mode
-    // #[clap(long)]
-    // pub manage_cgroups_mode: Option<String>,
+    #[clap(long, default_value = "soft", value_parser = clap::builder::PossibleValuesParser::new(["ignore", "full", "strict", "soft"]))]
+    pub manage_cgroups_mode: String,
     // TODO: Checkpoint a namespace, but don't save its properties
     // #[clap(long)]
     // pub empty_ns: bool,
     // TODO: Enable auto-deduplication
     // #[clap(long)]
     // pub auto_dedup: bool,
-    /// Container identifier
     #[clap(value_parser = clap::builder::NonEmptyStringValueParser::new(), required = true)]
     pub container_id: String,
 }

--- a/crates/youki/Cargo.toml
+++ b/crates/youki/Cargo.toml
@@ -49,6 +49,7 @@ tracing = { version = "0.1.44", features = ["attributes"] }
 tracing-subscriber = { version = "0.3.23", features = ["json", "env-filter"] }
 tracing-journald = "0.3.2"
 oci-spec = { version = "0.9.0", features = ["runtime"] }
+rust-criu = "0.5.0"
 
 [dev-dependencies]
 serial_test = "3.4.0"

--- a/crates/youki/src/commands/checkpoint.rs
+++ b/crates/youki/src/commands/checkpoint.rs
@@ -17,8 +17,52 @@ pub fn checkpoint(args: Checkpoint, root_path: PathBuf) -> Result<()> {
         shell_job: args.shell_job,
         tcp_established: args.tcp_established,
         work_path: args.work_path,
+        manage_cgroups_mode: parse_cgroups_mode(&args.manage_cgroups_mode)?,
     };
     container
         .checkpoint(&opts)
         .with_context(|| format!("failed to checkpoint container {}", args.container_id))
+}
+
+fn parse_cgroups_mode(s: &str) -> Result<rust_criu::CgMode, anyhow::Error> {
+    match s {
+        "ignore" => Ok(rust_criu::CgMode::IGNORE),
+        "full" => Ok(rust_criu::CgMode::FULL),
+        "strict" => Ok(rust_criu::CgMode::STRICT),
+        "soft" => Ok(rust_criu::CgMode::SOFT),
+        _ => Err(anyhow::anyhow!("invalid manage-cgroups-mode: {s}")),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_cgroups_mode_ok() {
+        assert!(matches!(
+            parse_cgroups_mode("ignore"),
+            Ok(rust_criu::CgMode::IGNORE)
+        ));
+        assert!(matches!(
+            parse_cgroups_mode("full"),
+            Ok(rust_criu::CgMode::FULL)
+        ));
+        assert!(matches!(
+            parse_cgroups_mode("strict"),
+            Ok(rust_criu::CgMode::STRICT)
+        ));
+        assert!(matches!(
+            parse_cgroups_mode("soft"),
+            Ok(rust_criu::CgMode::SOFT)
+        ));
+    }
+
+    #[test]
+    fn test_parse_cgroups_mode_ng() {
+        assert!(parse_cgroups_mode("IGNORE").is_err());
+        assert!(parse_cgroups_mode("Ignore").is_err());
+        assert!(parse_cgroups_mode("unknown").is_err());
+        assert!(parse_cgroups_mode("").is_err());
+    }
 }

--- a/tests/contest/contest/src/tests/lifecycle/checkpoint.rs
+++ b/tests/contest/contest/src/tests/lifecycle/checkpoint.rs
@@ -79,29 +79,12 @@ fn setup_network_namespace(project_path: &Path, id: &str) -> Result<(), TestResu
 fn checkpoint(
     project_path: &Path,
     id: &str,
+    image_path: &Path,
     args: Vec<&str>,
     work_path: Option<&str>,
 ) -> TestResult {
     if let Err(e) = setup_network_namespace(project_path, id) {
         return e;
-    }
-
-    let temp_dir = match tempfile::tempdir() {
-        Ok(td) => td,
-        Err(e) => {
-            return TestResult::Failed(anyhow::anyhow!(
-                "failed creating temporary directory {:?}",
-                e
-            ));
-        }
-    };
-    let checkpoint_dir = temp_dir.as_ref().join("checkpoint");
-    if let Err(e) = std::fs::create_dir(&checkpoint_dir) {
-        return TestResult::Failed(anyhow::anyhow!(
-            "failed creating checkpoint directory ({:?}): {}",
-            &checkpoint_dir,
-            e
-        ));
     }
 
     let additional_args = match work_path {
@@ -111,8 +94,8 @@ fn checkpoint(
 
     let runtime_path = get_runtime_path();
 
-    let checkpoint = Command::new(runtime_path)
-        .stdout(Stdio::piped())
+    let mut cmd = Command::new(runtime_path);
+    cmd.stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .arg("--root")
         .arg(project_path.join("runtime"))
@@ -121,7 +104,8 @@ fn checkpoint(
             _ => "checkpoint",
         })
         .arg("--image-path")
-        .arg(&checkpoint_dir)
+        .arg(image_path);
+    let checkpoint = cmd
         .args(additional_args)
         .args(args)
         .arg(id)
@@ -134,23 +118,23 @@ fn checkpoint(
     }
 
     // Check for complete checkpoint
-    if !Path::new(&checkpoint_dir.join("inventory.img")).exists() {
+    if !image_path.join("inventory.img").exists() {
         return TestResult::Failed(anyhow::anyhow!(
             "resulting checkpoint does not seem to be complete. {:?}/inventory.img is missing",
-            &checkpoint_dir,
+            image_path,
         ));
     }
 
-    if !Path::new(&checkpoint_dir.join("descriptors.json")).exists() {
+    if !image_path.join("descriptors.json").exists() {
         return TestResult::Failed(anyhow::anyhow!(
             "resulting checkpoint does not seem to be complete. {:?}/descriptors.json is missing",
-            &checkpoint_dir,
+            image_path,
         ));
     }
 
     let dump_log = match work_path {
         Some(wp) => Path::new(wp).join("dump.log"),
-        _ => checkpoint_dir.join("dump.log"),
+        _ => image_path.join("dump.log"),
     };
 
     if !dump_log.exists() {
@@ -163,10 +147,128 @@ fn checkpoint(
     TestResult::Passed
 }
 
+fn create_checkpoint_image_dir() -> Result<(tempfile::TempDir, std::path::PathBuf), TestResult> {
+    let temp_dir = tempfile::tempdir().map_err(|e| {
+        TestResult::Failed(anyhow::anyhow!(
+            "failed creating temporary directory {:?}",
+            e
+        ))
+    })?;
+    let image_path = temp_dir.path().join("checkpoint");
+    std::fs::create_dir(&image_path).map_err(|e| {
+        TestResult::Failed(anyhow::anyhow!(
+            "failed creating checkpoint directory ({:?}): {}",
+            &image_path,
+            e
+        ))
+    })?;
+    Ok((temp_dir, image_path))
+}
+
 pub fn checkpoint_leave_running_work_path_tmp(project_path: &Path, id: &str) -> TestResult {
-    checkpoint(project_path, id, vec!["--leave-running"], Some("/tmp/"))
+    let (_temp_dir, image_path) = match create_checkpoint_image_dir() {
+        Ok(v) => v,
+        Err(e) => return e,
+    };
+
+    checkpoint(
+        project_path,
+        id,
+        &image_path,
+        vec!["--leave-running"],
+        Some("/tmp/"),
+    )
 }
 
 pub fn checkpoint_leave_running(project_path: &Path, id: &str) -> TestResult {
-    checkpoint(project_path, id, vec!["--leave-running"], None)
+    let (_temp_dir, image_path) = match create_checkpoint_image_dir() {
+        Ok(v) => v,
+        Err(e) => return e,
+    };
+
+    checkpoint(project_path, id, &image_path, vec!["--leave-running"], None)
+}
+
+pub fn checkpoint_manage_cgroups_mode_ignore(project_path: &Path, id: &str) -> TestResult {
+    let (_temp_dir, image_path) = match create_checkpoint_image_dir() {
+        Ok(v) => v,
+        Err(e) => return e,
+    };
+
+    let result = checkpoint(
+        project_path,
+        id,
+        &image_path,
+        vec!["--leave-running", "--manage-cgroups-mode", "ignore"],
+        None,
+    );
+    if let TestResult::Failed(_) = &result {
+        return result;
+    }
+
+    let cgroup_img = image_path.join("cgroup.img");
+    let content = match std::fs::read(&cgroup_img) {
+        Ok(c) => c,
+        Err(e) => {
+            return TestResult::Failed(anyhow::anyhow!(
+                "failed to read cgroup.img at {:?}: {}",
+                cgroup_img,
+                e
+            ));
+        }
+    };
+
+    if content
+        .windows(b"cgroup.subtree_control".len())
+        .any(|w| w == b"cgroup.subtree_control")
+    {
+        return TestResult::Failed(anyhow::anyhow!(
+            "cgroup.img should not contain cgroup properties with --manage-cgroups-mode ignore, \
+             but found 'cgroup.subtree_control'",
+        ));
+    }
+
+    TestResult::Passed
+}
+
+pub fn checkpoint_manage_cgroups_mode_soft(project_path: &Path, id: &str) -> TestResult {
+    let (_temp_dir, image_path) = match create_checkpoint_image_dir() {
+        Ok(v) => v,
+        Err(e) => return e,
+    };
+
+    let result = checkpoint(
+        project_path,
+        id,
+        &image_path,
+        vec!["--leave-running", "--manage-cgroups-mode", "soft"],
+        None,
+    );
+    if let TestResult::Failed(_) = &result {
+        return result;
+    }
+
+    let cgroup_img = image_path.join("cgroup.img");
+    let content = match std::fs::read(&cgroup_img) {
+        Ok(c) => c,
+        Err(e) => {
+            return TestResult::Failed(anyhow::anyhow!(
+                "failed to read cgroup.img at {:?}: {}",
+                cgroup_img,
+                e
+            ));
+        }
+    };
+
+    if !content
+        .windows(b"cgroup.subtree_control".len())
+        .any(|w| w == b"cgroup.subtree_control")
+    {
+        return TestResult::Failed(anyhow::anyhow!(
+            "cgroup.img should contain cgroup properties with --manage-cgroups-mode soft, \
+             but 'cgroup.subtree_control' not found",
+        ));
+    }
+
+    TestResult::Passed
 }

--- a/tests/contest/contest/src/tests/lifecycle/container_lifecycle.rs
+++ b/tests/contest/contest/src/tests/lifecycle/container_lifecycle.rs
@@ -106,6 +106,30 @@ impl ContainerLifecycle {
         )
     }
 
+    // ignore and soft are used as representative cases, as checkpoint behavior
+    // primarily differs between ignore and other modes.
+    pub fn checkpoint_manage_cgroups_mode_ignore(&self) -> TestResult {
+        if !criu_installed() {
+            return TestResult::Skipped;
+        }
+
+        checkpoint::checkpoint_manage_cgroups_mode_ignore(
+            self.project_path.path(),
+            &self.container_id,
+        )
+    }
+
+    pub fn checkpoint_manage_cgroups_mode_soft(&self) -> TestResult {
+        if !criu_installed() {
+            return TestResult::Skipped;
+        }
+
+        checkpoint::checkpoint_manage_cgroups_mode_soft(
+            self.project_path.path(),
+            &self.container_id,
+        )
+    }
+
     /// Wait for the container to reach a specific state
     pub fn wait_for_state(&self, expected_state: &str, timeout: Duration) -> TestResult {
         use crate::tests::lifecycle::state;
@@ -149,6 +173,14 @@ impl TestableGroup for ContainerLifecycle {
                 "checkpoint and leave running",
                 self.checkpoint_leave_running(),
             ),
+            (
+                "checkpoint with cgroups-mode ignore",
+                self.checkpoint_manage_cgroups_mode_ignore(),
+            ),
+            (
+                "checkpoint with cgroups-mode soft",
+                self.checkpoint_manage_cgroups_mode_soft(),
+            ),
             ("kill", self.kill()),
             ("state", self.state()),
             ("delete", self.delete()),
@@ -168,6 +200,14 @@ impl TestableGroup for ContainerLifecycle {
                 "checkpoint_leave_running" => ret.push((
                     "checkpoint and leave running",
                     self.checkpoint_leave_running(),
+                )),
+                "checkpoint_manage_cgroups_mode_ignore" => ret.push((
+                    "checkpoint with cgroups-mode ignore",
+                    self.checkpoint_manage_cgroups_mode_ignore(),
+                )),
+                "checkpoint_manage_cgroups_mode_soft" => ret.push((
+                    "checkpoint with cgroups-mode soft",
+                    self.checkpoint_manage_cgroups_mode_soft(),
                 )),
                 "kill" => ret.push(("kill", self.kill())),
                 "state" => ret.push(("state", self.state())),


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of your changes -->
Add support for CRIU's `--manage-cgroup-mode` option in checkpoint command. This primarily affects restore behavior, and with "ignore" mode, cgroup information will not be dumped.

## Type of Change
<!-- Mark the appropriate option with an [x] -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test updates
- [ ] CI/CD related changes
- [ ] Other (please describe):

## Testing
<!-- Describe the tests you ran and/or added to verify your changes -->
- [ ] Added new unit tests
- [ ] Added new integration tests
- [ ] Ran existing test suite
- [ ] Tested manually (please provide steps)

## Related Issues
<!-- Link any related issues using the GitHub issue syntax: #issue-number
If there is no open issue for this, please add details of the problem or open a new issue. -->
https://github.com/youki-dev/youki/issues/3394

## Additional Context
<!-- Add any other context about the pull request here -->
For detail about the option, see https://criu.org/CGroups.