### PR TITLE
refactor: replace deprecated clap derive attributes with command and arg

### DIFF
--- a/crates/liboci-cli/src/checkpoint.rs
+++ b/crates/liboci-cli/src/checkpoint.rs
@@ -8,55 +8,55 @@ use clap::Parser;
 #[derive(Parser, Debug)]
 pub struct Checkpoint {
     /// Path for saving criu image files
-    #[clap(long, default_value = "checkpoint")]
+    #[arg(long, default_value = "checkpoint")]
     pub image_path: PathBuf,
     /// Path for saving work files and logs
-    #[clap(long)]
+    #[arg(long)]
     pub work_path: Option<PathBuf>,
     // TODO: Path for previous criu image file in pre-dump
-    // #[clap(long)]
+    // #[arg(long)]
     // pub parent_path: Option<PathBuf>,
     /// Leave the process running after checkpointing
-    #[clap(long)]
+    #[arg(long)]
     pub leave_running: bool,
     /// Allow open tcp connections
-    #[clap(long)]
+    #[arg(long)]
     pub tcp_established: bool,
     // TODO: Skip in-flight tcp connections
-    // #[clap(long)]
+    // #[arg(long)]
     // pub tcp_skip_in_flight: bool,
     // TODO: Allow one to link unlinked files back when possible
-    // #[clap(long)]
+    // #[arg(long)]
     // pub link_remap: bool,
     /// Allow external unix sockets
-    #[clap(long)]
+    #[arg(long)]
     pub ext_unix_sk: bool,
     /// Allow shell jobs
-    #[clap(long)]
+    #[arg(long)]
     pub shell_job: bool,
     // TODO: Use lazy migration mechanism
-    // #[clap(long)]
+    // #[arg(long)]
     // pub lazy_pages: bool,
     // TODO: Pass a file descriptor fd to criu. Is u32 the right type?
-    // #[clap(long)]
+    // #[arg(long)]
     // pub status_fd: Option<u32>,
     // TODO: Start a page server at the given URL
-    // #[clap(long)]
+    // #[arg(long)]
     // pub page_server: Option<String>,
     /// Allow file locks
-    #[clap(long)]
+    #[arg(long)]
     pub file_locks: bool,
     // TODO: Do a pre-dump
-    // #[clap(long)]
+    // #[arg(long)]
     // pub pre_dump: bool,
-    #[clap(long, default_value = "soft", value_parser = clap::builder::PossibleValuesParser::new(["ignore", "full", "strict", "soft"]))]
+    #[arg(long, default_value = "soft", value_parser = clap::builder::PossibleValuesParser::new(["ignore", "full", "strict", "soft"]))]
     pub manage_cgroups_mode: String,
     // TODO: Checkpoint a namespace, but don't save its properties
-    // #[clap(long)]
+    // #[arg(long)]
     // pub empty_ns: bool,
     // TODO: Enable auto-deduplication
-    // #[clap(long)]
+    // #[arg(long)]
     // pub auto_dedup: bool,
-    #[clap(value_parser = clap::builder::NonEmptyStringValueParser::new(), required = true)]
+    #[arg(value_parser = clap::builder::NonEmptyStringValueParser::new(), required = true)]
     pub container_id: String,
 }

--- a/crates/liboci-cli/src/create.rs
+++ b/crates/liboci-cli/src/create.rs
@@ -1,33 +1,33 @@
 //! Handles the creation of a new container
 use std::path::PathBuf;
 
-use clap::Parser;
+use clap::Args;
 
 /// Create a container
 /// Reference: https://github.com/opencontainers/runc/blob/main/man/runc-create.8.md
-#[derive(Parser, Debug)]
+#[derive(Args, Debug)]
 pub struct Create {
     /// Path to the bundle directory, containing config.json and root filesystem
-    #[clap(short, long, default_value = ".")]
+    #[arg(short, long, default_value = ".")]
     pub bundle: PathBuf,
     /// Unix socket (file) path , which will receive file descriptor of the writing end of the pseudoterminal
-    #[clap(short, long)]
+    #[arg(short, long)]
     pub console_socket: Option<PathBuf>,
     /// File to write pid of the container created
     // note that in the end, container is just another process
-    #[clap(short, long)]
+    #[arg(short, long)]
     pub pid_file: Option<PathBuf>,
     /// Do not use pivot rool to jail process inside rootfs
-    #[clap(long)]
+    #[arg(long)]
     pub no_pivot: bool,
     /// Do not create a new session keyring for the container.
-    #[clap(long)]
+    #[arg(long)]
     pub no_new_keyring: bool,
     /// Pass N additional file descriptors to the container (stdio + $LISTEN_FDS + N in total)
-    #[clap(long, default_value = "0")]
+    #[arg(long, default_value = "0")]
     pub preserve_fds: i32,
 
     /// Name of the container instance to be started
-    #[clap(value_parser = clap::builder::NonEmptyStringValueParser::new(), required = true)]
+    #[arg(value_parser = clap::builder::NonEmptyStringValueParser::new(), required = true)]
     pub container_id: String,
 }

--- a/crates/liboci-cli/src/delete.rs
+++ b/crates/liboci-cli/src/delete.rs
@@ -1,12 +1,12 @@
-use clap::Parser;
+use clap::Args;
 
 /// Release any resources held by the container
-#[derive(Parser, Debug)]
+#[derive(Args, Debug)]
 pub struct Delete {
     /// Container identifier
-    #[clap(value_parser = clap::builder::NonEmptyStringValueParser::new(), required = true)]
+    #[arg(value_parser = clap::builder::NonEmptyStringValueParser::new(), required = true)]
     pub container_id: String,
     /// forces deletion of the container if it is still running (using SIGKILL)
-    #[clap(short, long)]
+    #[arg(short, long)]
     pub force: bool,
 }

--- a/crates/liboci-cli/src/events.rs
+++ b/crates/liboci-cli/src/events.rs
@@ -1,15 +1,15 @@
-use clap::Parser;
+use clap::Args;
 
 /// Show resource statistics for the container
-#[derive(Parser, Debug)]
+#[derive(Args, Debug)]
 pub struct Events {
     /// Sets the stats collection interval in seconds (default: 5s)
-    #[clap(long, default_value = "5")]
+    #[arg(long, default_value = "5")]
     pub interval: u32,
     /// Display the container stats only once
-    #[clap(long)]
+    #[arg(long)]
     pub stats: bool,
     /// Name of the container instance
-    #[clap(value_parser = clap::builder::NonEmptyStringValueParser::new(), required = true)]
+    #[arg(value_parser = clap::builder::NonEmptyStringValueParser::new(), required = true)]
     pub container_id: String,
 }

--- a/crates/liboci-cli/src/exec.rs
+++ b/crates/liboci-cli/src/exec.rs
@@ -1,67 +1,67 @@
 use std::error::Error;
 use std::path::PathBuf;
 
-use clap::Parser;
+use clap::Args;
 
 /// Execute a process within an existing container
 /// Reference: https://github.com/opencontainers/runc/blob/main/man/runc-exec.8.md
-#[derive(Parser, Debug)]
+#[derive(Args, Debug)]
 pub struct Exec {
     /// Unix socket (file) path , which will receive file descriptor of the writing end of the pseudoterminal
-    #[clap(long)]
+    #[arg(long)]
     pub console_socket: Option<PathBuf>,
-    #[clap(long)]
+    #[arg(long)]
     /// Current working directory of the container
     pub cwd: Option<PathBuf>,
     /// Environment variables that should be set in the container
-    #[clap(short, long, value_parser = parse_env::<String, String>, number_of_values = 1)]
+    #[arg(short, long, value_parser = parse_env::<String, String>, num_args = 1)]
     pub env: Vec<(String, String)>,
     /// Allocate a pseudo-TTY for the process
-    #[clap(short, long)]
+    #[arg(short, long)]
     pub tty: bool,
     /// Run the command as a user
-    #[clap(short, long, value_parser = parse_user::<u32, u32>)]
+    #[arg(short, long, value_parser = parse_user::<u32, u32>)]
     pub user: Option<(u32, Option<u32>)>,
     /// Add additional group IDs. Can be specified multiple times
-    #[clap(long, short = 'g', number_of_values = 1)]
+    #[arg(long, short = 'g', num_args = 1)]
     pub additional_gids: Vec<u32>,
     /// Path to process.json
-    #[clap(short, long)]
+    #[arg(short, long)]
     pub process: Option<PathBuf>,
     /// Detach from the container process
-    #[clap(short, long)]
+    #[arg(short, long)]
     pub detach: bool,
-    #[clap(long)]
+    #[arg(long)]
     /// The file to which the pid of the container process should be written to
     pub pid_file: Option<PathBuf>,
     /// Set the asm process label for the process commonly used with selinux
-    #[clap(long)]
+    #[arg(long)]
     pub process_label: Option<String>,
     /// Set the apparmor profile for the process
-    #[clap(long)]
+    #[arg(long)]
     pub apparmor: Option<String>,
     /// Prevent the process from gaining additional privileges
-    #[clap(long)]
+    #[arg(long)]
     pub no_new_privs: bool,
     /// Add a capability to the bounding set for the process
-    #[clap(long, number_of_values = 1)]
+    #[arg(long, num_args = 1)]
     pub cap: Vec<String>,
     /// Pass N additional file descriptors to the container
-    #[clap(long, default_value = "0")]
+    #[arg(long, default_value = "0")]
     pub preserve_fds: i32,
     /// Allow exec in a paused container
-    #[clap(long)]
+    #[arg(long)]
     pub ignore_paused: bool,
     /// Execute a process in a sub-cgroup
-    #[clap(long)]
+    #[arg(long)]
     pub cgroup: Option<String>,
 
     /// Container identifier
-    #[clap(value_parser = clap::builder::NonEmptyStringValueParser::new(), required = true)]
+    #[arg(value_parser = clap::builder::NonEmptyStringValueParser::new(), required = true)]
     pub container_id: String,
 
     /// Command that should be executed in the container
-    #[clap(required = false, trailing_var_arg = true)]
+    #[arg(required = false, trailing_var_arg = true)]
     pub command: Vec<String>,
 }
 

--- a/crates/liboci-cli/src/features.rs
+++ b/crates/liboci-cli/src/features.rs
@@ -1,9 +1,9 @@
-use clap::Parser;
+use clap::Args;
 
 /// Return the features list for a container
 /// This subcommand was introduced in runc by
 /// https://github.com/opencontainers/runc/pull/3296
 /// It is documented here:
 /// https://github.com/opencontainers/runtime-spec/blob/main/features-linux.md
-#[derive(Parser, Debug)]
+#[derive(Args, Debug)]
 pub struct Features {}

--- a/crates/liboci-cli/src/kill.rs
+++ b/crates/liboci-cli/src/kill.rs
@@ -1,14 +1,14 @@
-use clap::Parser;
+use clap::Args;
 
 /// Send the specified signal to the container
-#[derive(Parser, Debug)]
+#[derive(Args, Debug)]
 pub struct Kill {
     /// Container identifier
-    #[clap(value_parser = clap::builder::NonEmptyStringValueParser::new(), required = true)]
+    #[arg(value_parser = clap::builder::NonEmptyStringValueParser::new(), required = true)]
     pub container_id: String,
     /// Signal to send to the container (e.g. KILL, TERM, 9)
     pub signal: String,
     /// Send the signal to all processes inside the container
-    #[clap(short, long)]
+    #[arg(short, long)]
     pub all: bool,
 }

--- a/crates/liboci-cli/src/lib.rs
+++ b/crates/liboci-cli/src/lib.rs
@@ -1,7 +1,7 @@
 use std::fmt::Debug;
 use std::path::PathBuf;
 
-use clap::Parser;
+use clap::{Args, Subcommand};
 
 // Subcommands that are specified in https://github.com/opencontainers/runtime-tools/blob/master/docs/command-line-interface.md
 
@@ -46,7 +46,7 @@ pub use update::Update;
 // runtime-spec](https://github.com/opencontainers/runtime-spec/blob/master/runtime.md)
 // and specifically the [OCI Command Line
 // Interface](https://github.com/opencontainers/runtime-tools/blob/master/docs/command-line-interface.md)
-#[derive(Parser, Debug)]
+#[derive(Subcommand, Debug)]
 pub enum StandardCmd {
     Create(Create),
     Start(Start),
@@ -59,7 +59,7 @@ pub enum StandardCmd {
 // but found in
 // [runc](https://github.com/opencontainers/runc/blob/master/man/runc.8.md)
 // and other runtimes.
-#[derive(Parser, Debug)]
+#[derive(Subcommand, Debug)]
 pub enum CommonCmd {
     Checkpointt(Checkpoint),
     Events(Events),
@@ -67,7 +67,6 @@ pub enum CommonCmd {
     Features(Features),
     List(List),
     Pause(Pause),
-    #[clap(allow_hyphen_values = true)]
     Ps(Ps),
     Resume(Resume),
     Run(Run),
@@ -77,21 +76,21 @@ pub enum CommonCmd {
 
 // The OCI Command Line Interface document doesn't define any global
 // flags, but these are commonly accepted by runtimes
-#[derive(Parser, Debug)]
+#[derive(Args, Debug)]
 pub struct GlobalOpts {
     /// set the log file to write youki logs to (default is '/dev/stderr')
-    #[clap(short, long, overrides_with("log"))]
+    #[arg(short, long, overrides_with("log"))]
     pub log: Option<PathBuf>,
     /// change log level to debug, but the `log-level` flag takes precedence
-    #[clap(long)]
+    #[arg(long)]
     pub debug: bool,
     /// set the log format ('text' (default), or 'json') (default: "text")
-    #[clap(long)]
+    #[arg(long)]
     pub log_format: Option<String>,
     /// root directory to store container state
-    #[clap(short, long)]
+    #[arg(short, long)]
     pub root: Option<PathBuf>,
     /// Enable systemd cgroup manager, rather then use the cgroupfs directly.
-    #[clap(short, long)]
+    #[arg(short, long)]
     pub systemd_cgroup: bool,
 }

--- a/crates/liboci-cli/src/list.rs
+++ b/crates/liboci-cli/src/list.rs
@@ -1,13 +1,13 @@
-use clap::Parser;
+use clap::Args;
 
 /// List created containers
-#[derive(Parser, Debug)]
+#[derive(Args, Debug)]
 pub struct List {
     /// Specify the format (default or table)
-    #[clap(long, default_value = "table")]
+    #[arg(long, default_value = "table")]
     pub format: String,
 
     /// Only display container IDs
-    #[clap(long, short)]
+    #[arg(long, short)]
     pub quiet: bool,
 }

--- a/crates/liboci-cli/src/pause.rs
+++ b/crates/liboci-cli/src/pause.rs
@@ -1,9 +1,9 @@
-use clap::Parser;
+use clap::Args;
 
 /// Suspend the processes within the container
-#[derive(Parser, Debug)]
+#[derive(Args, Debug)]
 pub struct Pause {
     /// Container identifier
-    #[clap(value_parser = clap::builder::NonEmptyStringValueParser::new(), required = true)]
+    #[arg(value_parser = clap::builder::NonEmptyStringValueParser::new(), required = true)]
     pub container_id: String,
 }

--- a/crates/liboci-cli/src/ps.rs
+++ b/crates/liboci-cli/src/ps.rs
@@ -1,15 +1,15 @@
-use clap::{self, Parser};
+use clap::{self, Args};
 
 /// Display the processes inside the container
-#[derive(Parser, Debug)]
+#[derive(Args, Debug)]
 pub struct Ps {
     /// format to display processes: table or json (default: "table")
-    #[clap(short, long, default_value = "table")]
+    #[arg(short, long, default_value = "table")]
     pub format: String,
     /// Container identifier
-    #[clap(value_parser = clap::builder::NonEmptyStringValueParser::new(), required = true)]
+    #[arg(value_parser = clap::builder::NonEmptyStringValueParser::new(), required = true)]
     pub container_id: String,
     /// options will be passed to the ps utility
-    #[clap(trailing_var_arg = true)]
+    #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
     pub ps_options: Vec<String>,
 }

--- a/crates/liboci-cli/src/resume.rs
+++ b/crates/liboci-cli/src/resume.rs
@@ -1,9 +1,9 @@
-use clap::Parser;
+use clap::Args;
 
 /// Resume the processes within the container
-#[derive(Parser, Debug)]
+#[derive(Args, Debug)]
 pub struct Resume {
     /// Container identifier
-    #[clap(value_parser = clap::builder::NonEmptyStringValueParser::new(), required = true)]
+    #[arg(value_parser = clap::builder::NonEmptyStringValueParser::new(), required = true)]
     pub container_id: String,
 }

--- a/crates/liboci-cli/src/run.rs
+++ b/crates/liboci-cli/src/run.rs
@@ -1,39 +1,39 @@
 use std::path::PathBuf;
 
-use clap::Parser;
+use clap::Args;
 
 /// Create a container and immediately start it
-#[derive(Parser, Debug)]
+#[derive(Args, Debug)]
 pub struct Run {
     /// Path to the bundle directory, containing config.json and root filesystem
-    #[clap(short, long, default_value = ".")]
+    #[arg(short, long, default_value = ".")]
     pub bundle: PathBuf,
     /// Unix socket (file) path , which will receive file descriptor of the writing end of the pseudoterminal
-    #[clap(short, long)]
+    #[arg(short, long)]
     pub console_socket: Option<PathBuf>,
     /// File to write pid of the container created
     // note that in the end, container is just another process
-    #[clap(short, long)]
+    #[arg(short, long)]
     pub pid_file: Option<PathBuf>,
     /// Disable the use of the subreaper used to reap reparented processes
-    #[clap(long)]
+    #[arg(long)]
     pub no_subreaper: bool,
     /// Do not use pivot root to jail process inside rootfs
-    #[clap(long)]
+    #[arg(long)]
     pub no_pivot: bool,
     /// Do not create a new session keyring for the container. This will cause the container to inherit the calling processes session key.
-    #[clap(long)]
+    #[arg(long)]
     pub no_new_keyring: bool,
     /// Pass N additional file descriptors to the container (stdio + $LISTEN_FDS + N in total)
-    #[clap(long, default_value = "0")]
+    #[arg(long, default_value = "0")]
     pub preserve_fds: i32,
     /// Keep container's state directory and cgroup after the container exits
-    #[clap(long)]
+    #[arg(long)]
     pub keep: bool,
     /// name of the container instance to be started
-    #[clap(value_parser = clap::builder::NonEmptyStringValueParser::new(), required = true)]
+    #[arg(value_parser = clap::builder::NonEmptyStringValueParser::new(), required = true)]
     pub container_id: String,
     /// Detach from the container process
-    #[clap(short, long)]
+    #[arg(short, long)]
     pub detach: bool,
 }

--- a/crates/liboci-cli/src/spec.rs
+++ b/crates/liboci-cli/src/spec.rs
@@ -1,15 +1,15 @@
 use std::path::PathBuf;
 
-use clap::Parser;
+use clap::Args;
 
 /// Command generates a config.json
-#[derive(Parser, Debug)]
+#[derive(Args, Debug)]
 pub struct Spec {
     /// Set path to the root of the bundle directory
-    #[clap(long, short)]
+    #[arg(long, short)]
     pub bundle: Option<PathBuf>,
 
     /// Generate a configuration for a rootless container
-    #[clap(long)]
+    #[arg(long)]
     pub rootless: bool,
 }

--- a/crates/liboci-cli/src/start.rs
+++ b/crates/liboci-cli/src/start.rs
@@ -1,9 +1,9 @@
-use clap::Parser;
+use clap::Args;
 
 /// Start a previously created container
-#[derive(Parser, Debug)]
+#[derive(Args, Debug)]
 pub struct Start {
     /// Container identifier
-    #[clap(value_parser = clap::builder::NonEmptyStringValueParser::new(), required = true)]
+    #[arg(value_parser = clap::builder::NonEmptyStringValueParser::new(), required = true)]
     pub container_id: String,
 }

--- a/crates/liboci-cli/src/state.rs
+++ b/crates/liboci-cli/src/state.rs
@@ -1,9 +1,9 @@
-use clap::Parser;
+use clap::Args;
 
 /// Show the container state
-#[derive(Parser, Debug)]
+#[derive(Args, Debug)]
 pub struct State {
     /// Container identifier
-    #[clap(value_parser = clap::builder::NonEmptyStringValueParser::new(), required = true)]
+    #[arg(value_parser = clap::builder::NonEmptyStringValueParser::new(), required = true)]
     pub container_id: String,
 }

--- a/crates/liboci-cli/src/update.rs
+++ b/crates/liboci-cli/src/update.rs
@@ -1,72 +1,72 @@
 use std::path::PathBuf;
 
-use clap::Parser;
+use clap::Args;
 
 /// Update running container resource constraints
-#[derive(Parser, Debug)]
+#[derive(Args, Debug)]
 pub struct Update {
     /// Read the new resource limits from the given json file. Use - to read from stdin.
     /// If this option is used, all other options are ignored.
-    #[clap(short, long)]
+    #[arg(short, long)]
     pub resources: Option<PathBuf>,
 
     /// Set a new I/O weight
-    #[clap(long)]
+    #[arg(long)]
     pub blkio_weight: Option<u64>,
 
     /// Set CPU CFS period to be used for hardcapping (in microseconds)
-    #[clap(long)]
+    #[arg(long)]
     pub cpu_period: Option<u64>,
 
     /// Set CPU usage limit within a given period (in microseconds)
-    #[clap(long)]
+    #[arg(long)]
     pub cpu_quota: Option<u64>,
 
     /// Set CPU realtime period to be used for hardcapping (in microseconds)
-    #[clap(long)]
+    #[arg(long)]
     pub cpu_rt_period: Option<u64>,
 
     /// Set CPU realtime hardcap limit (in microseconds)
-    #[clap(long)]
+    #[arg(long)]
     pub cpu_rt_runtime: Option<u64>,
 
     /// Set CPU shares (relative weight vs. other containers)
-    #[clap(long)]
+    #[arg(long)]
     pub cpu_share: Option<u64>,
 
     /// Set CPU(s) to use. The list can contain commas and ranges. For example: 0-3,7
-    #[clap(long)]
+    #[arg(long)]
     pub cpuset_cpus: Option<String>,
 
     /// Set memory node(s) to use. The list format is the same as for --cpuset-cpus.
-    #[clap(long)]
+    #[arg(long)]
     pub cpuset_mems: Option<String>,
 
     /// Set memory limit to num bytes.
-    #[clap(long)]
+    #[arg(long)]
     pub memory: Option<u64>,
 
     /// Set memory reservation (or soft limit) to num bytes.
-    #[clap(long)]
+    #[arg(long)]
     pub memory_reservation: Option<u64>,
 
     /// Set total memory + swap usage to num bytes. Use -1 to unset the limit (i.e. use unlimited swap).
-    #[clap(long)]
+    #[arg(long)]
     pub memory_swap: Option<i64>,
 
     /// Set the maximum number of processes allowed in the container
-    #[clap(long)]
+    #[arg(long)]
     pub pids_limit: Option<i64>,
 
     /// Set the value for Intel RDT/CAT L3 cache schema.
-    #[clap(long)]
+    #[arg(long)]
     pub l3_cache_schema: Option<String>,
 
     /// Set the Intel RDT/MBA memory bandwidth schema.
-    #[clap(long)]
+    #[arg(long)]
     pub mem_bw_schema: Option<String>,
 
     /// Container identifier
-    #[clap(value_parser = clap::builder::NonEmptyStringValueParser::new(), required = true)]
+    #[arg(value_parser = clap::builder::NonEmptyStringValueParser::new(), required = true)]
     pub container_id: String,
 }

--- a/crates/youki/src/commands/completion.rs
+++ b/crates/youki/src/commands/completion.rs
@@ -1,13 +1,13 @@
 use std::io;
 
 use anyhow::Result;
-use clap::{Command, Parser};
+use clap::{Args, Command};
 use clap_complete::{Shell, generate};
 
-#[derive(Debug, Parser)]
+#[derive(Debug, Args)]
 /// Generate scripts for shell completion
 pub struct Completion {
-    #[clap(long = "shell", short = 's', value_enum)]
+    #[arg(long = "shell", short = 's', value_enum)]
     pub shell: Shell,
 }
 

--- a/crates/youki/src/commands/info.rs
+++ b/crates/youki/src/commands/info.rs
@@ -5,13 +5,13 @@ use std::fs;
 use std::path::Path;
 
 use anyhow::Result;
-use clap::Parser;
+use clap::Args;
 #[cfg(feature = "v2")]
 use libcgroups::{common::CgroupSetup, v2::controller_type::ControllerType};
 use libcontainer::user_ns;
 use procfs::{CpuInfo, Current, Meminfo};
 /// Show information about the system
-#[derive(Parser, Debug)]
+#[derive(Args, Debug)]
 pub struct Info {}
 
 pub fn info(_: Info) -> Result<()> {

--- a/crates/youki/src/main.rs
+++ b/crates/youki/src/main.rs
@@ -7,20 +7,20 @@ mod rootpath;
 mod workload;
 
 use anyhow::{Context, Result};
-use clap::{CommandFactory, Parser};
+use clap::{Args, CommandFactory, Parser, Subcommand};
 use libcontainer::syscall::syscall::create_syscall;
 use liboci_cli::{CommonCmd, GlobalOpts, StandardCmd};
 
 use crate::commands::info;
 
 // Additional options that are not defined in OCI runtime-spec, but are used by Youki.
-#[derive(Parser, Debug)]
+#[derive(Args, Debug)]
 struct YoukiExtendOpts {
     /// Enable logging to systemd-journald
-    #[clap(long)]
+    #[arg(long)]
     pub systemd_log: bool,
     /// set the log level (default is 'error')
-    #[clap(long)]
+    #[arg(long)]
     pub log_level: Option<String>,
 }
 
@@ -28,31 +28,31 @@ struct YoukiExtendOpts {
 // This takes global options as well as individual commands as specified in [OCI runtime-spec](https://github.com/opencontainers/runtime-spec/blob/master/runtime.md)
 // Also check [runc commandline documentation](https://github.com/opencontainers/runc/blob/master/man/runc.8.md) for more explanation
 #[derive(Parser, Debug)]
-#[clap(author = env!("CARGO_PKG_AUTHORS"))]
+#[command(author = env!("CARGO_PKG_AUTHORS"))]
 #[command(version, disable_version_flag = true)]
 struct Opts {
-    #[clap(flatten)]
+    #[command(flatten)]
     global: GlobalOpts,
 
-    #[clap(flatten)]
+    #[command(flatten)]
     youki_extend: YoukiExtendOpts,
 
-    #[clap(subcommand)]
-    subcmd: Option<SubCommand>,
+    #[command(subcommand)]
+    subcmd: Option<YoukiSubCommand>,
 
     /// Display youki version and commit hash
-    #[clap(short, long)]
+    #[arg(short, long)]
     version: bool,
 }
 
 // Subcommands accepted by Youki, confirming with [OCI runtime-spec](https://github.com/opencontainers/runtime-spec/blob/master/runtime.md)
 // Also for a short information, check [runc commandline documentation](https://github.com/opencontainers/runc/blob/master/man/runc.8.md)
-#[derive(Parser, Debug)]
-enum SubCommand {
+#[derive(Subcommand, Debug)]
+enum YoukiSubCommand {
     // Standard and common commands handled by the liboci_cli crate
-    #[clap(flatten)]
+    #[command(flatten)]
     Standard(Box<liboci_cli::StandardCmd>),
-    #[clap(flatten)]
+    #[command(flatten)]
     Common(Box<liboci_cli::CommonCmd>),
 
     // Youki specific extensions
@@ -99,7 +99,7 @@ fn main() -> Result<()> {
     let systemd_cgroup = opts.global.systemd_cgroup;
 
     let cmd_result = match opts.subcmd {
-        Some(SubCommand::Standard(cmd)) => match *cmd {
+        Some(YoukiSubCommand::Standard(cmd)) => match *cmd {
             StandardCmd::Create(create) => {
                 commands::create::create(create, root_path, systemd_cgroup)
             }
@@ -108,7 +108,7 @@ fn main() -> Result<()> {
             StandardCmd::Delete(delete) => commands::delete::delete(delete, root_path),
             StandardCmd::State(state) => commands::state::state(state, root_path),
         },
-        Some(SubCommand::Common(cmd)) => match *cmd {
+        Some(YoukiSubCommand::Common(cmd)) => match *cmd {
             CommonCmd::Checkpointt(checkpoint) => {
                 commands::checkpoint::checkpoint(checkpoint, root_path)
             }
@@ -136,8 +136,8 @@ fn main() -> Result<()> {
             CommonCmd::Update(update) => commands::update::update(update, root_path),
         },
 
-        Some(SubCommand::Info(info)) => commands::info::info(info),
-        Some(SubCommand::Completion(completion)) => {
+        Some(YoukiSubCommand::Info(info)) => commands::info::info(info),
+        Some(YoukiSubCommand::Completion(completion)) => {
             commands::completion::completion(completion, &mut app)
         }
         None => app

--- a/docs/src/developer/liboci_cli.md
+++ b/docs/src/developer/liboci_cli.md
@@ -2,6 +2,6 @@
 
 This crate was separated from original youki crate, and now contains a standalone implementation of structs needed for parsing commandline arguments for OCI-spec compliant runtime commandline interface. This is in turn used by youki to parse the command line arguments passed to it, but can be used in any other projects where there is need to parse OCI spec based commandline arguments.
 
-This primarily uses the [crate clap-v3](https://docs.rs/clap/latest/clap/index.html) for parsing the actual commandline arguments given to the runtime.
+This primarily uses the [crate clap-v4](https://docs.rs/clap/latest/clap/index.html) for parsing the actual commandline arguments given to the runtime.
 
 You can refer to [OCI Commandline interface guide](https://github.com/opencontainers/runtime-tools/blob/master/docs/command-line-interface.md) to know more about the exact specification.

--- a/tests/contest/contest/src/main.rs
+++ b/tests/contest/contest/src/main.rs
@@ -4,7 +4,7 @@ mod utils;
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
-use clap::Parser;
+use clap::{Parser, Subcommand};
 use contest::logger;
 use test_framework::TestManager;
 use tests::cgroups;
@@ -59,17 +59,17 @@ use crate::tests::uid_mappings::get_uid_mappings_test;
 use crate::utils::support::{set_runtime_path, set_runtimetest_path};
 
 #[derive(Parser, Debug)]
-#[clap(version = "0.0.1", author = "youki team")]
+#[command(version = "0.0.1", author = "youki team")]
 struct Opts {
     /// Enables debug output
-    #[clap(short, long)]
+    #[arg(short, long)]
     debug: bool,
 
-    #[clap(subcommand)]
+    #[command(subcommand)]
     command: SubCommand,
 }
 
-#[derive(Parser, Debug)]
+#[derive(Subcommand, Debug)]
 enum SubCommand {
     /// run the integration tests
     Run(Run),
@@ -80,15 +80,15 @@ enum SubCommand {
 #[derive(Parser, Debug)]
 struct Run {
     /// Path for the container runtime to be tested
-    #[clap(long)]
+    #[arg(long)]
     runtime: PathBuf,
     /// Path for the runtimetest binary, which will be used to run tests inside the container
-    #[clap(long)]
+    #[arg(long)]
     runtimetest: PathBuf,
     /// Selected tests to be run, format should be
     /// space separated groups, eg
     /// -t group1::test1,test3 group2 group3::test5
-    #[clap(short, long, num_args(1..), value_delimiter = ' ')]
+    #[arg(short, long, num_args(1..), value_delimiter = ' ')]
     tests: Option<Vec<String>>,
 }
 


### PR DESCRIPTION
Updated the CLI definition to use the modern #[command] and #[arg] attributes, as the legacy #[clap] attributes are now deprecated in clap v4.

## Description
<!-- Provide a clear and concise description of your changes -->

## Type of Change
<!-- Mark the appropriate option with an [x] -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test updates
- [ ] CI/CD related changes
- [ ] Other (please describe):

## Testing
<!-- Describe the tests you ran and/or added to verify your changes -->
- [ ] Added new unit tests
- [ ] Added new integration tests
- [ ] Ran existing test suite
- [ ] Tested manually (please provide steps)

## Related Issues
<!-- Link any related issues using the GitHub issue syntax: #issue-number
If there is no open issue for this, please add details of the problem or open a new issue. -->
Fixes #

## Additional Context
<!-- Add any other context about the pull request here -->
