### PR TITLE
Checking source file type with `is_dir()` in bind mount implementation

### DIFF
--- a/crates/libcontainer/src/rootfs/mount.rs
+++ b/crates/libcontainer/src/rootfs/mount.rs
@@ -1022,9 +1022,9 @@ pub fn find_parent_mount(
 mod tests {
     #[cfg(feature = "v1")]
     use std::fs;
-    use std::fs::OpenOptions;
     use std::os::unix::fs::symlink;
     use std::str::FromStr;
+    use std::{fs::OpenOptions, os::unix::net::UnixListener};
 
     use anyhow::{Context, Ok, Result};
 
@@ -1117,6 +1117,39 @@ mod tests {
                     data: None,
                 },
             ];
+            let got = &m
+                .syscall
+                .as_any()
+                .downcast_ref::<TestHelperSyscall>()
+                .unwrap()
+                .get_mount_args();
+            assert_eq!(want, *got);
+            assert_eq!(got.len(), 2);
+        }
+        {
+            // Socket file bind-mount
+            // https://github.com/youki-dev/youki/issues/3483
+            let m = Mount::new();
+            let mount = &SpecMountBuilder::default()
+                .destination(PathBuf::from("/tmp.sock"))
+                .typ("bind")
+                .source(tmp_dir.path().join("tmp.sock"))
+                .build()?;
+            let mount_option_config = parse_mount(mount)?;
+            UnixListener::bind(tmp_dir.path().join("tmp.sock"))?;
+
+            assert!(
+                m.mount_into_container(mount, tmp_dir.path(), &mount_option_config, None)
+                    .is_ok()
+            );
+
+            let want = vec![MountArgs {
+                source: Some(tmp_dir.path().join("null")),
+                target: tmp_dir.path().join("dev/null"),
+                fstype: Some("bind".to_string()),
+                flags: MsFlags::empty(),
+                data: Some("".to_string()),
+            }];
             let got = &m
                 .syscall
                 .as_any()

--- a/crates/libcontainer/src/rootfs/mount.rs
+++ b/crates/libcontainer/src/rootfs/mount.rs
@@ -1022,9 +1022,10 @@ pub fn find_parent_mount(
 mod tests {
     #[cfg(feature = "v1")]
     use std::fs;
+    use std::fs::OpenOptions;
     use std::os::unix::fs::symlink;
+    use std::os::unix::net::UnixListener;
     use std::str::FromStr;
-    use std::{fs::OpenOptions, os::unix::net::UnixListener};
 
     use anyhow::{Context, Ok, Result};
 

--- a/crates/libcontainer/src/rootfs/mount.rs
+++ b/crates/libcontainer/src/rootfs/mount.rs
@@ -1145,8 +1145,8 @@ mod tests {
             );
 
             let want = vec![MountArgs {
-                source: Some(tmp_dir.path().join("null")),
-                target: tmp_dir.path().join("dev/null"),
+                source: Some(tmp_dir.path().join("tmp.sock")),
+                target: tmp_dir.path().join("tmp.sock"),
                 fstype: Some("bind".to_string()),
                 flags: MsFlags::empty(),
                 data: Some("".to_string()),

--- a/crates/libcontainer/src/rootfs/mount.rs
+++ b/crates/libcontainer/src/rootfs/mount.rs
@@ -595,7 +595,9 @@ impl Mount {
                 err
             })?;
 
-            if src.is_file() {
+            if src.is_dir() {
+                root.mkdir_all(container_dest, &dir_perm)?;
+            } else {
                 let parent = container_dest
                     .parent()
                     .ok_or(MountError::Custom("destination has no parent".to_string()))?;
@@ -616,8 +618,6 @@ impl Mount {
                         .map(|_| ())
                         .map_err(|_| create_err),
                 }?;
-            } else {
-                root.mkdir_all(container_dest, &dir_perm)?;
             };
 
             src


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of your changes -->

## Type of Change
<!-- Mark the appropriate option with an [x] -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test updates
- [ ] CI/CD related changes
- [ ] Other (please describe):

## Testing
<!-- Describe the tests you ran and/or added to verify your changes -->
- [x] Added new unit tests
- [ ] Added new integration tests
- [ ] Ran existing test suite
- [x] Tested manually (please provide steps)

## Related Issues
<!-- Link any related issues using the GitHub issue syntax: #issue-number
If there is no open issue for this, please add details of the problem or open a new issue. -->
Fixes #3483

## Additional Context
<!-- Add any other context about the pull request here -->
