### PR TITLE
seccomp: fix multi-condition rule handling and follow runc for duplicate arg comparators

### DIFF
--- a/crates/libcontainer/src/seccomp/mod.rs
+++ b/crates/libcontainer/src/seccomp/mod.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use std::num::TryFromIntError;
 use std::os::unix::io;
 
@@ -213,34 +214,65 @@ pub fn initialize_seccomp(seccomp: &LinuxSeccomp) -> Result<Option<io::RawFd>> {
                     }
                 };
                 match syscall.args() {
+                    // libseccomp allows multiple argument comparisons in a single rule,
+                    // but each syscall argument can only be compared once per rule.
+                    // When multiple comparisons target the same argument index,
+                    // we follow runc's behavior and add each condition as a separate rule.
+                    // Ref: libseccomp seccomp_rule_add(3)
+                    // https://github.com/seccomp/libseccomp/blob/9d7a3cd937e7841ece62ac19f0f06aafd0fdaaa9/doc/man/man3/seccomp_rule_add.3#L137
+                    // Ref: runc seccomp_linux.go
+                    // https://github.com/opencontainers/runc/blob/4b97e12fccdfca981a296d9ef82df5f3ae95e288/libcontainer/seccomp/seccomp_linux.go#L327
                     Some(args) => {
-                        // The `seccomp_rule_add` requires us to break multiple
-                        // args attaching to the same rules into multiple rules.
-                        // Breaking this rule will cause `seccomp_rule_add` to
-                        // return EINVAL.
-                        //
-                        // From the man page: when adding syscall argument
-                        // comparisons to the filter it is important to remember
-                        // that while it is possible to have multiple
-                        // comparisons in a single rule, you can only compare
-                        // each argument once in a single rule.  In other words,
-                        // you can not have multiple comparisons of the 3rd
-                        // syscall argument in a single rule.
+                        let mut comparators = Vec::<ScmpArgCompare>::with_capacity(args.len());
+                        let mut seen = HashSet::new();
+                        let mut has_duplicate_index = false;
+
                         for arg in args {
-                            let cmp = ScmpArgCompare::new(
-                                arg.index() as u32,
+                            let index = arg.index() as u32;
+                            let comparator = ScmpArgCompare::new(
+                                index,
                                 translate_op(arg.op(), arg.value_two()),
                                 arg.value(),
                             );
-                            tracing::trace!(?name, ?action, ?arg, "add seccomp conditional rule");
-                            ctx.add_rule_conditional(action, sc, &[cmp])
+                            if !seen.insert(index) {
+                                has_duplicate_index = true;
+                            }
+                            comparators.push(comparator);
+                        }
+
+                        if has_duplicate_index {
+                            for comparator in &comparators {
+                                tracing::trace!(
+                                    ?name,
+                                    ?action,
+                                    ?comparator,
+                                    "add seccomp conditional rule separately"
+                                );
+                                ctx.add_rule_conditional(action, sc, std::slice::from_ref(comparator))
+                                    .map_err(|err| {
+                                        tracing::error!(
+                                            "failed to add seccomp action: {:?}. Comparator: {:?} Syscall: {name}",
+                                            &action,
+                                            comparator,
+                                        );
+                                        SeccompError::AddRule { source: err }
+                                    })?;
+                            }
+                        } else {
+                            tracing::trace!(
+                                ?name,
+                                ?action,
+                                ?comparators,
+                                "add seccomp conditional rule"
+                            );
+                            ctx.add_rule_conditional(action, sc, &comparators)
                                 .map_err(|err| {
                                     tracing::error!(
-                                        "failed to add seccomp action: {:?}. Cmp: {:?} Syscall: {name}", &action, cmp,
+                                        "failed to add seccomp action: {:?}. Comparators: {:?} Syscall: {name}",
+                                        &action,
+                                        comparators,
                                     );
-                                    SeccompError::AddRule {
-                                        source: err,
-                                    }
+                                    SeccompError::AddRule { source: err }
                                 })?;
                         }
                     }
@@ -291,7 +323,9 @@ mod tests {
     use std::path;
 
     use anyhow::{Context, Result};
-    use oci_spec::runtime::{Arch, LinuxSeccompBuilder, LinuxSyscallBuilder};
+    use oci_spec::runtime::{
+        Arch, LinuxSeccompArgBuilder, LinuxSeccompBuilder, LinuxSyscallBuilder,
+    };
     use serial_test::serial;
 
     use super::*;
@@ -389,6 +423,128 @@ mod tests {
                     "failed to get a seccomp notify fd with notify seccomp profile".to_string(),
                 ))?;
             }
+
+            Ok(())
+        })?;
+
+        Ok(())
+    }
+
+    #[test]
+    #[serial]
+    fn test_seccomp_conditional_rule_multiple_distinct_args() -> Result<()> {
+        let syscall = LinuxSyscallBuilder::default()
+            .names(vec![String::from("socket")])
+            .action(LinuxSeccompAction::ScmpActErrno)
+            .errno_ret(libc::EAGAIN as u32)
+            .args(vec![
+                LinuxSeccompArgBuilder::default()
+                    .index(0_usize)
+                    .value(libc::AF_INET as u64)
+                    .op(LinuxSeccompOperator::ScmpCmpEq)
+                    .build()?,
+                LinuxSeccompArgBuilder::default()
+                    .index(1_usize)
+                    .value(libc::SOCK_STREAM as u64)
+                    .op(LinuxSeccompOperator::ScmpCmpEq)
+                    .build()?,
+            ])
+            .build()?;
+
+        let seccomp_profile = LinuxSeccompBuilder::default()
+            .default_action(LinuxSeccompAction::ScmpActAllow)
+            .architectures(vec![Arch::ScmpArchNative])
+            .syscalls(vec![syscall])
+            .build()?;
+
+        test_utils::test_in_child_process(|| {
+            let _ = prctl::set_no_new_privileges(true);
+            initialize_seccomp(&seccomp_profile).expect("failed to initialize seccomp");
+            Ok(())
+        })?;
+
+        Ok(())
+    }
+
+    #[test]
+    #[serial]
+    fn test_seccomp_conditional_rule_duplicate_arg_index() -> Result<()> {
+        let syscall = LinuxSyscallBuilder::default()
+            .names(vec![String::from("socket")])
+            .action(LinuxSeccompAction::ScmpActErrno)
+            .errno_ret(libc::EAGAIN as u32)
+            .args(vec![
+                LinuxSeccompArgBuilder::default()
+                    .index(0_usize)
+                    .value(libc::AF_INET as u64)
+                    .op(LinuxSeccompOperator::ScmpCmpEq)
+                    .build()?,
+                LinuxSeccompArgBuilder::default()
+                    .index(0_usize)
+                    .value(libc::AF_UNIX as u64)
+                    .op(LinuxSeccompOperator::ScmpCmpNe)
+                    .build()?,
+            ])
+            .build()?;
+
+        let seccomp_profile = LinuxSeccompBuilder::default()
+            .default_action(LinuxSeccompAction::ScmpActAllow)
+            .architectures(vec![Arch::ScmpArchNative])
+            .syscalls(vec![syscall])
+            .build()?;
+
+        test_utils::test_in_child_process(|| {
+            let _ = prctl::set_no_new_privileges(true);
+            initialize_seccomp(&seccomp_profile).expect("failed to initialize seccomp");
+            Ok(())
+        })?;
+
+        Ok(())
+    }
+
+    #[test]
+    #[serial]
+    fn test_seccomp_multiple_syscall_entries_for_same_name() -> Result<()> {
+        let rule1 = LinuxSyscallBuilder::default()
+            .names(vec!["socket".into()])
+            .action(LinuxSeccompAction::ScmpActErrno)
+            .errno_ret(libc::EAGAIN as u32)
+            .args(vec![
+                LinuxSeccompArgBuilder::default()
+                    .index(0_usize)
+                    .value(libc::AF_NETLINK as u64)
+                    .op(LinuxSeccompOperator::ScmpCmpEq)
+                    .build()?,
+                LinuxSeccompArgBuilder::default()
+                    .index(2_usize)
+                    .value(libc::NETLINK_AUDIT as u64)
+                    .op(LinuxSeccompOperator::ScmpCmpNe)
+                    .build()?,
+            ])
+            .build()?;
+
+        let rule2 = LinuxSyscallBuilder::default()
+            .names(vec!["socket".into()])
+            .action(LinuxSeccompAction::ScmpActErrno)
+            .errno_ret(libc::EAGAIN as u32)
+            .args(vec![
+                LinuxSeccompArgBuilder::default()
+                    .index(0_usize)
+                    .value(libc::AF_INET as u64)
+                    .op(LinuxSeccompOperator::ScmpCmpNe)
+                    .build()?,
+            ])
+            .build()?;
+
+        let profile = LinuxSeccompBuilder::default()
+            .default_action(LinuxSeccompAction::ScmpActAllow)
+            .architectures(vec![Arch::ScmpArchNative])
+            .syscalls(vec![rule1, rule2])
+            .build()?;
+
+        test_utils::test_in_child_process(|| {
+            let _ = prctl::set_no_new_privileges(true);
+            initialize_seccomp(&profile).expect("failed to initialize seccomp");
 
             Ok(())
         })?;


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of your changes -->

I fixed a bug related to seccomp.

### Fixed the behavior when multiple syscall arguments are specified

When multiple syscall arguments are specified, they must be evaluated with AND semantics.

For example, when a seccomp syscall entry like the following is specified, the two arguments should be combined with AND semantics:

```
        {
          "names": [
            "socket"
          ],
          "action": "SCMP_ACT_ALLOW",
          "args": [
            {
              "index": 0,
              "value": 16,
              "op": "SCMP_CMP_EQ"
            },
            {
              "index": 2,
              "value": 9,
              "op": "SCMP_CMP_NE"
            }
          ]
        }
```

To implement this, the args can be passed directly to `add_rule_conditional` as comparators.

### Align seccomp argument condition handling with runc

If multiple syscalls are specified with the same argument condition, as in the example below, the condition should be applied to each syscall individually. This follows the behavior of runc.

https://github.com/opencontainers/runc/blob/main/libcontainer/seccomp/seccomp_linux.go#L327

```
        {
          "names": [
            "clone"
          ],
          "action": "SCMP_ACT_ERRNO",
          "errnoRet": 1,
          "args": [
            {
              "index": 0,
              "value": 131072,
              "valueTwo": 131072,
              "op": "SCMP_CMP_MASKED_EQ"
            },
            {
              "index": 0,
              "value": 67108864,
              "valueTwo": 67108864,
              "op": "SCMP_CMP_MASKED_EQ"
            },
...
```


## Type of Change
<!-- Mark the appropriate option with an [x] -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test updates
- [ ] CI/CD related changes
- [ ] Other (please describe):

## Testing
<!-- Describe the tests you ran and/or added to verify your changes -->
- [x] Added new unit tests
- [ ] Added new integration tests
- [x] Ran existing test suite
- [x] Tested manually (please provide steps)

## Related Issues
<!-- Link any related issues using the GitHub issue syntax: #issue-number
If there is no open issue for this, please add details of the problem or open a new issue. -->
Fixed #3479

## Additional Context
<!-- Add any other context about the pull request here -->

The following command completed successfully.
For the detailed configuration, please refer to the issue.

```
/usr/local/bin/crictl run --with-pull --runtime youki /tmp/container.json /tmp/sandbox.json
```

Execution with the following `config.json` using `youki` succeeded.

<details>
<summary>config.json</summary>

```json
{
  "ociVersion": "1.0.2-dev",
  "root": {
    "path": "rootfs",
    "readonly": true
  },
  "mounts": [
    {
      "destination": "/proc",
      "type": "proc",
      "source": "proc"
    },
    {
      "destination": "/dev",
      "type": "tmpfs",
      "source": "tmpfs",
      "options": [
        "nosuid",
        "strictatime",
        "mode=755",
        "size=65536k"
      ]
    },
    {
      "destination": "/dev/pts",
      "type": "devpts",
      "source": "devpts",
      "options": [
        "nosuid",
        "noexec",
        "newinstance",
        "ptmxmode=0666",
        "mode=0620",
        "gid=5"
      ]
    },
    {
      "destination": "/dev/shm",
      "type": "tmpfs",
      "source": "shm",
      "options": [
        "nosuid",
        "noexec",
        "nodev",
        "mode=1777",
        "size=65536k"
      ]
    },
    {
      "destination": "/dev/mqueue",
      "type": "mqueue",
      "source": "mqueue",
      "options": [
        "nosuid",
        "noexec",
        "nodev"
      ]
    },
    {
      "destination": "/sys",
      "type": "sysfs",
      "source": "sysfs",
      "options": [
        "nosuid",
        "noexec",
        "nodev",
        "ro"
      ]
    },
    {
      "destination": "/sys/fs/cgroup",
      "type": "cgroup",
      "source": "cgroup",
      "options": [
        "nosuid",
        "noexec",
        "nodev",
        "relatime",
        "ro"
      ]
    }
  ],
  "process": {
    "terminal": false,
    "user": {
      "uid": 0,
      "gid": 0
    },
    "args": [
      "sh"
    ],
    "env": [
      "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
      "TERM=xterm"
    ],
    "cwd": "/",
    "capabilities": {
      "bounding": [
        "CAP_NET_BIND_SERVICE",
        "CAP_KILL",
        "CAP_AUDIT_WRITE"
      ],
      "effective": [
        "CAP_NET_BIND_SERVICE",
        "CAP_KILL",
        "CAP_AUDIT_WRITE"
      ],
      "inheritable": [
        "CAP_NET_BIND_SERVICE",
        "CAP_KILL",
        "CAP_AUDIT_WRITE"
      ],
      "permitted": [
        "CAP_NET_BIND_SERVICE",
        "CAP_KILL",
        "CAP_AUDIT_WRITE"
      ],
      "ambient": [
        "CAP_NET_BIND_SERVICE",
        "CAP_KILL",
        "CAP_AUDIT_WRITE"
      ]
    },
    "rlimits": [
      {
        "type": "RLIMIT_NOFILE",
        "hard": 1024,
        "soft": 1024
      }
    ],
    "noNewPrivileges": true
  },
  "hostname": "youki",
  "annotations": {},
  "linux": {
    "seccomp": {
      "defaultAction": "SCMP_ACT_ERRNO",
      "defaultErrnoRet": 38,
      "architectures": [
        "SCMP_ARCH_X86_64",
        "SCMP_ARCH_X86",
        "SCMP_ARCH_X32"
      ],
      "syscalls": [
        {
          "names": [
            "bdflush",
            "cachestat",
            "futex_requeue",
            "futex_wait",
            "futex_waitv",
            "futex_wake",
            "io_pgetevents",
            "io_pgetevents_time64",
            "kexec_file_load",
            "kexec_load",
            "map_shadow_stack",
            "migrate_pages",
            "move_pages",
            "nfsservctl",
            "nice",
            "oldfstat",
            "oldlstat",
            "oldolduname",
            "oldstat",
            "olduname",
            "pciconfig_iobase",
            "pciconfig_read",
            "pciconfig_write",
            "sgetmask",
            "ssetmask",
            "swapoff",
            "swapon",
            "syscall",
            "sysfs",
            "uselib",
            "userfaultfd",
            "ustat",
            "vm86",
            "vm86old",
            "vmsplice"
          ],
          "action": "SCMP_ACT_ERRNO",
          "errnoRet": 1
        },
        {
          "names": [
            "_llseek",
            "_newselect",
            "accept",
            "accept4",
            "access",
            "adjtimex",
            "alarm",
            "bind",
            "brk",
            "capget",
            "capset",
            "chdir",
            "chmod",
            "chown",
            "chown32",
            "clock_adjtime",
            "clock_adjtime64",
            "clock_getres",
            "clock_getres_time64",
            "clock_gettime",
            "clock_gettime64",
            "clock_nanosleep",
            "clock_nanosleep_time64",
            "writev",
            "writev",
            "close",
            "close_range",
            "connect",
            "copy_file_range",
            "creat",
            "dup",
            "dup2",
            "dup3",
            "epoll_create",
            "epoll_create1",
            "epoll_ctl",
            "epoll_ctl_old",
            "epoll_pwait",
            "epoll_pwait2",
            "epoll_wait",
            "epoll_wait_old",
            "eventfd",
            "eventfd2",
            "execve",
            "execveat",
            "exit",
            "exit_group",
            "faccessat",
            "faccessat2",
            "fadvise64",
            "fadvise64_64",
            "fallocate",
            "fanotify_init",
            "fanotify_mark",
            "fchdir",
            "fchmod",
            "fchmodat",
            "fchmodat2",
            "fchown",
            "fchown32",
            "fchownat",
            "fcntl",
            "fcntl64",
            "fdatasync",
            "fgetxattr",
            "flistxattr",
            "flock",
            "fork",
            "fremovexattr",
            "fsconfig",
            "fsetxattr",
            "fsmount",
            "fsopen",
            "fspick",
            "fstat",
            "fstat64",
            "fstatat64",
            "fstatfs",
            "fstatfs64",
            "fsync",
            "ftruncate",
            "ftruncate64",
            "futex",
            "futex_time64",
            "futimesat",
            "get_mempolicy",
            "get_robust_list",
            "get_thread_area",
            "getcpu",
            "getcwd",
            "getdents",
            "getdents64",
            "getegid",
            "getegid32",
            "geteuid",
            "geteuid32",
            "getgid",
            "getgid32",
            "getgroups",
            "getgroups32",
            "getitimer",
            "getpeername",
            "getpgid",
            "getpgrp",
            "getpid",
            "getppid",
            "getpriority",
            "getrandom",
            "getresgid",
            "getresgid32",
            "getresuid",
            "getresuid32",
            "getrlimit",
            "getrusage",
            "getsid",
            "getsockname",
            "getsockopt",
            "gettid",
            "gettimeofday",
            "getuid",
            "getuid32",
            "getxattr",
            "inotify_add_watch",
            "inotify_init",
            "inotify_init1",
            "inotify_rm_watch",
            "io_cancel",
            "io_destroy",
            "io_getevents",
            "io_setup",
            "io_submit",
            "ioctl",
            "ioprio_get",
            "ioprio_set",
            "ipc",
            "keyctl",
            "kill",
            "landlock_add_rule",
            "landlock_create_ruleset",
            "landlock_restrict_self",
            "lchown",
            "lchown32",
            "lgetxattr",
            "link",
            "linkat",
            "listen",
            "listxattr",
            "llistxattr",
            "lremovexattr",
            "lseek",
            "lsetxattr",
            "lstat",
            "lstat64",
            "madvise",
            "mbind",
            "membarrier",
            "memfd_create",
            "memfd_secret",
            "mincore",
            "mkdir",
            "mkdirat",
            "mknod",
            "mknodat",
            "mlock",
            "mlock2",
            "mlockall",
            "mmap",
            "mmap2",
            "mount",
            "mount_setattr",
            "move_mount",
            "mprotect",
            "mq_getsetattr",
            "mq_notify",
            "mq_open",
            "mq_timedreceive",
            "mq_timedreceive_time64",
            "mq_timedsend",
            "mq_timedsend_time64",
            "mq_unlink",
            "mremap",
            "msgctl",
            "msgget",
            "msgrcv",
            "msgsnd",
            "msync",
            "munlock",
            "munlockall",
            "munmap",
            "name_to_handle_at",
            "nanosleep",
            "newfstatat",
            "open",
            "open_tree",
            "openat",
            "openat2",
            "pause",
            "pidfd_getfd",
            "pidfd_open",
            "pidfd_send_signal",
            "pipe",
            "pipe2",
            "pivot_root",
            "pkey_alloc",
            "pkey_free",
            "pkey_mprotect",
            "poll",
            "ppoll",
            "ppoll_time64",
            "prctl",
            "pread64",
            "preadv",
            "preadv2",
            "prlimit64",
            "process_mrelease",
            "process_vm_readv",
            "process_vm_writev",
            "pselect6",
            "pselect6_time64",
            "ptrace",
            "pwrite64",
            "pwritev",
            "pwritev2",
            "read",
            "readahead",
            "readlink",
            "readlinkat",
            "readv",
            "reboot",
            "recv",
            "recvfrom",
            "recvmmsg",
            "recvmmsg_time64",
            "recvmsg",
            "remap_file_pages",
            "removexattr",
            "rename",
            "renameat",
            "renameat2",
            "restart_syscall",
            "rmdir",
            "rseq",
            "rt_sigaction",
            "rt_sigpending",
            "rt_sigprocmask",
            "rt_sigqueueinfo",
            "rt_sigreturn",
            "rt_sigsuspend",
            "rt_sigtimedwait",
            "rt_sigtimedwait_time64",
            "rt_tgsigqueueinfo",
            "sched_get_priority_max",
            "sched_get_priority_min",
            "sched_getaffinity",
            "sched_getattr",
            "sched_getparam",
            "sched_getscheduler",
            "sched_rr_get_interval",
            "sched_rr_get_interval_time64",
            "sched_setaffinity",
            "sched_setattr",
            "sched_setparam",
            "sched_setscheduler",
            "sched_yield",
            "seccomp",
            "select",
            "semctl",
            "semget",
            "semop",
            "semtimedop",
            "semtimedop_time64",
            "send",
            "sendfile",
            "sendfile64",
            "sendmmsg",
            "sendmsg",
            "sendto",
            "set_mempolicy",
            "set_robust_list",
            "set_thread_area",
            "set_tid_address",
            "setfsgid",
            "setfsgid32",
            "setfsuid",
            "setfsuid32",
            "setgid",
            "setgid32",
            "setgroups",
            "setgroups32",
            "setitimer",
            "setns",
            "setpgid",
            "setpriority",
            "setregid",
            "setregid32",
            "setresgid",
            "setresgid32",
            "setresuid",
            "setresuid32",
            "setreuid",
            "setreuid32",
            "setrlimit",
            "setsid",
            "setsockopt",
            "setuid",
            "setuid32",
            "setxattr",
            "shmat",
            "shmctl",
            "shmdt",
            "shmget",
            "shutdown",
            "sigaltstack",
            "signal",
            "signalfd",
            "signalfd4",
            "sigprocmask",
            "sigreturn",
            "socketcall",
            "socketpair",
            "splice",
            "stat",
            "stat64",
            "statfs",
            "statfs64",
            "statx",
            "symlink",
            "symlinkat",
            "sync",
            "sync_file_range",
            "syncfs",
            "sysinfo",
            "syslog",
            "tee",
            "tgkill",
            "time",
            "timer_create",
            "timer_delete",
            "timer_getoverrun",
            "timer_gettime",
            "timer_gettime64",
            "timer_settime",
            "timer_settime64",
            "timerfd_create",
            "timerfd_gettime",
            "timerfd_gettime64",
            "timerfd_settime",
            "timerfd_settime64",
            "times",
            "tkill",
            "truncate",
            "truncate64",
            "ugetrlimit",
            "umask",
            "umount",
            "umount2",
            "uname",
            "unlink",
            "unlinkat",
            "writev",
            "utime",
            "utimensat",
            "utimensat_time64",
            "utimes",
            "vfork",
            "wait4",
            "waitid",
            "waitpid",
            "write",
            "writev"
          ],
          "action": "SCMP_ACT_ALLOW"
        },
        {
          "names": [
            "personality"
          ],
          "action": "SCMP_ACT_ALLOW",
          "args": [
            {
              "index": 0,
              "value": 0,
              "op": "SCMP_CMP_EQ"
            }
          ]
        },
        {
          "names": [
            "personality"
          ],
          "action": "SCMP_ACT_ALLOW",
          "args": [
            {
              "index": 0,
              "value": 8,
              "op": "SCMP_CMP_EQ"
            }
          ]
        },
        {
          "names": [
            "personality"
          ],
          "action": "SCMP_ACT_ALLOW",
          "args": [
            {
              "index": 0,
              "value": 131072,
              "op": "SCMP_CMP_EQ"
            }
          ]
        },
        {
          "names": [
            "personality"
          ],
          "action": "SCMP_ACT_ALLOW",
          "args": [
            {
              "index": 0,
              "value": 131080,
              "op": "SCMP_CMP_EQ"
            }
          ]
        },
        {
          "names": [
            "personality"
          ],
          "action": "SCMP_ACT_ALLOW",
          "args": [
            {
              "index": 0,
              "value": 4294967295,
              "op": "SCMP_CMP_EQ"
            }
          ]
        },
        {
          "names": [
            "arch_prctl"
          ],
          "action": "SCMP_ACT_ALLOW"
        },
        {
          "names": [
            "modify_ldt"
          ],
          "action": "SCMP_ACT_ALLOW"
        },
        {
          "names": [
            "open_by_handle_at"
          ],
          "action": "SCMP_ACT_ERRNO",
          "errnoRet": 1
        },
        {
          "names": [
            "lookup_dcookie",
            "quotactl",
            "quotactl_fd",
            "setdomainname",
            "sethostname",
            "setns"
          ],
          "action": "SCMP_ACT_ERRNO",
          "errnoRet": 1
        },
        {
          "names": [
            "chroot"
          ],
          "action": "SCMP_ACT_ERRNO",
          "errnoRet": 1
        },
        {
          "names": [
            "delete_module",
            "finit_module",
            "init_module",
            "query_module"
          ],
          "action": "SCMP_ACT_ERRNO",
          "errnoRet": 1
        },
        {
          "names": [
            "acct"
          ],
          "action": "SCMP_ACT_ERRNO",
          "errnoRet": 1
        },
        {
          "names": [
            "kcmp",
            "process_madvise"
          ],
          "action": "SCMP_ACT_ERRNO",
          "errnoRet": 1
        },
        {
          "names": [
            "ioperm",
            "iopl"
          ],
          "action": "SCMP_ACT_ERRNO",
          "errnoRet": 1
        },
        {
          "names": [
            "clock_settime",
            "clock_settime64",
            "settimeofday",
            "stime"
          ],
          "action": "SCMP_ACT_ERRNO",
          "errnoRet": 1
        },
        {
          "names": [
            "vhangup"
          ],
          "action": "SCMP_ACT_ERRNO",
          "errnoRet": 1
        },
        {
          "names": [
            "socket"
          ],
          "action": "SCMP_ACT_ERRNO",
          "errnoRet": 1,
          "args": [
            {
              "index": 0,
              "value": 40,
              "op": "SCMP_CMP_EQ"
            }
          ]
        },
        {
          "names": [
            "socket"
          ],
          "action": "SCMP_ACT_ERRNO",
          "errnoRet": 22,
          "args": [
            {
              "index": 0,
              "value": 16,
              "op": "SCMP_CMP_EQ"
            },
            {
              "index": 2,
              "value": 9,
              "op": "SCMP_CMP_EQ"
            }
          ]
        },
        {
          "names": [
            "socket"
          ],
          "action": "SCMP_ACT_ALLOW",
          "args": [
            {
              "index": 0,
              "value": 16,
              "op": "SCMP_CMP_EQ"
            },
            {
              "index": 2,
              "value": 9,
              "op": "SCMP_CMP_NE"
            }
          ]
        },
        {
          "names": [
            "socket"
          ],
          "action": "SCMP_ACT_ALLOW",
          "args": [
            {
              "index": 0,
              "value": 16,
              "op": "SCMP_CMP_NE"
            }
          ]
        },
        {
          "names": [
            "bpf"
          ],
          "action": "SCMP_ACT_ERRNO",
          "errnoRet": 1
        },
        {
          "names": [
            "perf_event_open"
          ],
          "action": "SCMP_ACT_ERRNO",
          "errnoRet": 1
        },
        {
          "names": [
            "clone"
          ],
          "action": "SCMP_ACT_ALLOW",
          "args": [
            {
              "index": 0,
              "value": 2114060288,
              "op": "SCMP_CMP_MASKED_EQ"
            }
          ]
        },
        {
          "names": [
            "clone"
          ],
          "action": "SCMP_ACT_ERRNO",
          "errnoRet": 1,
          "args": [
            {
              "index": 0,
              "value": 131072,
              "valueTwo": 131072,
              "op": "SCMP_CMP_MASKED_EQ"
            },
            {
              "index": 0,
              "value": 67108864,
              "valueTwo": 67108864,
              "op": "SCMP_CMP_MASKED_EQ"
            },
            {
              "index": 0,
              "value": 134217728,
              "valueTwo": 134217728,
              "op": "SCMP_CMP_MASKED_EQ"
            },
            {
              "index": 0,
              "value": 268435456,
              "valueTwo": 268435456,
              "op": "SCMP_CMP_MASKED_EQ"
            },
            {
              "index": 0,
              "value": 536870912,
              "valueTwo": 536870912,
              "op": "SCMP_CMP_MASKED_EQ"
            },
            {
              "index": 0,
              "value": 1073741824,
              "valueTwo": 1073741824,
              "op": "SCMP_CMP_MASKED_EQ"
            },
            {
              "index": 0,
              "value": 33554432,
              "valueTwo": 33554432,
              "op": "SCMP_CMP_MASKED_EQ"
            }
          ]
        },
        {
          "names": [
            "clone3"
          ],
          "action": "SCMP_ACT_ERRNO",
          "errnoRet": 38
        }
      ]
    },
    "resources": {
      "devices": []
    },
    "namespaces": [
      {
        "type": "pid"
      },
      {
        "type": "network"
      },
      {
        "type": "ipc"
      },
      {
        "type": "uts"
      },
      {
        "type": "mount"
      },
      {
        "type": "cgroup"
      }
    ],
    "maskedPaths": [
      "/proc/acpi",
      "/proc/asound",
      "/proc/kcore",
      "/proc/keys",
      "/proc/latency_stats",
      "/proc/timer_list",
      "/proc/timer_stats",
      "/proc/sched_debug",
      "/sys/firmware",
      "/proc/scsi"
    ],
    "readonlyPaths": [
      "/proc/bus",
      "/proc/fs",
      "/proc/irq",
      "/proc/sys",
      "/proc/sysrq-trigger"
    ]
  }
}
```
</details>