### PR TITLE
chore(dependabot): temporarily disable Cargo version update PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,9 @@ updates:
     directory: "."
     schedule:
       interval: daily
-    open-pull-requests-limit: 10
+    # Temporarily disable Dependabot version update PRs for Cargo.
+    # Re-enable this after https://github.com/youki-dev/youki/pull/3477 is merged.
+    open-pull-requests-limit: 0
     allow:
       - dependency-type: direct
     groups:


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of your changes -->

Temporarily disable automatic Cargo version update PRs from Dependabot.

PR #3477 contains substantial Cargo-related changes. If Dependabot update PRs are auto-merged before it is merged, they are likely to create conflicts with #3477.

To avoid that, this change temporarily sets `open-pull-requests-limit` to `0` for Cargo updates.

This is intended to be a temporary change. We should re-enable Dependabot version update PRs once #3477 is merged.

## Type of Change
<!-- Mark the appropriate option with an [x] -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test updates
- [ ] CI/CD related changes
- [x] Other (please describe):

Temporarily disable automatic Cargo version update PRs from Dependabot.

## Testing
<!-- Describe the tests you ran and/or added to verify your changes -->
- [ ] Added new unit tests
- [ ] Added new integration tests
- [ ] Ran existing test suite
- [ ] Tested manually (please provide steps)

## Related Issues
<!-- Link any related issues using the GitHub issue syntax: #issue-number
If there is no open issue for this, please add details of the problem or open a new issue. -->
Fixes #

## Additional Context
<!-- Add any other context about the pull request here -->
