### PR TITLE
fix(channel): split intermediate and init readiness channels

### DIFF
--- a/crates/libcontainer/src/process/channel.rs
+++ b/crates/libcontainer/src/process/channel.rs
@@ -43,7 +43,13 @@ pub enum ChannelError {
 
 pub fn main_channel() -> Result<(MainSender, MainReceiver), ChannelError> {
     let (sender, receiver) = channel::<Message>()?;
-    Ok((MainSender { sender }, MainReceiver { receiver }))
+    Ok((
+        MainSender { sender },
+        MainReceiver {
+            receiver,
+            init_ready_cached: false,
+        },
+    ))
 }
 
 pub struct MainSender {
@@ -112,28 +118,40 @@ impl MainSender {
 
 pub struct MainReceiver {
     receiver: Receiver<Message>,
+    init_ready_cached: bool,
 }
 
 impl MainReceiver {
     /// Waits for associated intermediate process to send ready message
     /// and return the pid of init process which is forked by intermediate process
     pub fn wait_for_intermediate_ready(&mut self) -> Result<Pid, ChannelError> {
-        let msg = self
-            .receiver
-            .recv()
-            .map_err(|err| ChannelError::ReceiveError {
-                msg: "waiting for intermediate process".to_string(),
-                source: err,
-            })?;
+        loop {
+            let msg = self
+                .receiver
+                .recv()
+                .map_err(|err| ChannelError::ReceiveError {
+                    msg: "waiting for intermediate process".to_string(),
+                    source: err,
+                })?;
 
-        match msg {
-            Message::IntermediateReady(pid) => Ok(Pid::from_raw(pid)),
-            Message::ExecFailed(err) => Err(ChannelError::ExecError(err)),
-            Message::OtherError(err) => Err(ChannelError::OtherError(err)),
-            msg => Err(ChannelError::UnexpectedMessage {
-                expected: Message::IntermediateReady(0),
-                received: msg,
-            }),
+            match msg {
+                Message::IntermediateReady(pid) => return Ok(Pid::from_raw(pid)),
+                Message::ExecFailed(err) => return Err(ChannelError::ExecError(err)),
+                Message::OtherError(err) => return Err(ChannelError::OtherError(err)),
+                Message::InitReady => {
+                    tracing::debug!(
+                        "received InitReady before IntermediateReady, caching for later"
+                    );
+                    self.init_ready_cached = true;
+                    continue;
+                }
+                msg => {
+                    return Err(ChannelError::UnexpectedMessage {
+                        expected: Message::IntermediateReady(0),
+                        received: msg,
+                    });
+                }
+            }
         }
     }
 
@@ -203,6 +221,12 @@ impl MainReceiver {
     /// Waits for associated init process to send ready message
     /// and return the pid of init process which is forked by init process
     pub fn wait_for_init_ready(&mut self) -> Result<(), ChannelError> {
+        if self.init_ready_cached {
+            tracing::debug!("consuming cached InitReady");
+            self.init_ready_cached = false;
+            return Ok(());
+        }
+
         let msg = self
             .receiver
             .recv()

--- a/crates/libcontainer/src/process/container_intermediate_process.rs
+++ b/crates/libcontainer/src/process/container_intermediate_process.rs
@@ -42,7 +42,8 @@ pub fn container_intermediate_process(
     args: &ContainerArgs,
     intermediate_chan: &mut (channel::IntermediateSender, channel::IntermediateReceiver),
     init_chan: &mut (channel::InitSender, channel::InitReceiver),
-    main_sender: &mut channel::MainSender,
+    intermediate_main_sender: &mut channel::MainSender,
+    init_main_sender: &mut channel::MainSender,
 ) -> Result<()> {
     let (inter_sender, inter_receiver) = intermediate_chan;
     let (init_sender, init_receiver) = init_chan;
@@ -102,7 +103,12 @@ pub fn container_intermediate_process(
     // https://man7.org/linux/man-pages/man7/user_namespaces.7.html for more
     // information
     if let Some(user_namespace) = namespaces.get(LinuxNamespaceType::User)? {
-        setup_userns(&namespaces, user_namespace, main_sender, inter_receiver)?;
+        setup_userns(
+            &namespaces,
+            user_namespace,
+            intermediate_main_sender,
+            inter_receiver,
+        )?;
 
         // After UID and GID mapping is configured correctly in the Youki main
         // process, We want to make sure continue as the root user inside the
@@ -147,11 +153,18 @@ pub fn container_intermediate_process(
                 tracing::error!(?err, "failed to close sender in the intermediate process");
                 return -1;
             }
-            match init_process::container_init_process(args, main_sender, init_receiver) {
+            if let Err(err) = intermediate_main_sender.close() {
+                tracing::error!(
+                    ?err,
+                    "failed to close intermediate main sender in init process"
+                );
+                return -1;
+            }
+            match init_process::container_init_process(args, init_main_sender, init_receiver) {
                 Ok(_) => 0,
                 Err(e) => {
                     tracing::error!("failed to initialize container process: {e}");
-                    if let Err(err) = main_sender.exec_failed(e.to_string()) {
+                    if let Err(err) = init_main_sender.exec_failed(e.to_string()) {
                         tracing::error!(?err, "failed sending error to main sender");
                     }
                     if let ContainerType::TenantContainer { exec_notify_fd } = args.container_type {
@@ -193,14 +206,20 @@ pub fn container_intermediate_process(
         })?;
     }
 
-    main_sender.intermediate_ready(pid).map_err(|err| {
-        tracing::error!("failed to wait on intermediate process: {}", err);
-        err
-    })?;
+    intermediate_main_sender
+        .intermediate_ready(pid)
+        .map_err(|err| {
+            tracing::error!("failed to wait on intermediate process: {}", err);
+            err
+        })?;
 
     // Close unused senders here so we don't have lingering socket around.
-    main_sender.close().map_err(|err| {
+    intermediate_main_sender.close().map_err(|err| {
         tracing::error!("failed to close unused main sender: {}", err);
+        err
+    })?;
+    init_main_sender.close().map_err(|err| {
+        tracing::error!("failed to close unused init main sender: {}", err);
         err
     })?;
     inter_sender.close().map_err(|err| {

--- a/crates/libcontainer/src/process/container_main_process.rs
+++ b/crates/libcontainer/src/process/container_main_process.rs
@@ -56,7 +56,8 @@ pub fn container_main_process(container_args: &ContainerArgs) -> Result<(Pid, bo
     // cloned process, we have to be deligent about closing any unused channel.
     // At minimum, we have to close down any unused senders. The corresponding
     // receivers will be cleaned up once the senders are closed down.
-    let (mut main_sender, mut main_receiver) = channel::main_channel()?;
+    let (mut intermediate_main_sender, mut intermediate_main_receiver) = channel::main_channel()?;
+    let (mut init_main_sender, mut init_main_receiver) = channel::main_channel()?;
     let mut inter_chan = channel::intermediate_channel()?;
     let mut init_chan = channel::init_channel()?;
 
@@ -71,12 +72,13 @@ pub fn container_main_process(container_args: &ContainerArgs) -> Result<(Pid, bo
                 container_args,
                 &mut inter_chan,
                 &mut init_chan,
-                &mut main_sender,
+                &mut intermediate_main_sender,
+                &mut init_main_sender,
             ) {
                 Ok(_) => 0,
                 Err(err) => {
                     tracing::error!("failed to run intermediate process {}", err);
-                    match main_sender.send_error(err.to_string()) {
+                    match intermediate_main_sender.send_error(err.to_string()) {
                         Ok(_) => {}
                         Err(e) => {
                             tracing::error!(
@@ -105,7 +107,11 @@ pub fn container_main_process(container_args: &ContainerArgs) -> Result<(Pid, bo
 
     // Close down unused fds. The corresponding fds are duplicated to the
     // child process during clone.
-    main_sender.close().map_err(|err| {
+    intermediate_main_sender.close().map_err(|err| {
+        tracing::error!("failed to close unused sender: {}", err);
+        err
+    })?;
+    init_main_sender.close().map_err(|err| {
         tracing::error!("failed to close unused sender: {}", err);
         err
     })?;
@@ -117,7 +123,7 @@ pub fn container_main_process(container_args: &ContainerArgs) -> Result<(Pid, bo
     // the main process to set up uid and gid mapping, once the intermediate
     // process enters into a new user namespace.
     if let Some(config) = &container_args.user_ns_config {
-        main_receiver.wait_for_mapping_request()?;
+        intermediate_main_receiver.wait_for_mapping_request()?;
         setup_mapping(config, intermediate_pid)?;
         inter_sender.mapping_written()?;
     }
@@ -131,7 +137,7 @@ pub fn container_main_process(container_args: &ContainerArgs) -> Result<(Pid, bo
 
     // The intermediate process will send the init pid once it forks the init
     // process.  The intermediate process should exit after this point.
-    let init_pid = main_receiver.wait_for_intermediate_ready()?;
+    let init_pid = intermediate_main_receiver.wait_for_intermediate_ready()?;
     let mut need_to_clean_up_intel_rdt_subdirectory = false;
 
     if let Some(linux) = container_args.spec.linux() {
@@ -154,7 +160,7 @@ pub fn container_main_process(container_args: &ContainerArgs) -> Result<(Pid, bo
 
     if matches!(container_args.container_type, ContainerType::InitContainer) {
         if let Some(hooks) = container_args.spec.hooks() {
-            main_receiver.wait_for_hook_request()?;
+            init_main_receiver.wait_for_hook_request()?;
             if let Some(container_for_hooks) = &container_args.container {
                 hooks::run_hooks(
                     hooks.prestart().as_ref(),
@@ -183,7 +189,12 @@ pub fn container_main_process(container_args: &ContainerArgs) -> Result<(Pid, bo
     }
 
     if let Some(linux) = container_args.spec.linux() {
-        move_network_devices_to_container(linux, init_pid, &mut main_receiver, &mut init_sender)?;
+        move_network_devices_to_container(
+            linux,
+            init_pid,
+            &mut init_main_receiver,
+            &mut init_sender,
+        )?;
 
         #[cfg(feature = "libseccomp")]
         if let Some(seccomp) = linux.seccomp() {
@@ -221,7 +232,7 @@ pub fn container_main_process(container_args: &ContainerArgs) -> Result<(Pid, bo
                 seccomp,
                 &state,
                 &mut init_sender,
-                &mut main_receiver,
+                &mut init_main_receiver,
             )?;
         }
     }
@@ -233,7 +244,7 @@ pub fn container_main_process(container_args: &ContainerArgs) -> Result<(Pid, bo
         err
     })?;
 
-    main_receiver.wait_for_init_ready().map_err(|err| {
+    init_main_receiver.wait_for_init_ready().map_err(|err| {
         tracing::error!("failed to wait for init ready: {}", err);
         err
     })?;
@@ -252,8 +263,13 @@ pub fn container_main_process(container_args: &ContainerArgs) -> Result<(Pid, bo
         err
     })?;
 
-    main_receiver.close().map_err(|err| {
-        tracing::error!("failed to close main process receiver: {}", err);
+    intermediate_main_receiver.close().map_err(|err| {
+        tracing::error!("failed to close intermediate main receiver: {}", err);
+        err
+    })?;
+
+    init_main_receiver.close().map_err(|err| {
+        tracing::error!("failed to close init main receiver: {}", err);
         err
     })?;
 


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of your changes -->
Under high concurrency, the init process can send InitReady before the
intermediate process sends IntermediateReady. The main process used to wait
for both messages on the same receiver, so wait_for_intermediate_ready()
could receive InitReady first and fail with an unexpected message error.

Add separate main-facing receivers for intermediate-owned and init-owned
readiness messages. IntermediateReady is read from the intermediate receiver,
while InitReady is forwarded through the init receiver and remains available
until wait_for_init_ready() consumes it.

## Type of Change
<!-- Mark the appropriate option with an [x] -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test updates
- [ ] CI/CD related changes
- [ ] Other (please describe):

## Testing
<!-- Describe the tests you ran and/or added to verify your changes -->
- [ ] Added new unit tests
- [ ] Added new integration tests
- [x] Ran existing test suite
- [x] Tested manually (please provide steps): 1. clone [boxlite](https://github.com/uran0sH/boxlite/tree/fix/test-rustflags) 2. apply this patch and change the youki's version in the boxlite 3. run `make test`.

## Related Issues
<!-- Link any related issues using the GitHub issue syntax: #issue-number
If there is no open issue for this, please add details of the problem or open a new issue. -->
ContainerBuilder::build() fails intermittently with:
  received unexpected message: InitReady, expected: IntermediateReady(0)
  The error comes from libcontainer::process::channel::MainReceiver::wait_for_intermediate_ready().

Normal message flow
During container creation, libcontainer spawns two child processes:
  1. Intermediate process — sets up namespaces, cgroups, etc.
  2. Init process — the actual container payload.
  They communicate with the parent via a SOCK_SEQPACKET socket:
  1. Intermediate sends IntermediateReady(pid).
  2. Parent receives it in wait_for_intermediate_ready().
  3. Init sends InitReady.
  4. Parent receives it in wait_for_init_ready().
  
Root cause: parallel scheduling race
  The init process is forked by the intermediate process using clone3(CLONE_PARENT). The two processes run in parallel. Under CPU pressure, the scheduler may execute the init process faster than the intermediate process. Consequently, InitReady can arrive at the parent before IntermediateReady.
  wait_for_intermediate_ready() only calls recv() once. When it sees InitReady, it treats it as an unexpected message and aborts the build

## Additional Context
<!-- Add any other context about the pull request here -->
