### PR TITLE
ci: group wasmtime-related Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,10 @@ updates:
     allow:
       - dependency-type: direct
     groups:
+      wasmtime:
+        patterns:
+          - "wasmtime"
+          - "wasi-common"
       patch:
         update-types: 
         - patch


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of your changes -->

With the current Dependabot configuration, Wasmtime-related PRs are created separately, which can cause build failures due to version mismatches.

To avoid this, this change updates the Dependabot configuration so that Wasmtime-related PRs are grouped together.

see

- https://docs.github.com/en/code-security/tutorials/secure-your-dependencies/optimizing-pr-creation-version-updates#grouping-related-dependencies-together
- https://github.com/youki-dev/youki/pull/3507
- https://github.com/youki-dev/youki/pull/3508

also see

https://github.com/youki-dev/youki/pull/3422#issuecomment-3956883600

## Type of Change
<!-- Mark the appropriate option with an [x] -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test updates
- [ ] CI/CD related changes
- [ ] Other (please describe):

## Testing
<!-- Describe the tests you ran and/or added to verify your changes -->
- [ ] Added new unit tests
- [ ] Added new integration tests
- [x] Ran existing test suite
- [ ] Tested manually (please provide steps)

## Related Issues
<!-- Link any related issues using the GitHub issue syntax: #issue-number
If there is no open issue for this, please add details of the problem or open a new issue. -->
Fixes #

## Additional Context
<!-- Add any other context about the pull request here -->
