### PR TITLE
ci: remove unused cgroups v1 dind workflow steps

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -196,9 +196,6 @@ jobs:
   docker-in-docker:
     runs-on: ubuntu-24.04
     needs: [youki-build]
-    strategy:
-      matrix:
-        cgroup-version: ["v2"]
     steps:
       - uses: actions/checkout@v4
       - name: Install just
@@ -209,53 +206,5 @@ jobs:
           name: youki-x86_64-musl
       - name: Add the permission to run
         run: chmod +x ./youki
-      # Steps for cgroups-v1 only (using Lima with AlmaLinux 8)
-      - name: Setup Lima
-        if: matrix.cgroup-version == 'v1'
-        uses: lima-vm/lima-actions/setup@v1
-        id: lima-actions-setup
-      - uses: actions/cache@v4
-        if: matrix.cgroup-version == 'v1'
-        with:
-          path: ~/.cache/lima
-          key: lima-${{ steps.lima-actions-setup.outputs.version }}
-      - name: Start the guest VM
-        if: matrix.cgroup-version == 'v1'
-        run: |
-          set -eux
-          # containerd=none is set because the built-in containerd support conflicts with Docker
-          limactl start \
-            --name=default \
-            --cpus=4 \
-            --memory=8 \
-            --containerd=none \
-            --set '.mounts=[{"location":"~/","writable":true}] | .portForwards=[{"guestSocket":"/var/run/docker.sock","hostSocket":"{{.Dir}}/sock/docker.sock"}]' \
-            template://almalinux-8
-      - name: Install dockerd in the guest VM
-        if: matrix.cgroup-version == 'v1'
-        run: |
-          set -eux
-          lima sudo mkdir -p /etc/systemd/system/docker.socket.d
-          cat <<-EOF | lima sudo tee /etc/systemd/system/docker.socket.d/override.conf
-          [Socket]
-          SocketUser=$(whoami)
-          EOF
-          lima sudo dnf config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
-          lima sudo dnf -q -y install docker-ce --nobest
-          lima sudo systemctl enable --now docker
-      - name: Configure the host to use dockerd in the guest VM
-        if: matrix.cgroup-version == 'v1'
-        run: |
-          set -eux
-          sudo systemctl disable --now docker.service docker.socket
-          export DOCKER_HOST="unix://$(limactl ls --format '{{.Dir}}/sock/docker.sock' default)"
-          echo "DOCKER_HOST=${DOCKER_HOST}" >>$GITHUB_ENV
-          docker info
-          docker version
-      # Run tests differently based on cgroup version
       - name: Run tests (cgroups-v2)
-        if: matrix.cgroup-version == 'v2'
-        run: just test-dind
-      - name: Run tests (cgroups-v1)
-        if: matrix.cgroup-version == 'v1'
         run: just test-dind


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of your changes -->

Remove unused cgroups v1 logic from the docker-in-docker job in the e2e workflow.

see: 
- https://github.com/youki-dev/youki/issues/3285
- https://github.com/youki-dev/youki/pull/3284

## Type of Change
<!-- Mark the appropriate option with an [x] -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test updates
- [ ] CI/CD related changes
- [ ] Other (please describe):

## Testing
<!-- Describe the tests you ran and/or added to verify your changes -->
- [ ] Added new unit tests
- [ ] Added new integration tests
- [x] Ran existing test suite
- [ ] Tested manually (please provide steps)

## Related Issues
<!-- Link any related issues using the GitHub issue syntax: #issue-number
If there is no open issue for this, please add details of the problem or open a new issue. -->
Fixes #

## Additional Context
<!-- Add any other context about the pull request here -->
