### PR TITLE
ci: build CRIU from source

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -56,10 +56,18 @@ jobs:
         with:
           go-version: '1.24.3'
           cache: true
-      - name: Add CRIU PPA
-        run: sudo add-apt-repository -y ppa:criu/ppa
       - run: sudo apt-get -y update
-      - run: sudo apt-get install -y pkg-config libsystemd-dev libelf-dev libseccomp-dev btrfs-progs libbtrfs-dev criu gperf
+      - run: sudo apt-get install -y pkg-config libsystemd-dev libelf-dev libseccomp-dev btrfs-progs libbtrfs-dev gperf
+      - name: Install CRIU from source
+        run: |
+          sudo apt-get install -y \
+            libcap-dev libnet1-dev libnl-3-dev uuid-dev \
+            libprotobuf-c-dev libprotobuf-dev protobuf-c-compiler protobuf-compiler
+          git clone --depth 1 --branch criu-dev --single-branch \
+            https://github.com/checkpoint-restore/criu.git ~/criu
+          (cd ~/criu && sudo make -j $(nproc) install-criu)
+          rm -rf ~/criu
+          criu --version
       - name: Setup libseccomp
         run: sudo ./script/setup/install-seccomp
       - name: Build containerd
@@ -161,10 +169,18 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
       - name: Install just
         uses: taiki-e/install-action@just
-      - name: Add CRIU PPA
-        run: sudo add-apt-repository -y ppa:criu/ppa
       - name: Install requirements
         run: sudo env PATH=$PATH just ci-prepare
+      - name: Install CRIU from source
+        run: |
+          sudo apt-get install -y \
+            libcap-dev libnet1-dev libnl-3-dev uuid-dev \
+            libprotobuf-c-dev libprotobuf-dev protobuf-c-compiler protobuf-compiler
+          git clone --depth 1 --branch criu-dev --single-branch \
+            https://github.com/checkpoint-restore/criu.git ~/criu
+          (cd ~/criu && sudo make -j $(nproc) install-criu)
+          rm -rf ~/criu
+          criu --version
       - name: Download youki binary
         uses: actions/download-artifact@v4
         with:
@@ -190,10 +206,18 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
       - name: Install just
         uses: taiki-e/install-action@just
-      - name: Add CRIU PPA
-        run: sudo add-apt-repository -y ppa:criu/ppa
       - name: Install requirements
         run: sudo env PATH=$PATH just ci-prepare
+      - name: Install CRIU from source
+        run: |
+          sudo apt-get install -y \
+            libcap-dev libnet1-dev libnl-3-dev uuid-dev \
+            libprotobuf-c-dev libprotobuf-dev protobuf-c-compiler protobuf-compiler
+          git clone --depth 1 --branch criu-dev --single-branch \
+            https://github.com/checkpoint-restore/criu.git ~/criu
+          (cd ~/criu && sudo make -j $(nproc) install-criu)
+          rm -rf ~/criu
+          criu --version
       - name: Download youki binary
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/integration_tests_validation.yaml
+++ b/.github/workflows/integration_tests_validation.yaml
@@ -88,10 +88,18 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1.3.7
       - name: Install just
         uses: taiki-e/install-action@just
-      - name: Add CRIU PPA
-        run: sudo add-apt-repository -y ppa:criu/ppa
       - name: Install requirements
         run: sudo env PATH=$PATH just ci-prepare
+      - name: Install CRIU from source
+        run: |
+          sudo apt-get install -y \
+            libcap-dev libnet1-dev libnl-3-dev uuid-dev \
+            libprotobuf-c-dev libprotobuf-dev protobuf-c-compiler protobuf-compiler
+          git clone --depth 1 --branch criu-dev --single-branch \
+            https://github.com/checkpoint-restore/criu.git ~/criu
+          (cd ~/criu && sudo make -j $(nproc) install-criu)
+          rm -rf ~/criu
+          criu --version
       - name: Install runc 1.4.0
         run: |
           wget -q https://github.com/opencontainers/runc/releases/download/v1.4.0/runc.amd64

--- a/.github/workflows/podman_tests.yaml
+++ b/.github/workflows/podman_tests.yaml
@@ -12,10 +12,18 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install just
         uses: taiki-e/install-action@just
-      - name: Add CRIU PPA
-        run: sudo add-apt-repository -y ppa:criu/ppa
       - name: Install requirements
         run: sudo env PATH=$PATH just ci-prepare
+      - name: Install CRIU from source
+        run: |
+          sudo apt-get install -y \
+            libcap-dev libnet1-dev libnl-3-dev uuid-dev \
+            libprotobuf-c-dev libprotobuf-dev protobuf-c-compiler protobuf-compiler
+          git clone --depth 1 --branch criu-dev --single-branch \
+            https://github.com/checkpoint-restore/criu.git ~/criu
+          (cd ~/criu && sudo make -j $(nproc) install-criu)
+          rm -rf ~/criu
+          criu --version
       
       - name: Install skopeo and podman requirements
         run: |

--- a/justfile
+++ b/justfile
@@ -171,8 +171,7 @@ ci-prepare:
                 libelf-dev \
                 libseccomp-dev \
                 libclang-dev \
-                libssl-dev \
-                criu
+                libssl-dev
             exit 0
         fi
     fi


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of your changes -->

This updates CI to build CRIU from source instead of using the CRIU PPA.
This follows the same approach as runc, which also builds CRIU from source.

https://github.com/opencontainers/runc/blob/main/.github/workflows/test.yml#L101

The CRIU PPA can occasionally fail to connect during CI setup.
For example, we are seeing this failure in the following CI job:

https://github.com/youki-dev/youki/actions/runs/25196987760/job/74020979949?pr=3519

## Type of Change
<!-- Mark the appropriate option with an [x] -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test updates
- [x] CI/CD related changes
- [ ] Other (please describe):

## Testing
<!-- Describe the tests you ran and/or added to verify your changes -->
- [ ] Added new unit tests
- [ ] Added new integration tests
- [x] Ran existing test suite
- [ ] Tested manually (please provide steps)

## Related Issues
<!-- Link any related issues using the GitHub issue syntax: #issue-number
If there is no open issue for this, please add details of the problem or open a new issue. -->
Fixes #

## Additional Context
<!-- Add any other context about the pull request here -->
