### PR TITLE
fix: validate process.terminal field against --console-socket option

### DIFF
--- a/crates/libcontainer/src/container/builder.rs
+++ b/crates/libcontainer/src/container/builder.rs
@@ -1,9 +1,11 @@
 use std::os::fd::OwnedFd;
 use std::path::PathBuf;
 
+use oci_spec::runtime::Spec;
+
 use super::init_builder::InitContainerBuilder;
 use super::tenant_builder::TenantContainerBuilder;
-use crate::error::{ErrInvalidID, LibcontainerError};
+use crate::error::{ErrInvalidID, ErrInvalidSpec, LibcontainerError};
 use crate::syscall::syscall::SyscallType;
 use crate::utils::PathBufExt;
 use crate::workload::{self, Executor};
@@ -336,6 +338,28 @@ impl ContainerBuilder {
         self.stderr = Some(stderr.into());
         self
     }
+
+    pub(super) fn check_terminal(
+        &self,
+        spec: &Spec,
+        detached: bool,
+    ) -> Result<(), LibcontainerError> {
+        let terminal = spec
+            .process()
+            .as_ref()
+            .and_then(|p| p.terminal())
+            .unwrap_or(false);
+        let has_console_socket = self.console_socket.is_some();
+        let requires_console_socket = detached && terminal;
+
+        if requires_console_socket && !has_console_socket {
+            Err(ErrInvalidSpec::ConsoleSocketRequired)?;
+        }
+        if !requires_console_socket && has_console_socket {
+            Err(ErrInvalidSpec::InvalidConsoleSocket)?;
+        }
+        Ok(())
+    }
 }
 
 #[cfg(test)]
@@ -345,8 +369,10 @@ mod tests {
 
     use anyhow::{Context, Result};
     use nix::unistd::pipe;
+    use oci_spec::runtime::{ProcessBuilder, SpecBuilder};
 
     use crate::container::builder::ContainerBuilder;
+    use crate::error::{ErrInvalidSpec, LibcontainerError};
     use crate::syscall::syscall::SyscallType;
 
     #[test]
@@ -445,5 +471,99 @@ mod tests {
             Some(stderr_raw)
         );
         Ok(())
+    }
+
+    fn make_builder(console_socket: Option<&str>) -> ContainerBuilder {
+        ContainerBuilder::new("test".to_owned(), SyscallType::default())
+            .with_console_socket(console_socket)
+    }
+
+    fn make_spec(terminal: bool) -> oci_spec::runtime::Spec {
+        let process = ProcessBuilder::default()
+            .terminal(terminal)
+            .args(vec!["sh".to_owned()])
+            .build()
+            .expect("failed to build process spec");
+        SpecBuilder::default()
+            .process(process)
+            .build()
+            .expect("failed to build spec")
+    }
+
+    #[test]
+    fn test_check_terminal_ok_terminal_true_with_socket_detached() {
+        assert!(
+            make_builder(Some("/tmp/console.sock"))
+                .check_terminal(&make_spec(true), true)
+                .is_ok()
+        );
+    }
+
+    #[test]
+    fn test_check_terminal_ok_terminal_false_no_socket_detached() {
+        assert!(
+            make_builder(None)
+                .check_terminal(&make_spec(false), true)
+                .is_ok()
+        );
+    }
+
+    #[test]
+    fn test_check_terminal_ok_terminal_false_no_socket_foreground() {
+        assert!(
+            make_builder(None)
+                .check_terminal(&make_spec(false), false)
+                .is_ok()
+        );
+    }
+
+    #[test]
+    fn test_check_terminal_err_terminal_true_no_socket_detached() {
+        let err = make_builder(None)
+            .check_terminal(&make_spec(true), true)
+            .unwrap_err();
+        assert!(
+            matches!(
+                err,
+                LibcontainerError::InvalidSpec(ErrInvalidSpec::ConsoleSocketRequired)
+            ),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn test_check_terminal_err_terminal_false_with_socket_detached() {
+        let err = make_builder(Some("/tmp/console.sock"))
+            .check_terminal(&make_spec(false), true)
+            .unwrap_err();
+        assert!(
+            matches!(
+                err,
+                LibcontainerError::InvalidSpec(ErrInvalidSpec::InvalidConsoleSocket)
+            ),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn test_check_terminal_err_terminal_true_with_socket_foreground() {
+        let err = make_builder(Some("/tmp/console.sock"))
+            .check_terminal(&make_spec(true), false)
+            .unwrap_err();
+        assert!(
+            matches!(
+                err,
+                LibcontainerError::InvalidSpec(ErrInvalidSpec::InvalidConsoleSocket)
+            ),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn test_check_terminal_ok_no_process_in_spec() {
+        let spec = SpecBuilder::default()
+            .build()
+            .expect("failed to build spec");
+        assert!(make_builder(None).check_terminal(&spec, true).is_ok());
     }
 }

--- a/crates/libcontainer/src/container/init_builder.rs
+++ b/crates/libcontainer/src/container/init_builder.rs
@@ -73,6 +73,10 @@ impl InitContainerBuilder {
     /// Creates a new container
     pub fn build(self) -> Result<Container, LibcontainerError> {
         let spec = self.load_spec()?;
+        // validate terminal field against console socket presence before any side effects
+        // (mirrors runc's checkTerminal called at the top of runner.run())
+        self.base.check_terminal(&spec, self.detached)?;
+
         let container_dir = self.create_container_dir()?;
 
         let mut container = self.create_container_state(&container_dir)?;

--- a/crates/libcontainer/src/container/tenant_builder.rs
+++ b/crates/libcontainer/src/container/tenant_builder.rs
@@ -241,6 +241,8 @@ impl TenantContainerBuilder {
         let container = self.load_container_state(container_dir.clone())?;
         let mut spec = self.load_init_spec(&container)?;
         self.adapt_spec_for_tenant(&mut spec, &container)?;
+        // validate terminal field against console socket presence before any side effects
+        self.base.check_terminal(&spec, self.detached)?;
 
         tracing::debug!("{:#?}", spec);
 

--- a/crates/libcontainer/src/error.rs
+++ b/crates/libcontainer/src/error.rs
@@ -104,6 +104,10 @@ pub enum ErrInvalidSpec {
     IoPriority,
     #[error("invalid scheduler config for process")]
     Scheduler,
+    #[error("cannot allocate tty if youki will detach without setting console socket")]
+    ConsoleSocketRequired,
+    #[error("cannot use console socket if youki will not detach or allocate tty")]
+    InvalidConsoleSocket,
 }
 
 #[derive(Debug, thiserror::Error)]


### PR DESCRIPTION
## Description

Fixes the issue where youki ignored the `process.terminal` field from the OCI Runtime Spec when handling `--console-socket`, causing incorrect behavior compared to runc.

Adds `check_terminal()` validation that mirrors runc's `checkTerminal()` in `utils_linux.go`: it rejects invalid combinations of `process.terminal` and `--console-socket` **before** any container state is created on disk.

| Case | Before | After |
|------|--------|-------|
| `terminal=true` + `--console-socket` provided | OK | OK |
| `terminal=true` + `--console-socket` missing | Not validated | Error |
| `terminal=false` + `--console-socket` provided | Silently creates PTY | Error |
| `terminal=false` + `--console-socket` missing | OK | OK |

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test updates
- [ ] CI/CD related changes
- [ ] Other (please describe):

## Testing

- [x] Added new unit tests
- [ ] Added new integration tests
- [x] Ran existing test suite
- [ ] Tested manually (please provide steps)

## Related Issues

Fixes #3522

## Additional Context

The validation is intentionally placed before `create_container_dir()` so that no container state is written to disk when validation fails — matching the ordering of runc's `checkTerminal()` call at the top of `runner.run()`.