### PR TITLE
docs: fix several typos in code, error messages, and docs

### DIFF
--- a/crates/libcontainer/src/process/intel_rdt.rs
+++ b/crates/libcontainer/src/process/intel_rdt.rs
@@ -185,7 +185,7 @@ fn combine_l3_cache_and_mem_bw_schemas(
             Some(output.join("\n"))
         }
         (Some(_), None) => {
-            // Apprarently the "MB:"-lines don't need to be removed in this case?
+            // Apparently the "MB:"-lines don't need to be removed in this case?
             l3_cache_schema.to_owned()
         }
         (None, Some(_)) => mem_bw_schema.to_owned(),

--- a/crates/youki/src/commands/info.rs
+++ b/crates/youki/src/commands/info.rs
@@ -224,7 +224,7 @@ pub fn print_namespaces() {
             }
         } else {
             println!("{:<18}UNKNOWN", "Namespaces");
-            // we don't return as  we can atleast try and see if anything is enabled
+            // we don't return as  we can at least try and see if anything is enabled
         }
 
         // mount namespace is always enabled if namespaces are enabled

--- a/crates/youki/src/commands/ps.rs
+++ b/crates/youki/src/commands/ps.rs
@@ -56,5 +56,5 @@ fn get_pid_index(title: &str) -> Result<usize> {
             return Ok(index);
         }
     }
-    bail!("could't find PID field in ps output");
+    bail!("couldn't find PID field in ps output");
 }

--- a/docs/src/user/basic_setup.md
+++ b/docs/src/user/basic_setup.md
@@ -91,7 +91,7 @@ Install the build dependencies and then run:
 just youki-dev # or youki-release
 ```
 
-Install the build dependencies using your distribution's package manger
+Install the build dependencies using your distribution's package manager
 
 #### Debian, Ubuntu and related distributions
 ```console

--- a/docs/src/user/basic_usage.md
+++ b/docs/src/user/basic_usage.md
@@ -155,7 +155,7 @@ sudo ./youki delete tutorial_container
 
 The example above shows how to run Youki in a 'rootful' way. To run it without root permissions, that is, in rootless mode, few changes are required.
 
-First, after exporting the rootfs from docker, while generating the config, you will need to pass the rootless flag. This will generate the config withe the options needed for rootless operation of the container.
+First, after exporting the rootfs from docker, while generating the config, you will need to pass the rootless flag. This will generate the config with the options needed for rootless operation of the container.
 
 ```console
 ../youki spec --rootless

--- a/experiment/seccomp/src/seccomp.rs
+++ b/experiment/seccomp/src/seccomp.rs
@@ -26,9 +26,9 @@ pub enum SeccompError {
     Apply(String),
     #[error("valid indices are 0–5")]
     InvalidArgumentSize,
-    #[error("Cant ScmpActNotify to default action")]
+    #[error("Can't ScmpActNotify to default action")]
     InvalidDefaultAction,
-    #[error("Cant filter to write system call")]
+    #[error("Can't filter to write system call")]
     InvalidSystemCall,
 }
 

--- a/scripts/cargo.sh
+++ b/scripts/cargo.sh
@@ -19,9 +19,9 @@ set -euo pipefail
 # build scripts, proc macros). The computed value of the target
 # directory can be obtained with `cargo.sh --print-target-dir`.
 #
-# Lastly, when using `cross` this scrips sets some configuration
+# Lastly, when using `cross` this scripts sets some configuration
 # to allow running `youki` tests inside the `cross`` container.
-# Please check the comments in this scrips to learm more about that.
+# Please check the comments in this scripts to learm more about that.
 #
 # Limitations:
 #  * You **must** use the `CARGO_BUILD_TARGET` environment variable

--- a/tests/contest/contest/src/tests/cgroups/blkio.rs
+++ b/tests/contest/contest/src/tests/cgroups/blkio.rs
@@ -16,7 +16,7 @@ use crate::utils::test_utils::{CGROUP_ROOT, check_container_created};
 // for some reason, Ubuntu and other distributions might come with a kernel compiled with mq-deadline
 // schedular, which does not expose/support options such as blkio.weight, blkio.weight_device
 // for these we can skip all the tests, or skip the corresponding tests
-// the current implementation skips corresponding tests, so one can test atleast bps and iops
+// the current implementation skips corresponding tests, so one can test at least bps and iops
 // device on such systems
 // check https://superuser.com/questions/1449688/a-couple-of-blkio-cgroup-files-are-not-present-in-linux-kernel-5
 // and https://github.com/opencontainers/runc/issues/140

--- a/tests/contest/contest/src/tests/fd_control/mod.rs
+++ b/tests/contest/contest/src/tests/fd_control/mod.rs
@@ -34,7 +34,7 @@ fn open_devnull_no_cloexec() -> Result<(fs::File, RawFd)> {
     Ok((devnull, devnull_fd))
 }
 
-// If not opening any other FDs, verify youki itself doesnt open anything that gets
+// If not opening any other FDs, verify youki itself doesn't open anything that gets
 // leaked in if passing --preserve-fds with a large number
 // NOTE: this will also fail if the test harness itself starts leaking FDs
 fn only_stdio_test() -> TestResult {


### PR DESCRIPTION
## Description

Corrects a number of minor misspellings spread across user-facing error messages, code comments, shell scripts, test code, and documentation. No behavior changes — purely textual fixes.

The typos were initially surfaced by running [`codespell`](https://github.com/codespell-project/codespell) over the repository, then each occurrence was manually verified to avoid touching anything intentional.

Summary of changes:

| File | Fix |
|---|---|
| `crates/youki/src/commands/info.rs` | `atleast` → `at least` (`info` output) |
| `crates/youki/src/commands/ps.rs` | `could't` → `couldn't` (user-facing `bail!` error) |
| `crates/libcontainer/src/process/intel_rdt.rs` | `Apprarently` → `Apparently` (comment) |
| `tests/contest/contest/src/tests/cgroups/blkio.rs` | `atleast` → `at least` (comment) |
| `tests/contest/contest/src/tests/fd_control/mod.rs` | `doesnt` → `doesn't` (comment) |
| `docs/src/user/basic_setup.md` | `manger` → `manager` |
| `docs/src/user/basic_usage.md` | `withe` → `with` |
| `scripts/cargo.sh` | `scrips` → `scripts` (comment, two occurrences) |
| `experiment/seccomp/src/seccomp.rs` | `Cant` → `Can't` (two messages) |

Diff stat: **9 files changed, 11 insertions(+), 11 deletions(-)**.

## Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test updates
- [ ] CI/CD related changes
- [ ] Other (please describe):

## Testing
- [ ] Added new unit tests
- [ ] Added new integration tests
- [ ] Ran existing test suite
- [ ] Tested manually (please provide steps)

Not applicable — typo-only changes with no functional impact. CI will run the existing test suite.

## Related Issues
Fixes #

## Additional Context

All changes preserve the surrounding tone/voice of the original text and only fix the misspelling itself. Happy to split this into smaller PRs (e.g., docs vs. code vs. tests) if maintainers prefer.