### PR TITLE
fix: preserve mount flags for readonly remount of rootfs in init

### DIFF
--- a/crates/libcontainer/src/process/init/process.rs
+++ b/crates/libcontainer/src/process/init/process.rs
@@ -8,6 +8,7 @@ use nc;
 use nix::mount::{MntFlags, MsFlags};
 use nix::sched::CloneFlags;
 use nix::sys::stat::Mode;
+use nix::sys::statfs::statfs;
 use nix::unistd::{self, Gid, Uid, close, dup2, setsid};
 use oci_spec::runtime::{
     IOPriorityClass, LinuxIOPriority, LinuxNamespaceType, LinuxNetDevice, LinuxPersonalityDomain,
@@ -198,12 +199,22 @@ pub fn container_init_process(
 
     if matches!(args.container_type, ContainerType::InitContainer) {
         if ctx.rootfs_ro {
+            let current_flags = statfs("/")
+                .map_err(|err| {
+                    tracing::error!(?err, "failed to statfs root '/' to get current mount flags");
+                    InitProcessError::SyscallOther(SyscallError::Nix(err))
+                })?
+                .flags()
+                .bits();
             ctx.syscall
                 .mount(
                     None,
                     Path::new("/"),
                     None,
-                    MsFlags::MS_RDONLY | MsFlags::MS_REMOUNT | MsFlags::MS_BIND,
+                    MsFlags::MS_RDONLY
+                        | MsFlags::MS_REMOUNT
+                        | MsFlags::MS_BIND
+                        | MsFlags::from_bits_truncate(current_flags),
                     None,
                 )
                 .map_err(|err| {

--- a/tests/contest/contest/src/tests/root_readonly_true/root_readonly_tests.rs
+++ b/tests/contest/contest/src/tests/root_readonly_true/root_readonly_tests.rs
@@ -1,4 +1,7 @@
+use std::path::Path;
+
 use anyhow::{Context, Ok, Result};
+use nix::mount::MsFlags;
 use oci_spec::runtime::{ProcessBuilder, RootBuilder, Spec, SpecBuilder};
 use test_framework::{Test, TestGroup, TestResult, test_result};
 
@@ -25,6 +28,40 @@ fn root_readonly_true_test() -> TestResult {
     test_inside_container(&spec_true, &CreateOptions::default(), &|_| Ok(()))
 }
 
+fn root_readonly_true_in_userns_test() -> TestResult {
+    let uid = nix::unistd::geteuid().as_raw();
+    let gid = nix::unistd::getegid().as_raw();
+    let mut spec = Spec::rootless(uid, gid);
+    spec.set_root(RootBuilder::default().readonly(true).build().ok())
+        .set_process(
+            ProcessBuilder::default()
+                .args(vec!["runtimetest".to_string(), "root_readonly".to_string()])
+                .build()
+                .ok(),
+        );
+    test_inside_container(&spec, &CreateOptions::default(), &|rootfs: &Path| {
+        // Bind-mount the rootfs onto itself with MS_NODEV | MS_NOSUID, simulating a
+        // filesystem that has those flags locked (the typical case in user namespaces).
+        // Without the fix for #3517, the subsequent readonly remount would fail with
+        // EPERM because the kernel rejects dropping these flags in a user namespace.
+        nix::mount::mount(
+            Some(rootfs),
+            rootfs,
+            None::<&str>,
+            MsFlags::MS_BIND,
+            None::<&str>,
+        )?;
+        nix::mount::mount(
+            Some(rootfs),
+            rootfs,
+            None::<&str>,
+            MsFlags::MS_REMOUNT | MsFlags::MS_BIND | MsFlags::MS_NODEV | MsFlags::MS_NOSUID,
+            None::<&str>,
+        )?;
+        Ok(())
+    })
+}
+
 fn root_readonly_false_test() -> TestResult {
     let spec_false = test_result!(create_spec(false));
     test_inside_container(&spec_false, &CreateOptions::default(), &|_| Ok(()))
@@ -34,11 +71,19 @@ pub fn get_root_readonly_test() -> TestGroup {
     let mut root_readonly_test_group = TestGroup::new("root_readonly");
 
     let test_true = Test::new("root_readonly_true_test", Box::new(root_readonly_true_test));
+    let test_true_in_userns = Test::new(
+        "root_readonly_true_in_userns_test",
+        Box::new(root_readonly_true_in_userns_test),
+    );
     let test_false = Test::new(
         "root_readonly_false_test",
         Box::new(root_readonly_false_test),
     );
-    root_readonly_test_group.add(vec![Box::new(test_true), Box::new(test_false)]);
+    root_readonly_test_group.add(vec![
+        Box::new(test_true),
+        Box::new(test_true_in_userns),
+        Box::new(test_false),
+    ]);
 
     root_readonly_test_group
 }


### PR DESCRIPTION
## Description
Fixes the issue where `youki`'s init process fails to remount its `/` rootfs as read-only in a rootless container. When a mount is cloned across a user namespace boundary, the kernel locks certain flags (MNT_LOCK_NODEV, MNT_LOCK_NOSUID, MNT_LOCK_NOEXEC, MNT_LOCK_ATIME) on the resulting mount [(/include/linux/mount.h#L39-L43)](https://github.com/torvalds/linux/blob/1bfaee9d3351b9b32a99766bbfb1f5baed60ddef/include/linux/mount.h#L39-L43) [(/fs/namespace.c#L2412-L2437)](https://github.com/torvalds/linux/blob/1bfaee9d3351b9b32a99766bbfb1f5baed60ddef/fs/namespace.c#L2412-L2437). An MS_REMOUNT that drops any locked flag is rejected with EPERM. The fix reads the current mount flags via `statfs(2)` and preserves them in the remount call.

## Type of Change
<!-- Mark the appropriate option with an [x] -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test updates
- [ ] CI/CD related changes
- [ ] Other (please describe):

## Testing
<!-- Describe the tests you ran and/or added to verify your changes -->
- [ ] Added new unit tests
- [x] Added new integration tests
- [x] Ran existing test suite (edit: not all of them though, there are still many things to set up for my `flake.nix` env to be complete)
- [ ] Tested manually (please provide steps)

## Related Issues
<!-- Link any related issues using the GitHub issue syntax: #issue-number
If there is no open issue for this, please add details of the problem or open a new issue. -->
Fixes #3517 

## Additional Context
<!-- Add any other context about the pull request here -->
