### PR TITLE
test(dind): pin docker:dind to 29.4 until youki supports time namespace

### DIFF
--- a/tests/dind/run.sh
+++ b/tests/dind/run.sh
@@ -3,11 +3,15 @@ set -e
 
 ROOT=$(git rev-parse --show-toplevel)
 
+# Pin the DinD image to a known-working Docker version for CI reproducibility.
+#
+# Docker 29.5 enables time namespaces by default, which youki does not
+# support yet. Do not move past Docker 29.4 until time namespace support is added.
 docker run --privileged -dq \
   --name youki-test-dind \
   -v $ROOT/youki:/usr/bin/youki \
   -v $ROOT/tests/dind/daemon.json:/etc/docker/daemon.json \
-  docker:dind > /dev/null
+  docker:29.4-dind > /dev/null
 
 trap "docker rm -f youki-test-dind > /dev/null" EXIT
 


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of your changes -->

 Docker 29.5 adds the time namespace to the default OCI spec, which youki rejects. Pin to 29.4 as a workaround.

## Type of Change
<!-- Mark the appropriate option with an [x] -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test updates
- [x] CI/CD related changes
- [ ] Other (please describe):

## Testing
<!-- Describe the tests you ran and/or added to verify your changes -->
- [ ] Added new unit tests
- [ ] Added new integration tests
- [x] Ran existing test suite
- [ ] Tested manually (please provide steps)

## Related Issues
<!-- Link any related issues using the GitHub issue syntax: #issue-number
If there is no open issue for this, please add details of the problem or open a new issue. -->
Related #3538

## Additional Context
<!-- Add any other context about the pull request here -->
