### PR TITLE
fix(libcontainer): support time namespace

### DIFF
--- a/crates/libcontainer/src/namespaces.rs
+++ b/crates/libcontainer/src/namespaces.rs
@@ -31,6 +31,8 @@ pub enum NamespaceError {
     NotSupported(String),
 }
 
+const CLONE_NEWTIME: CloneFlags = CloneFlags::from_bits_retain(libc::CLONE_NEWTIME);
+
 static ORDERED_NAMESPACES: &[CloneFlags] = &[
     CloneFlags::CLONE_NEWUSER,
     CloneFlags::CLONE_NEWPID,
@@ -38,6 +40,7 @@ static ORDERED_NAMESPACES: &[CloneFlags] = &[
     CloneFlags::CLONE_NEWIPC,
     CloneFlags::CLONE_NEWNET,
     CloneFlags::CLONE_NEWCGROUP,
+    CLONE_NEWTIME,
     CloneFlags::CLONE_NEWNS,
 ];
 
@@ -56,7 +59,7 @@ fn get_clone_flag(namespace_type: LinuxNamespaceType) -> Result<CloneFlags> {
         LinuxNamespaceType::Network => CloneFlags::CLONE_NEWNET,
         LinuxNamespaceType::Cgroup => CloneFlags::CLONE_NEWCGROUP,
         LinuxNamespaceType::Mount => CloneFlags::CLONE_NEWNS,
-        LinuxNamespaceType::Time => return Err(NamespaceError::NotSupported("time".to_string())),
+        LinuxNamespaceType::Time => CLONE_NEWTIME,
     };
 
     Ok(flag)
@@ -167,6 +170,10 @@ mod tests {
                 .typ(LinuxNamespaceType::Ipc)
                 .build()
                 .unwrap(),
+            LinuxNamespaceBuilder::default()
+                .typ(LinuxNamespaceType::Time)
+                .build()
+                .unwrap(),
         ]
     }
 
@@ -195,8 +202,26 @@ mod tests {
 
         let mut unshare_args = test_command.get_unshare_args();
         unshare_args.sort();
-        let mut expect = vec![CloneFlags::CLONE_NEWUSER, CloneFlags::CLONE_NEWPID];
+        let mut expect = vec![
+            CloneFlags::CLONE_NEWUSER,
+            CloneFlags::CLONE_NEWPID,
+            CLONE_NEWTIME,
+        ];
         expect.sort();
         assert_eq!(unshare_args, expect)
+    }
+
+    #[test]
+    #[serial]
+    fn test_time_namespace_is_supported() -> Result<()> {
+        let namespaces = vec![
+            LinuxNamespaceBuilder::default()
+                .typ(LinuxNamespaceType::Time)
+                .build()
+                .unwrap(),
+        ];
+
+        assert!(Namespaces::try_from(Some(&namespaces)).is_ok());
+        Ok(())
     }
 }


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of your changes -->
Docker-in-Docker now reads the OCI runtime features output and may include a time namespace in the generated container spec. Youki already reported the namespace as supported, but create rejected it with Namespace type not supported: time, causing dockerd to fail container creation with exit status 1.

Map LinuxNamespaceType::Time to the kernel CLONE_NEWTIME bit from libc, since nix does not expose a named CloneFlags constant yet. Include the flag in namespace application order and add regression coverage for time namespace parsing.

## Type of Change
<!-- Mark the appropriate option with an [x] -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test updates
- [x] CI/CD related changes
- [ ] Other (please describe):

## Testing
<!-- Describe the tests you ran and/or added to verify your changes -->
- [x] Added new unit tests
- [ ] Added new integration tests
- [x] Ran existing test suite
- [ ] Tested manually (please provide steps)

## Related Issues
<!-- Link any related issues using the GitHub issue syntax: #issue-number
If there is no open issue for this, please add details of the problem or open a new issue. -->
Fixes #

## Additional Context
<!-- Add any other context about the pull request here -->
