### PR TITLE
fix: parse info parameters exactly

### DIFF
--- a/crates/youki/src/commands/info.rs
+++ b/crates/youki/src/commands/info.rs
@@ -115,8 +115,8 @@ fn try_read_os_from<P: AsRef<Path>>(path: P) -> Option<String> {
 fn find_parameter<'a>(content: &'a str, param_name: &str) -> Option<&'a str> {
     content
         .lines()
-        .find(|l| l.starts_with(param_name))
-        .and_then(|l| l.split_terminator('=').next_back())
+        .filter_map(|l| l.split_once('='))
+        .find_map(|(key, value)| (key == param_name).then_some(value))
 }
 
 /// Print Hardware information of system
@@ -312,5 +312,24 @@ impl<'a> FeatureDisplay<'a> {
             enabled,
             disabled,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn find_parameter_matches_exact_key() {
+        let content = "NAME_SUFFIX=wrong\nNAME=right\n";
+
+        assert_eq!(find_parameter(content, "NAME"), Some("right"));
+    }
+
+    #[test]
+    fn find_parameter_keeps_equals_signs_in_value() {
+        let content = "PRETTY_NAME=\"Foo=Bar\"\n";
+
+        assert_eq!(find_parameter(content, "PRETTY_NAME"), Some("\"Foo=Bar\""));
     }
 }


### PR DESCRIPTION
## Description
Fixes a tiny parser footgun in `youki info`.

`find_parameter` used prefix matching and split on the last `=`, so `NAME_SUFFIX=wrong` could beat `NAME=right`, and `PRETTY_NAME="Foo=Bar"` became `Bar"`. Not great.

Repro with the old code:
```text
NAME_SUFFIX=wrong
NAME=right
```
asking for `NAME` returns `wrong`.

```text
PRETTY_NAME="Foo=Bar"
```
asking for `PRETTY_NAME` returns `Bar"`.

Now it matches the exact key and keeps the full value after the first `=`.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test updates
- [ ] CI/CD related changes
- [ ] Other (please describe):

## Testing
- [x] Added new unit tests
- [ ] Added new integration tests
- [x] Ran existing test suite
- [ ] Tested manually (please provide steps)

Ran:
```text
cargo test -p youki commands::info::tests
cargo test -p youki commands::info
cargo test -p youki
cargo fmt --check
```

## Related Issues
No direct issue found, afaict.

## Additional Context
`/etc/os-release` is environment-like key/value data, so exact key matching is the boring-but-right move here imo.
