### PR TITLE
fix: respect bundle option in youki spec command

### DIFF
--- a/crates/youki/src/commands/spec_json.rs
+++ b/crates/youki/src/commands/spec_json.rs
@@ -93,8 +93,11 @@ pub fn spec(args: liboci_cli::Spec, syscall: &dyn Syscall) -> Result<()> {
         get_default()?
     };
 
-    // write data to config.json
-    let file = File::create("config.json")?;
+    let path = match args.bundle {
+        Some(bundle) => bundle.join("config.json"),
+        None => PathBuf::from("config.json"),
+    };
+    let file = File::create(path)?;
     let mut writer = BufWriter::new(file);
     to_writer_pretty(&mut writer, &spec)?;
     writer.flush()?;
@@ -112,14 +115,15 @@ mod tests {
     #[test]
     #[serial]
     fn test_spec_json() -> Result<()> {
-        let syscall = create_syscall();
-        let spec = get_rootless(&*syscall)?;
         let tmpdir = tempfile::tempdir().expect("failed to create temp dir");
-        let path = tmpdir.path().join("config.json");
-        let file = File::create(path)?;
-        let mut writer = BufWriter::new(file);
-        to_writer_pretty(&mut writer, &spec)?;
-        writer.flush()?;
+        let args = liboci_cli::Spec {
+            bundle: Some(tmpdir.path().to_path_buf()),
+            rootless: true,
+        };
+        let syscall = create_syscall();
+        spec(args, syscall.as_ref()).expect("failed to run spec subcommand");
+        let config_path = tmpdir.path().join("config.json");
+        assert!(config_path.is_file());
         Ok(())
     }
 }


### PR DESCRIPTION
## Description
When generating a spec using `youki spec --bundle ./path-to-bundle-dir`, youki doesn't respect the `--bundle` option and drops `config.json` into the `$(pwd)`.
On the contrary, `runc spec --bundle ./path-to-bundle-dir` respects it.

## Type of Change
<!-- Mark the appropriate option with an [x] -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test updates
- [ ] CI/CD related changes
- [ ] Other (please describe):

## Testing
<!-- Describe the tests you ran and/or added to verify your changes -->
- [x] Added new unit tests
- [ ] Added new integration tests
- [x] Ran existing test suite (only `just test-unit`)
- [ ] Tested manually (please provide steps)

## Related Issues
<!-- Link any related issues using the GitHub issue syntax: #issue-number
If there is no open issue for this, please add details of the problem or open a new issue. -->
Fixes #3542

## Additional Context
<!-- Add any other context about the pull request here -->
