### PR TITLE
Skip namespaces that are not specified for the init process

### DIFF
--- a/crates/libcontainer/src/container/tenant_builder.rs
+++ b/crates/libcontainer/src/container/tenant_builder.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::convert::TryFrom;
 use std::ffi::{OsStr, OsString};
 use std::fs;
@@ -525,7 +525,11 @@ impl TenantContainerBuilder {
         ))?;
 
         let init_process = procfs::process::Process::new(container_pid.as_raw())?;
-        let ns = self.get_namespaces(init_process.namespaces()?.0)?;
+        let spec_namespaces = spec
+            .linux()
+            .as_ref()
+            .and_then(|l| l.namespaces().as_deref());
+        let ns = self.get_namespaces(init_process.namespaces()?.0, spec_namespaces)?;
 
         // it should never be the case that linux is not present in spec
         let spec_linux = spec.linux().as_ref().unwrap();
@@ -613,12 +617,20 @@ impl TenantContainerBuilder {
     fn get_namespaces(
         &self,
         init_namespaces: HashMap<OsString, Namespace>,
+        spec_namespaces: Option<&[LinuxNamespace]>,
     ) -> Result<Vec<LinuxNamespace>, LibcontainerError> {
+        let landlord_ns_types: HashSet<LinuxNamespaceType> = spec_namespaces
+            .map(|nss| nss.iter().map(|ns| ns.typ()).collect())
+            .unwrap_or_default();
         let mut tenant_namespaces = Vec::with_capacity(init_namespaces.len());
 
         for &ns_type in NAMESPACE_TYPES {
+            let tenant_ns = LinuxNamespaceType::try_from(ns_type)?;
+            // Skip namespaces that are not specified for the init process.
+            if !landlord_ns_types.contains(&tenant_ns) {
+                continue;
+            }
             if let Some(init_ns) = init_namespaces.get(OsStr::new(ns_type)) {
-                let tenant_ns = LinuxNamespaceType::try_from(ns_type)?;
                 tenant_namespaces.push(
                     LinuxNamespaceBuilder::default()
                         .typ(tenant_ns)
@@ -874,5 +886,102 @@ mod tests {
         let b = builder_with_env(&[]);
         let result = b.get_environment(Vec::new());
         assert!(result.is_empty());
+    }
+
+    // --- namespaces tests ---
+    fn ns_entry(ns_type: &str, path: &str) -> (OsString, Namespace) {
+        (
+            OsString::from(ns_type),
+            Namespace {
+                ns_type: OsString::from(ns_type),
+                path: PathBuf::from(path),
+                identifier: 0,
+                device_id: 0,
+            },
+        )
+    }
+
+    fn init_ns() -> HashMap<OsString, Namespace> {
+        HashMap::from([
+            ns_entry("ipc", "/proc/1/ns/ipc"),
+            ns_entry("uts", "/proc/1/ns/uts"),
+            ns_entry("net", "/proc/1/ns/net"),
+            ns_entry("pid", "/proc/1/ns/pid"),
+            ns_entry("mnt", "/proc/1/ns/mnt"),
+            ns_entry("cgroup", "/proc/1/ns/cgroup"),
+        ])
+    }
+
+    fn spec_ns(typ: LinuxNamespaceType) -> LinuxNamespace {
+        LinuxNamespaceBuilder::default().typ(typ).build().unwrap()
+    }
+
+    fn want_ns(typ: LinuxNamespaceType, path: &str) -> LinuxNamespace {
+        LinuxNamespaceBuilder::default()
+            .typ(typ)
+            .path(PathBuf::from(path))
+            .build()
+            .unwrap()
+    }
+
+    fn tenant_builder() -> TenantContainerBuilder {
+        TenantContainerBuilder::new(ContainerBuilder::new(
+            "test".to_string(),
+            SyscallType::default(),
+        ))
+    }
+
+    #[test]
+    fn ns_all_declared_returned() -> Result<(), LibcontainerError> {
+        use LinuxNamespaceType::*;
+        let got = tenant_builder().get_namespaces(
+            init_ns(),
+            Some(&[
+                spec_ns(Ipc),
+                spec_ns(Uts),
+                spec_ns(Network),
+                spec_ns(Pid),
+                spec_ns(Mount),
+                spec_ns(Cgroup),
+            ]),
+        )?;
+        assert_eq!(
+            got,
+            vec![
+                want_ns(Ipc, "/proc/1/ns/ipc"),
+                want_ns(Uts, "/proc/1/ns/uts"),
+                want_ns(Network, "/proc/1/ns/net"),
+                want_ns(Pid, "/proc/1/ns/pid"),
+                want_ns(Mount, "/proc/1/ns/mnt"),
+                want_ns(Cgroup, "/proc/1/ns/cgroup"),
+            ]
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn ns_spec_subset_filters_init() -> Result<(), LibcontainerError> {
+        use LinuxNamespaceType::*;
+        let got =
+            tenant_builder().get_namespaces(init_ns(), Some(&[spec_ns(Ipc), spec_ns(Network)]))?;
+        assert_eq!(
+            got,
+            vec![
+                want_ns(Ipc, "/proc/1/ns/ipc"),
+                want_ns(Network, "/proc/1/ns/net"),
+            ]
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn ns_spec_entry_missing_from_init_is_skipped() -> Result<(), LibcontainerError> {
+        use LinuxNamespaceType::*;
+        let got = tenant_builder().get_namespaces(
+            HashMap::from([ns_entry("ipc", "/proc/1/ns/ipc")]),
+            Some(&[spec_ns(Ipc), spec_ns(Pid)]),
+        )?;
+        assert_eq!(got, vec![want_ns(Ipc, "/proc/1/ns/ipc")]);
+        Ok(())
     }
 }


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of your changes -->

When running `youki exec`, we only need to join the namespaces that were specified for the init process.

Namespaces that were not specified for the init process are inherited, so we skip them here.

See also runc:
https://github.com/opencontainers/runc/blob/main/libcontainer/container_linux.go#L1015

For example, create a `config.json` that does not specify the UTS namespace, as shown below.

In this case, when running `youki exec`, youki still attempts to `setns`(`unshare_or_setns`) into the UTS namespace.

```
    "namespaces": [
      {
        "type": "pid"
      },
      {
        "type": "network"
      },
      {
        "type": "ipc"
      },
      {
        "type": "mount"
      },
      {
        "type": "cgroup"
      }
    ],
```

```
$ youki run  container
$ youki exec container sh
...
DEBUG libcontainer::namespaces: unshare or setns: LinuxNamespace { typ: Pid, path: Some("/proc/328968/ns/pid") }
DEBUG libcontainer::process::channel: sending init pid (Pid(328985))
DEBUG libcontainer::namespaces: unshare or setns: LinuxNamespace { typ: Uts, path: Some("/proc/328968/ns/uts") }
DEBUG libcontainer::namespaces: unshare or setns: LinuxNamespace { typ: Ipc, path: Some("/proc/328968/ns/ipc") }
DEBUG libcontainer::namespaces: unshare or setns: LinuxNamespace { typ: Network, path: Some("/proc/328968/ns/net") }
DEBUG libcontainer::namespaces: unshare or setns: LinuxNamespace { typ: Cgroup, path: Some("/proc/328968/ns/cgroup") }
DEBUG libcontainer::namespaces: unshare or setns: LinuxNamespace { typ: Mount, path: Some("/proc/328968/ns/mnt") }
...
```

However, as can be confirmed with `readlink /proc/self/ns/uts`, the container init process did not create a separate UTS namespace. Its UTS namespace is the same as the parent executor's namespace, such as Podman's.

Therefore, `youki exec` does not need to `setns` into the UTS namespace in this case, and we skip it.


## Type of Change
<!-- Mark the appropriate option with an [x] -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test updates
- [ ] CI/CD related changes
- [ ] Other (please describe):

## Testing
<!-- Describe the tests you ran and/or added to verify your changes -->
- [ ] Added new unit tests
- [ ] Added new integration tests
- [ ] Ran existing test suite
- [ ] Tested manually (please provide steps)


## Related Issues
<!-- Link any related issues using the GitHub issue syntax: #issue-number
If there is no open issue for this, please add details of the problem or open a new issue. -->
Fixes #

## Additional Context
<!-- Add any other context about the pull request here -->
see also
https://github.com/youki-dev/youki/pull/3550#issuecomment-4524129455


