### PR TITLE
fix: drop bounding caps by default if unset

### DIFF
--- a/crates/libcontainer/src/capabilities.rs
+++ b/crates/libcontainer/src/capabilities.rs
@@ -135,10 +135,10 @@ pub fn drop_privileges<S: Syscall + ?Sized>(
     cs: &LinuxCapabilities,
     syscall: &S,
 ) -> Result<(), SyscallError> {
-    if let Some(bounding) = cs.bounding() {
-        tracing::debug!("dropping bounding capabilities to {:?}", bounding);
-        syscall.set_capability(CapSet::Bounding, &to_set(bounding))?;
-    }
+    let empty_caps = Default::default();
+    let bounding = cs.bounding().as_ref().unwrap_or(&empty_caps);
+    tracing::debug!("dropping bounding capabilities to {:?}", bounding);
+    syscall.set_capability(CapSet::Bounding, &to_set(bounding))?;
 
     if let Some(effective) = cs.effective() {
         tracing::debug!("dropping effective capabilities to {:?}", effective);
@@ -611,8 +611,21 @@ mod tests {
                     (CapSet::Effective, cps.clone()),
                     (CapSet::Permitted, cps.clone()),
                     (CapSet::Inheritable, cps.clone()),
-                    (CapSet::Ambient, cps),
+                    (CapSet::Ambient, cps.clone()),
                 ],
+            },
+            Testcase {
+                name: format!("unset LinuxCapabilities fields with caps: {cps:?}"),
+                input: {
+                    let mut caps = LinuxCapabilities::default();
+                    caps.set_bounding(None)
+                        .set_effective(None)
+                        .set_inheritable(None)
+                        .set_permitted(None)
+                        .set_ambient(None);
+                    caps
+                },
+                want: vec![(CapSet::Bounding, vec![])],
             },
         ];
 

--- a/tests/contest/contest/src/main.rs
+++ b/tests/contest/contest/src/main.rs
@@ -42,6 +42,7 @@ use crate::tests::poststop_fail::get_poststop_fail_tests;
 use crate::tests::prestart::get_prestart_tests;
 use crate::tests::prestart_fail::get_prestart_fail_tests;
 use crate::tests::process::get_process_test;
+use crate::tests::process_capabilities_bounding::get_process_capabilities_bounding_test;
 use crate::tests::process_capabilities_fail::get_process_capabilities_fail_test;
 use crate::tests::process_oom_score_adj::get_process_oom_score_adj_test;
 use crate::tests::process_rlimits::get_process_rlimits_test;
@@ -168,6 +169,7 @@ fn main() -> Result<()> {
     let masked_paths = get_linux_masked_paths_tests();
     let rootfs_propagation = get_rootfs_propagation_test();
     let process_capabilities_fail = get_process_capabilities_fail_test();
+    let process_capabilities_bounding = get_process_capabilities_bounding_test();
     let uid_mappings = get_uid_mappings_test();
     let exec_cpu_affinity = get_exec_cpu_affinity_test();
     let exec_env = get_exec_env_test();
@@ -224,6 +226,7 @@ fn main() -> Result<()> {
     tm.add_test_group(Box::new(rootfs_propagation));
     tm.add_test_group(Box::new(net_devices));
     tm.add_test_group(Box::new(process_capabilities_fail));
+    tm.add_test_group(Box::new(process_capabilities_bounding));
     tm.add_test_group(Box::new(uid_mappings));
     tm.add_test_group(Box::new(exec_cpu_affinity));
     tm.add_test_group(Box::new(exec_env));

--- a/tests/contest/contest/src/tests/exec/cap_test.rs
+++ b/tests/contest/contest/src/tests/exec/cap_test.rs
@@ -57,6 +57,45 @@ pub(crate) fn get_test_no_capabilities() -> TestResult {
     })
 }
 
+pub(crate) fn get_test_unset_bounding_capabilities() -> TestResult {
+    let mut unset_caps = LinuxCapabilitiesBuilder::default()
+        .effective(HashSet::new())
+        .inheritable(HashSet::new())
+        .permitted(HashSet::new())
+        .ambient(HashSet::new())
+        .build()
+        .expect("build unset_caps failed");
+    unset_caps.set_bounding(None);
+
+    let spec = test_result!(super::create_spec(Some(
+        ProcessBuilder::default()
+            .no_new_privileges(true)
+            .capabilities(unset_caps)
+    )));
+
+    test_outside_container(&spec, &|data| {
+        test_result!(check_container_created(&data));
+
+        let id = &data.id;
+        let dir = &data.bundle;
+
+        let start_result = start_container(id, dir).unwrap().wait().unwrap();
+        if !start_result.success() {
+            return TestResult::Failed(anyhow!("container start failed"));
+        }
+
+        let (stdout, _) =
+            exec_container(id, dir, &["cat", "/proc/self/status"], None, &[]).expect("exec failed");
+
+        // CapBnd is the set of bounding capabilities.
+        if !stdout.contains("CapBnd:\t0000000000000000") {
+            return TestResult::Failed(anyhow!("CapBnd unexpected output: {}", stdout));
+        }
+
+        TestResult::Passed
+    })
+}
+
 pub(crate) fn get_test_new_privileges() -> TestResult {
     let no_caps = LinuxCapabilitiesBuilder::default()
         .bounding(HashSet::new())

--- a/tests/contest/contest/src/tests/exec/mod.rs
+++ b/tests/contest/contest/src/tests/exec/mod.rs
@@ -36,6 +36,10 @@ pub fn get_exec_test() -> TestGroup {
         "no_capabilities_test",
         Box::new(cap_test::get_test_no_capabilities),
     );
+    let unset_bounding_capabilities_test = Test::new(
+        "unset_bounding_capabilities_test",
+        Box::new(cap_test::get_test_unset_bounding_capabilities),
+    );
     let new_privileges_test = Test::new(
         "new_privileges_test",
         Box::new(cap_test::get_test_new_privileges),
@@ -59,6 +63,7 @@ pub fn get_exec_test() -> TestGroup {
         Box::new(ignore_paused_test),
         Box::new(cgroup_test),
         Box::new(no_capabilities_test),
+        Box::new(unset_bounding_capabilities_test),
         Box::new(new_privileges_test),
         Box::new(some_capabilities_test),
         Box::new(capabilities_by_flag_test_case1),

--- a/tests/contest/contest/src/tests/mod.rs
+++ b/tests/contest/contest/src/tests/mod.rs
@@ -32,6 +32,7 @@ pub mod poststop_fail;
 pub mod prestart;
 pub mod prestart_fail;
 pub mod process;
+pub mod process_capabilities_bounding;
 pub mod process_capabilities_fail;
 pub mod process_oom_score_adj;
 pub mod process_rlimits;

--- a/tests/contest/contest/src/tests/process_capabilities_bounding/mod.rs
+++ b/tests/contest/contest/src/tests/process_capabilities_bounding/mod.rs
@@ -1,0 +1,3 @@
+mod process_capabilities_bounding_test;
+
+pub use process_capabilities_bounding_test::get_process_capabilities_bounding_test;

--- a/tests/contest/contest/src/tests/process_capabilities_bounding/process_capabilities_bounding_test.rs
+++ b/tests/contest/contest/src/tests/process_capabilities_bounding/process_capabilities_bounding_test.rs
@@ -1,0 +1,102 @@
+use std::collections::HashSet;
+
+use anyhow::{Context, Ok, anyhow};
+use oci_spec::runtime::{Capability, LinuxCapabilitiesBuilder, ProcessBuilder, SpecBuilder};
+use test_framework::{Test, TestGroup, TestResult, test_result};
+
+use crate::utils::test_inside_container;
+use crate::utils::test_utils::CreateOptions;
+
+// Happy path: bounding is unset and the other four sets are
+// empty. With the fix for #3434, youki defaults the bounding set to empty and drops it,
+// so runtimetest sees all five cap bitmasks as zero in /proc/self/status.
+// Without the fix, CapBnd would retain the host's full root bounding set.
+fn bounding_dropped_when_unset_test() -> TestResult {
+    let spec = test_result!({
+        let mut caps = LinuxCapabilitiesBuilder::default()
+            .effective(HashSet::new())
+            .inheritable(HashSet::new())
+            .permitted(HashSet::new())
+            .ambient(HashSet::new())
+            .build()
+            .expect("error in creating capabilities");
+        caps.set_bounding(None);
+
+        let process = ProcessBuilder::default()
+            .args(vec![
+                "runtimetest".to_string(),
+                "process_capabilities_bounding_unset".to_string(),
+            ])
+            .capabilities(caps)
+            .build()
+            .expect("error in creating process config");
+
+        SpecBuilder::default()
+            .process(process)
+            .build()
+            .context("failed to build spec")
+    });
+    test_inside_container(&spec, &CreateOptions::default(), &|_| Ok(()))
+}
+
+// Unhappy path: bounding is unset but inheritable contains CAP_SYS_ADMIN.
+// With the fix for #3434, youki drops bounding to empty first, then capset() for the
+// non-empty inheritable is rejected by the kernel with EPERM (inheritable
+// caps must be in bounding). The test passes if the runtime surfaces EPERM.
+fn bounding_unset_with_other_caps_fails_test() -> TestResult {
+    let spec = test_result!({
+        let mut non_empty = HashSet::new();
+        non_empty.insert(Capability::SysAdmin);
+
+        let mut caps = LinuxCapabilitiesBuilder::default()
+            .effective(non_empty.clone())
+            .inheritable(non_empty.clone())
+            .permitted(non_empty)
+            .ambient(HashSet::new())
+            .build()
+            .expect("error in creating capabilities");
+        caps.set_bounding(None);
+
+        let process = ProcessBuilder::default()
+            .args(vec!["sleep".to_string(), "1s".to_string()])
+            .capabilities(caps)
+            .build()
+            .expect("error in creating process config");
+
+        SpecBuilder::default()
+            .process(process)
+            .build()
+            .context("failed to build spec")
+    });
+    let result = test_inside_container(&spec, &CreateOptions::default(), &|_| Ok(()));
+
+    match result {
+        TestResult::Failed(e) => {
+            let err = format!("{e:?}");
+            if err.contains("EPERM")
+                || err.contains("Operation not permitted")
+                || err.contains("operation not permitted")
+            {
+                TestResult::Passed
+            } else {
+                TestResult::Failed(anyhow!("expected EPERM in container error, got: {err}"))
+            }
+        }
+        TestResult::Passed => TestResult::Failed(anyhow!("container start unexpectedly succeeded")),
+        TestResult::Skipped => TestResult::Failed(anyhow!("test was skipped unexpectedly")),
+    }
+}
+
+pub fn get_process_capabilities_bounding_test() -> TestGroup {
+    let mut tg = TestGroup::new("process_capabilities_bounding");
+    let dropped = Test::new(
+        "bounding_dropped_when_unset_test",
+        Box::new(bounding_dropped_when_unset_test),
+    );
+    let fails = Test::new(
+        "bounding_unset_with_other_caps_fails_test",
+        Box::new(bounding_unset_with_other_caps_fails_test),
+    );
+    tg.add(vec![Box::new(dropped), Box::new(fails)]);
+    tg
+}

--- a/tests/contest/runtimetest/src/main.rs
+++ b/tests/contest/runtimetest/src/main.rs
@@ -48,6 +48,9 @@ fn main() {
         "memory_policy" => tests::validate_memory_policy(&spec),
         "devices" => tests::validate_devices(&spec),
         "root_readonly" => tests::test_validate_root_readonly(&spec),
+        "process_capabilities_bounding_unset" => {
+            tests::validate_process_capabilities_bounding_unset(&spec)
+        }
         "process" => tests::validate_process(&spec),
         "process_user" => tests::validate_process_user(&spec),
         "process_rlimits" => tests::validate_process_rlimits(&spec),

--- a/tests/contest/runtimetest/src/tests.rs
+++ b/tests/contest/runtimetest/src/tests.rs
@@ -862,6 +862,26 @@ pub fn validate_memory_policy(spec: &Spec) {
     }
 }
 
+pub fn validate_process_capabilities_bounding_unset(_spec: &Spec) {
+    let status = match fs::read_to_string("/proc/self/status") {
+        Ok(s) => s,
+        Err(e) => return eprintln!("failed to read /proc/self/status: {e}"),
+    };
+
+    for label in ["CapInh", "CapPrm", "CapEff", "CapBnd", "CapAmb"] {
+        let expected = format!("{label}:\t0000000000000000");
+        if !status.contains(&expected) {
+            let actual = status
+                .lines()
+                .find(|l| l.starts_with(label))
+                .unwrap_or("<missing>");
+            eprintln!(
+                "expected {label} to be all zeros when bounding is unset and other caps are empty, got: {actual}"
+            );
+        }
+    }
+}
+
 pub fn test_validate_root_readonly(spec: &Spec) {
     let root = spec.root().as_ref().unwrap();
     if root.readonly().unwrap() {


### PR DESCRIPTION
## Description
This PR fixes #3434: youki's `run` and `exec` paths handled a missing `.process.capabilities.bounding` inconsistently.

The table below shows the current state of things:
| command | reaction to missing bounding caps | result |
|---------|-----------------------------------|--------|
| sudo runc run | explicitly drop all bounding, then capset fails | fails |
| sudo youki run | don't touch bounding | succeeds |
| sudo youki exec | explicitly drop all bounding, then capset fails | fails (at exec!) |

The chosen way to fix it is essentially the same as it is in runc ([libcontainer/capabilities/capabilities.go#L100-L107](https://github.com/opencontainers/runc/blob/d0aeb9e3e22e02eec9f9a42416267a4f358cc571/libcontainer/capabilities/capabilities.go#L100-L107), [called here: libcontainer/init_linux.go#L340-L343](https://github.com/opencontainers/runc/blob/d0aeb9e3e22e02eec9f9a42416267a4f358cc571/libcontainer/init_linux.go#L340-L343)). Always clear bounding caps and then set only what was given (or nothing in case bounding is unset), after that apply.

## Type of Change
<!-- Mark the appropriate option with an [x] -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - it breaks all configs that have eff/inh/perm caps set but miss bounding (mostly hand-crafted oci configs)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test updates
- [ ] CI/CD related changes
- [ ] Other (please describe):

## Testing
<!-- Describe the tests you ran and/or added to verify your changes -->
- [ ] Added new unit tests
- [x] Added new integration tests
- [x] Ran existing test suite
- [ ] Tested manually (please provide steps)

## Related Issues
<!-- Link any related issues using the GitHub issue syntax: #issue-number
If there is no open issue for this, please add details of the problem or open a new issue. -->
Fixes #3434 

## Additional Context
<!-- Add any other context about the pull request here -->
