### PR TITLE
fix youki spec command overwrites the existing config.json

### DIFF
--- a/crates/youki/src/commands/spec_json.rs
+++ b/crates/youki/src/commands/spec_json.rs
@@ -1,8 +1,8 @@
 use std::fs::File;
-use std::io::{BufWriter, Write};
+use std::io::{BufWriter, ErrorKind, Write};
 use std::path::{Path, PathBuf};
 
-use anyhow::Result;
+use anyhow::{Result, anyhow};
 use libcontainer::oci_spec::runtime::{
     LinuxBuilder, LinuxIdMappingBuilder, LinuxNamespace, LinuxNamespaceBuilder, LinuxNamespaceType,
     Mount, Spec,
@@ -97,7 +97,12 @@ pub fn spec(args: liboci_cli::Spec, syscall: &dyn Syscall) -> Result<()> {
         Some(bundle) => bundle.join("config.json"),
         None => PathBuf::from("config.json"),
     };
-    let file = File::create(path)?;
+
+    let file = File::create_new(&path).map_err(|e| match e.kind() {
+        ErrorKind::AlreadyExists => anyhow!("File `config.json` already exists"),
+        _ => anyhow!(e),
+    })?;
+
     let mut writer = BufWriter::new(file);
     to_writer_pretty(&mut writer, &spec)?;
     writer.flush()?;
@@ -124,6 +129,31 @@ mod tests {
         spec(args, syscall.as_ref()).expect("failed to run spec subcommand");
         let config_path = tmpdir.path().join("config.json");
         assert!(config_path.is_file());
+        Ok(())
+    }
+
+    #[test]
+    #[serial]
+    fn test_spec_json_already_exists() -> Result<()> {
+        let tmpdir = tempfile::tempdir().expect("failed to create temp dir");
+        let args = liboci_cli::Spec {
+            bundle: Some(tmpdir.path().to_path_buf()),
+            rootless: true,
+        };
+        let syscall = create_syscall();
+
+        let config_path = tmpdir.path().join("config.json");
+        File::create(config_path).expect("failed to create initial config.json");
+
+        let result = spec(args, syscall.as_ref());
+        assert!(
+            result.is_err(),
+            "spec subcommand should fail if config.json already exists"
+        );
+
+        let err_msg = result.unwrap_err().to_string();
+        assert_eq!(err_msg, "File `config.json` already exists");
+
         Ok(())
     }
 }


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of your changes -->

## Type of Change
<!-- Mark the appropriate option with an [x] -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test updates
- [ ] CI/CD related changes
- [ ] Other (please describe):

## Testing
<!-- Describe the tests you ran and/or added to verify your changes -->
- [x] Added new unit tests
- [ ] Added new integration tests
- [ ] Ran existing test suite
- [x] Tested manually (please provide steps)

## Related Issues
<!-- Link any related issues using the GitHub issue syntax: #issue-number
If there is no open issue for this, please add details of the problem or open a new issue. -->
Fixes #3552

## Additional Context
<!-- Add any other context about the pull request here -->

```bash
./target/debug/youki spec # success

./target/debug/youki spec
ERROR youki: error in executing command: File `config.json` already exists
Error: File `config.json` already exists
```
