### PR TITLE
fix: validation differences between youki and runc

### DIFF
--- a/crates/libcontainer/src/container/init_builder.rs
+++ b/crates/libcontainer/src/container/init_builder.rs
@@ -227,6 +227,7 @@ impl InitContainerBuilder {
         }
 
         let syscall = create_syscall();
+        utils::validate_spec_for_uts_namespace(spec)?;
         utils::validate_spec_for_new_user_ns(spec, &*syscall)?;
         utils::validate_spec_for_net_devices(spec, &*syscall)
             .map_err(LibcontainerError::NetDevicesError)?;

--- a/crates/libcontainer/src/container/init_builder.rs
+++ b/crates/libcontainer/src/container/init_builder.rs
@@ -13,6 +13,7 @@ use crate::error::{ErrInvalidSpec, LibcontainerError, MissingSpecError};
 use crate::notify_socket::NOTIFY_FILE;
 use crate::process::args::ContainerType;
 use crate::syscall::syscall::create_syscall;
+use crate::validator::Validator;
 use crate::{apparmor, tty, user_ns, utils};
 
 // Builder that can be used to configure the properties of a new container
@@ -184,6 +185,8 @@ impl InitContainerBuilder {
             Err(ErrInvalidSpec::UnsupportedVersion)?;
         }
 
+        Validator::validate_spec(spec)?;
+
         if let Some(process) = spec.process() {
             if let Some(profile) = process.apparmor_profile() {
                 let apparmor_is_enabled = apparmor::is_enabled().map_err(|err| {
@@ -227,7 +230,6 @@ impl InitContainerBuilder {
         }
 
         let syscall = create_syscall();
-        utils::validate_spec_for_uts_namespace(spec)?;
         utils::validate_spec_for_new_user_ns(spec, &*syscall)?;
         utils::validate_spec_for_net_devices(spec, &*syscall)
             .map_err(LibcontainerError::NetDevicesError)?;

--- a/crates/libcontainer/src/container/init_builder.rs
+++ b/crates/libcontainer/src/container/init_builder.rs
@@ -201,28 +201,6 @@ impl InitContainerBuilder {
                     Err(ErrInvalidSpec::AppArmorNotEnabled)?;
                 }
             }
-
-            if let Some(io_priority) = process.io_priority() {
-                let priority = io_priority.priority();
-                let iop_class_res = serde_json::to_string(&io_priority.class());
-                match iop_class_res {
-                    Ok(iop_class) => {
-                        if !(0..=7).contains(&priority) {
-                            tracing::error!(
-                                ?priority,
-                                "io priority '{}' not between 0 and 7 (inclusive), class '{}' not in (IO_PRIO_CLASS_RT,IO_PRIO_CLASS_BE,IO_PRIO_CLASS_IDLE)",
-                                priority,
-                                iop_class
-                            );
-                            Err(ErrInvalidSpec::IoPriority)?;
-                        }
-                    }
-                    Err(e) => {
-                        tracing::error!(?priority, ?e, "failed to parse io priority class");
-                        Err(ErrInvalidSpec::IoPriority)?;
-                    }
-                }
-            }
         }
 
         if let Some(mounts) = spec.mounts() {

--- a/crates/libcontainer/src/container/tenant_builder.rs
+++ b/crates/libcontainer/src/container/tenant_builder.rs
@@ -443,6 +443,7 @@ impl TenantContainerBuilder {
         }
 
         let syscall = create_syscall();
+        utils::validate_spec_for_uts_namespace(spec)?;
         utils::validate_spec_for_new_user_ns(spec, &*syscall)?;
         utils::validate_spec_for_net_devices(spec, &*syscall)
             .map_err(LibcontainerError::NetDevicesError)?;

--- a/crates/libcontainer/src/container/tenant_builder.rs
+++ b/crates/libcontainer/src/container/tenant_builder.rs
@@ -14,7 +14,7 @@ use nix::unistd::{Pid, pipe2, read};
 use oci_spec::runtime::{
     Capabilities as SpecCapabilities, Capability as SpecCapability, LinuxBuilder,
     LinuxCapabilities, LinuxCapabilitiesBuilder, LinuxNamespace, LinuxNamespaceBuilder,
-    LinuxNamespaceType, LinuxSchedulerPolicy, Process, ProcessBuilder, Spec, UserBuilder,
+    LinuxNamespaceType, Process, ProcessBuilder, Spec, UserBuilder,
 };
 use procfs::process::Namespace;
 
@@ -377,65 +377,6 @@ impl TenantContainerBuilder {
                     Err(e) => {
                         tracing::error!(?priority, ?e, "failed to parse io priority class");
                         Err(ErrInvalidSpec::IoPriority)?;
-                    }
-                }
-            }
-
-            if let Some(sc) = process.scheduler() {
-                let policy = sc.policy();
-                if let Some(nice) = sc.nice() {
-                    // https://man7.org/linux/man-pages/man2/sched_setattr.2.html#top_of_page
-                    if (*policy == LinuxSchedulerPolicy::SchedBatch
-                        || *policy == LinuxSchedulerPolicy::SchedOther)
-                        && (*nice < -20 || *nice > 19)
-                    {
-                        tracing::error!(
-                            ?nice,
-                            "invalid scheduler.nice: '{}', must be within -20 to 19",
-                            nice
-                        );
-                        Err(ErrInvalidSpec::Scheduler)?;
-                    }
-                }
-                if let Some(priority) = sc.priority() {
-                    if *priority != 0
-                        && (*policy != LinuxSchedulerPolicy::SchedFifo
-                            && *policy != LinuxSchedulerPolicy::SchedRr)
-                    {
-                        tracing::error!(
-                            ?policy,
-                            "scheduler.priority can only be specified for SchedFIFO or SchedRR policy"
-                        );
-                        Err(ErrInvalidSpec::Scheduler)?;
-                    }
-                }
-                if *policy != LinuxSchedulerPolicy::SchedDeadline {
-                    if let Some(runtime) = sc.runtime() {
-                        if *runtime != 0 {
-                            tracing::error!(
-                                ?runtime,
-                                "scheduler runtime can only be specified for SchedDeadline policy"
-                            );
-                            Err(ErrInvalidSpec::Scheduler)?;
-                        }
-                    }
-                    if let Some(deadline) = sc.deadline() {
-                        if *deadline != 0 {
-                            tracing::error!(
-                                ?deadline,
-                                "scheduler deadline can only be specified for SchedDeadline policy"
-                            );
-                            Err(ErrInvalidSpec::Scheduler)?;
-                        }
-                    }
-                    if let Some(period) = sc.period() {
-                        if *period != 0 {
-                            tracing::error!(
-                                ?period,
-                                "scheduler period can only be specified for SchedDeadline policy"
-                            );
-                            Err(ErrInvalidSpec::Scheduler)?;
-                        }
                     }
                 }
             }

--- a/crates/libcontainer/src/container/tenant_builder.rs
+++ b/crates/libcontainer/src/container/tenant_builder.rs
@@ -358,30 +358,6 @@ impl TenantContainerBuilder {
 
         Validator::validate_spec(spec)?;
 
-        if let Some(process) = spec.process() {
-            if let Some(io_priority) = process.io_priority() {
-                let priority = io_priority.priority();
-                let iop_class_res = serde_json::to_string(&io_priority.class());
-                match iop_class_res {
-                    Ok(iop_class) => {
-                        if !(0..=7).contains(&priority) {
-                            tracing::error!(
-                                ?priority,
-                                "io priority '{}' not between 0 and 7 (inclusive), class '{}' not in (IO_PRIO_CLASS_RT,IO_PRIO_CLASS_BE,IO_PRIO_CLASS_IDLE)",
-                                priority,
-                                iop_class
-                            );
-                            Err(ErrInvalidSpec::IoPriority)?;
-                        }
-                    }
-                    Err(e) => {
-                        tracing::error!(?priority, ?e, "failed to parse io priority class");
-                        Err(ErrInvalidSpec::IoPriority)?;
-                    }
-                }
-            }
-        }
-
         if let Some(mounts) = spec.mounts() {
             utils::validate_mount_options(mounts)?;
         }

--- a/crates/libcontainer/src/container/tenant_builder.rs
+++ b/crates/libcontainer/src/container/tenant_builder.rs
@@ -28,6 +28,7 @@ use crate::notify_socket::NotifySocket;
 use crate::process::args::ContainerType;
 use crate::syscall::syscall::create_syscall;
 use crate::user_ns::UserNamespaceConfig;
+use crate::validator::Validator;
 use crate::{tty, utils};
 
 const NAMESPACE_TYPES: &[&str] = &["ipc", "uts", "net", "pid", "mnt", "cgroup"];
@@ -355,6 +356,8 @@ impl TenantContainerBuilder {
             Err(ErrInvalidSpec::UnsupportedVersion)?;
         }
 
+        Validator::validate_spec(spec)?;
+
         if let Some(process) = spec.process() {
             if let Some(io_priority) = process.io_priority() {
                 let priority = io_priority.priority();
@@ -443,7 +446,6 @@ impl TenantContainerBuilder {
         }
 
         let syscall = create_syscall();
-        utils::validate_spec_for_uts_namespace(spec)?;
         utils::validate_spec_for_new_user_ns(spec, &*syscall)?;
         utils::validate_spec_for_net_devices(spec, &*syscall)
             .map_err(LibcontainerError::NetDevicesError)?;

--- a/crates/libcontainer/src/error.rs
+++ b/crates/libcontainer/src/error.rs
@@ -128,6 +128,8 @@ pub enum ErrInvalidSpec {
     SysctlNotAllowedInHostUser(String),
     #[error("sysctl {0} is not in a separate kernel namespace")]
     SysctlNotInSeparateNamespace(String),
+    #[error("invalid intelRdt.closID (must not contain '.', '..', or '/')")]
+    InvalidIntelRdtClosId,
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/crates/libcontainer/src/error.rs
+++ b/crates/libcontainer/src/error.rs
@@ -114,6 +114,8 @@ pub enum ErrInvalidSpec {
     DomainnameWithoutUTS,
     #[error("user namespace mappings specified, but user namespace isn't enabled in the config")]
     UserMappingsWithoutNamespace,
+    #[error("unable to restrict sys entries without a private MNT namespace")]
+    SysEntriesWithoutMntNamespace,
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/crates/libcontainer/src/error.rs
+++ b/crates/libcontainer/src/error.rs
@@ -112,6 +112,8 @@ pub enum ErrInvalidSpec {
     HostnameWithoutUTS,
     #[error("unable to set domainname without a private UTS namespace")]
     DomainnameWithoutUTS,
+    #[error("user namespace mappings specified, but user namespace isn't enabled in the config")]
+    UserMappingsWithoutNamespace,
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/crates/libcontainer/src/error.rs
+++ b/crates/libcontainer/src/error.rs
@@ -32,7 +32,7 @@ pub enum LibcontainerError {
     InvalidID(#[from] ErrInvalidID),
     #[error(transparent)]
     MissingSpec(#[from] MissingSpecError),
-    #[error("invalid runtime spec")]
+    #[error(transparent)]
     InvalidSpec(#[from] ErrInvalidSpec),
 
     // Errors from submodules and other errors
@@ -108,6 +108,10 @@ pub enum ErrInvalidSpec {
     ConsoleSocketRequired,
     #[error("cannot use console socket if youki will not detach or allocate tty")]
     InvalidConsoleSocket,
+    #[error("unable to set hostname without a private UTS namespace")]
+    HostnameWithoutUTS,
+    #[error("unable to set domainname without a private UTS namespace")]
+    DomainnameWithoutUTS,
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/crates/libcontainer/src/error.rs
+++ b/crates/libcontainer/src/error.rs
@@ -102,8 +102,8 @@ pub enum ErrInvalidSpec {
     AppArmorNotEnabled,
     #[error("invalid io priority or class.")]
     IoPriority,
-    #[error("invalid scheduler config for process")]
-    Scheduler,
+    #[error("invalid scheduler config for process: {0}")]
+    Scheduler(String),
     #[error("cannot allocate tty if youki will detach without setting console socket")]
     ConsoleSocketRequired,
     #[error("cannot use console socket if youki will not detach or allocate tty")]

--- a/crates/libcontainer/src/error.rs
+++ b/crates/libcontainer/src/error.rs
@@ -108,6 +108,8 @@ pub enum ErrInvalidSpec {
     ConsoleSocketRequired,
     #[error("cannot use console socket if youki will not detach or allocate tty")]
     InvalidConsoleSocket,
+    #[error("invalid netns path: {0}")]
+    InvalidNetNsPath(String),
     #[error("unable to set hostname without a private UTS namespace")]
     HostnameWithoutUTS,
     #[error("unable to set domainname without a private UTS namespace")]

--- a/crates/libcontainer/src/error.rs
+++ b/crates/libcontainer/src/error.rs
@@ -116,6 +116,16 @@ pub enum ErrInvalidSpec {
     UserMappingsWithoutNamespace,
     #[error("unable to restrict sys entries without a private MNT namespace")]
     SysEntriesWithoutMntNamespace,
+    #[error("sysctl {0} is not allowed in the hosts ipc namespace")]
+    SysctlNotAllowedInHostIpc(String),
+    #[error("sysctl {0} not allowed in host network namespace")]
+    SysctlNotAllowedInHostNet(String),
+    #[error("sysctl {0} is not allowed as it conflicts with the OCI {1} field")]
+    SysctlConflictsWithOci(String, String),
+    #[error("setting ucounts without a user namespace not allowed: {0}")]
+    SysctlNotAllowedInHostUser(String),
+    #[error("sysctl {0} is not in a separate kernel namespace")]
+    SysctlNotInSeparateNamespace(String),
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/crates/libcontainer/src/lib.rs
+++ b/crates/libcontainer/src/lib.rs
@@ -18,6 +18,7 @@ pub mod test_utils;
 pub mod tty;
 pub mod user_ns;
 pub mod utils;
+pub mod validator;
 pub mod workload;
 
 // Because the `libcontainer` api uses the oci_spec who resides in a different

--- a/crates/libcontainer/src/utils.rs
+++ b/crates/libcontainer/src/utils.rs
@@ -14,7 +14,7 @@ use nix::sys::statfs::{Statfs, fstatfs};
 use nix::unistd::{Uid, User};
 use oci_spec::runtime::{LinuxNamespaceType, Spec};
 
-use crate::error::{ErrInvalidSpec, LibcontainerError, MissingSpecError};
+use crate::error::{LibcontainerError, MissingSpecError};
 use crate::syscall::syscall::Syscall;
 use crate::user_ns::UserNamespaceConfig;
 
@@ -277,33 +277,6 @@ pub fn validate_spec_for_new_user_ns(
     spec: &Spec,
     syscall: &dyn Syscall,
 ) -> Result<(), LibcontainerError> {
-    let has_user_namespace = spec
-        .linux()
-        .as_ref()
-        .and_then(|l| l.namespaces().as_ref())
-        .is_some_and(|namespace| {
-            namespace
-                .iter()
-                .any(|ns| ns.typ() == oci_spec::runtime::LinuxNamespaceType::User)
-        });
-
-    if !has_user_namespace {
-        let has_uid_mappings = spec
-            .linux()
-            .as_ref()
-            .is_some_and(|l| l.uid_mappings().as_ref().is_some_and(|m| !m.is_empty()));
-        let has_gid_mappings = spec
-            .linux()
-            .as_ref()
-            .is_some_and(|l| l.gid_mappings().as_ref().is_some_and(|m| !m.is_empty()));
-
-        if has_uid_mappings || has_gid_mappings {
-            return Err(LibcontainerError::InvalidSpec(
-                ErrInvalidSpec::UserMappingsWithoutNamespace,
-            ));
-        }
-    }
-
     let config = UserNamespaceConfig::new(spec)?;
     let in_user_ns = is_in_new_userns().map_err(LibcontainerError::OtherIO)?;
     let is_rootless_required = rootless_required(syscall).map_err(LibcontainerError::OtherIO)?;

--- a/crates/libcontainer/src/utils.rs
+++ b/crates/libcontainer/src/utils.rs
@@ -277,6 +277,33 @@ pub fn validate_spec_for_new_user_ns(
     spec: &Spec,
     syscall: &dyn Syscall,
 ) -> Result<(), LibcontainerError> {
+    let has_user_namespace = spec
+        .linux()
+        .as_ref()
+        .and_then(|l| l.namespaces().as_ref())
+        .is_some_and(|namespace| {
+            namespace
+                .iter()
+                .any(|ns| ns.typ() == oci_spec::runtime::LinuxNamespaceType::User)
+        });
+
+    if !has_user_namespace {
+        let has_uid_mappings = spec
+            .linux()
+            .as_ref()
+            .is_some_and(|l| l.uid_mappings().as_ref().is_some_and(|m| !m.is_empty()));
+        let has_gid_mappings = spec
+            .linux()
+            .as_ref()
+            .is_some_and(|l| l.gid_mappings().as_ref().is_some_and(|m| !m.is_empty()));
+
+        if has_uid_mappings || has_gid_mappings {
+            return Err(LibcontainerError::InvalidSpec(
+                ErrInvalidSpec::UserMappingsWithoutNamespace,
+            ));
+        }
+    }
+
     let config = UserNamespaceConfig::new(spec)?;
     let in_user_ns = is_in_new_userns().map_err(LibcontainerError::OtherIO)?;
     let is_rootless_required = rootless_required(syscall).map_err(LibcontainerError::OtherIO)?;
@@ -449,11 +476,13 @@ mod tests {
 
     use anyhow::{Result, bail};
     use nix::unistd::Gid;
-    use oci_spec::runtime::{LinuxBuilder, LinuxNamespaceBuilder, LinuxNetDevice, SpecBuilder};
+    use oci_spec::runtime::{
+        LinuxBuilder, LinuxIdMappingBuilder, LinuxNamespaceBuilder, LinuxNetDevice, SpecBuilder,
+    };
     use serial_test::serial;
 
     use super::*;
-    use crate::syscall::syscall::create_syscall;
+    use crate::syscall::{syscall::create_syscall, test::TestHelperSyscall};
     use crate::test_utils;
 
     #[test]
@@ -685,10 +714,6 @@ mod tests {
 
     #[test]
     fn test_validate_spec_for_uts_namespace() {
-        use oci_spec::runtime::{
-            LinuxBuilder, LinuxNamespaceBuilder, LinuxNamespaceType, SpecBuilder,
-        };
-
         let sepc_no_uts_with_hostname = SpecBuilder::default()
             .hostname("some-host")
             .linux(LinuxBuilder::default().namespaces(vec![]).build().unwrap())
@@ -733,5 +758,31 @@ mod tests {
             .build()
             .unwrap();
         assert!(validate_spec_for_uts_namespace(&spec_no_uts_no_host_domain_names).is_ok());
+    }
+
+    #[test]
+    fn test_validate_user_ns_mappings() {
+        let syscall = TestHelperSyscall::default();
+        let spec_with_mappings_no_ns = SpecBuilder::default()
+            .linux(
+                LinuxBuilder::default()
+                    .namespaces(vec![])
+                    .uid_mappings(vec![
+                        LinuxIdMappingBuilder::default()
+                            .container_id(0_u32)
+                            .host_id(1000_u32)
+                            .size(1_u32)
+                            .build()
+                            .unwrap(),
+                    ])
+                    .build()
+                    .unwrap(),
+            )
+            .build()
+            .unwrap();
+        assert!(matches!(
+            validate_spec_for_new_user_ns(&spec_with_mappings_no_ns, &syscall).unwrap_err(),
+            LibcontainerError::InvalidSpec(ErrInvalidSpec::UserMappingsWithoutNamespace)
+        ));
     }
 }

--- a/crates/libcontainer/src/utils.rs
+++ b/crates/libcontainer/src/utils.rs
@@ -446,43 +446,17 @@ fn dev_valid_name(name: &str) -> bool {
     true
 }
 
-pub fn validate_spec_for_uts_namespace(spec: &Spec) -> Result<(), ErrInvalidSpec> {
-    let has_uts_namespace = spec
-        .linux()
-        .as_ref()
-        .and_then(|l| l.namespaces().as_ref())
-        .is_some_and(|namespace| {
-            namespace
-                .iter()
-                .any(|ns| ns.typ() == oci_spec::runtime::LinuxNamespaceType::Uts)
-        });
-
-    if !has_uts_namespace {
-        if spec.hostname().is_some() {
-            return Err(ErrInvalidSpec::HostnameWithoutUTS);
-        }
-
-        if spec.domainname().is_some() {
-            return Err(ErrInvalidSpec::DomainnameWithoutUTS);
-        }
-    }
-
-    Ok(())
-}
-
 #[cfg(test)]
 mod tests {
     use core::panic;
 
     use anyhow::{Result, bail};
     use nix::unistd::Gid;
-    use oci_spec::runtime::{
-        LinuxBuilder, LinuxIdMappingBuilder, LinuxNamespaceBuilder, LinuxNetDevice, SpecBuilder,
-    };
+    use oci_spec::runtime::{LinuxBuilder, LinuxNamespaceBuilder, LinuxNetDevice, SpecBuilder};
     use serial_test::serial;
 
     use super::*;
-    use crate::syscall::{syscall::create_syscall, test::TestHelperSyscall};
+    use crate::syscall::syscall::create_syscall;
     use crate::test_utils;
 
     #[test]
@@ -710,79 +684,5 @@ mod tests {
         syscall.set_id(Uid::from_raw(0), Gid::from_raw(0)).unwrap();
         let result = validate_spec_for_net_devices(&spec, &*syscall);
         assert!(result.is_ok());
-    }
-
-    #[test]
-    fn test_validate_spec_for_uts_namespace() {
-        let sepc_no_uts_with_hostname = SpecBuilder::default()
-            .hostname("some-host")
-            .linux(LinuxBuilder::default().namespaces(vec![]).build().unwrap())
-            .build()
-            .unwrap();
-        assert!(matches!(
-            validate_spec_for_uts_namespace(&sepc_no_uts_with_hostname).unwrap_err(),
-            ErrInvalidSpec::HostnameWithoutUTS
-        ));
-
-        let mut spec_no_uts_with_domainname = SpecBuilder::default()
-            .domainname("some-domain")
-            .linux(LinuxBuilder::default().namespaces(vec![]).build().unwrap())
-            .build()
-            .unwrap();
-        spec_no_uts_with_domainname.set_hostname(None);
-        assert!(matches!(
-            validate_spec_for_uts_namespace(&spec_no_uts_with_domainname).unwrap_err(),
-            ErrInvalidSpec::DomainnameWithoutUTS
-        ));
-
-        let spec_with_uts_and_host_domain_names = SpecBuilder::default()
-            .hostname("my-host")
-            .domainname("my-domain")
-            .linux(
-                LinuxBuilder::default()
-                    .namespaces(vec![
-                        LinuxNamespaceBuilder::default()
-                            .typ(LinuxNamespaceType::Uts)
-                            .build()
-                            .unwrap(),
-                    ])
-                    .build()
-                    .unwrap(),
-            )
-            .build()
-            .unwrap();
-        assert!(validate_spec_for_uts_namespace(&spec_with_uts_and_host_domain_names).is_ok());
-
-        let spec_no_uts_no_host_domain_names = SpecBuilder::default()
-            .linux(LinuxBuilder::default().build().unwrap())
-            .build()
-            .unwrap();
-        assert!(validate_spec_for_uts_namespace(&spec_no_uts_no_host_domain_names).is_ok());
-    }
-
-    #[test]
-    fn test_validate_user_ns_mappings() {
-        let syscall = TestHelperSyscall::default();
-        let spec_with_mappings_no_ns = SpecBuilder::default()
-            .linux(
-                LinuxBuilder::default()
-                    .namespaces(vec![])
-                    .uid_mappings(vec![
-                        LinuxIdMappingBuilder::default()
-                            .container_id(0_u32)
-                            .host_id(1000_u32)
-                            .size(1_u32)
-                            .build()
-                            .unwrap(),
-                    ])
-                    .build()
-                    .unwrap(),
-            )
-            .build()
-            .unwrap();
-        assert!(matches!(
-            validate_spec_for_new_user_ns(&spec_with_mappings_no_ns, &syscall).unwrap_err(),
-            LibcontainerError::InvalidSpec(ErrInvalidSpec::UserMappingsWithoutNamespace)
-        ));
     }
 }

--- a/crates/libcontainer/src/utils.rs
+++ b/crates/libcontainer/src/utils.rs
@@ -14,7 +14,7 @@ use nix::sys::statfs::{Statfs, fstatfs};
 use nix::unistd::{Uid, User};
 use oci_spec::runtime::{LinuxNamespaceType, Spec};
 
-use crate::error::{LibcontainerError, MissingSpecError};
+use crate::error::{ErrInvalidSpec, LibcontainerError, MissingSpecError};
 use crate::syscall::syscall::Syscall;
 use crate::user_ns::UserNamespaceConfig;
 
@@ -419,6 +419,30 @@ fn dev_valid_name(name: &str) -> bool {
     true
 }
 
+pub fn validate_spec_for_uts_namespace(spec: &Spec) -> Result<(), ErrInvalidSpec> {
+    let has_uts_namespace = spec
+        .linux()
+        .as_ref()
+        .and_then(|l| l.namespaces().as_ref())
+        .is_some_and(|namespace| {
+            namespace
+                .iter()
+                .any(|ns| ns.typ() == oci_spec::runtime::LinuxNamespaceType::Uts)
+        });
+
+    if !has_uts_namespace {
+        if spec.hostname().is_some() {
+            return Err(ErrInvalidSpec::HostnameWithoutUTS);
+        }
+
+        if spec.domainname().is_some() {
+            return Err(ErrInvalidSpec::DomainnameWithoutUTS);
+        }
+    }
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use core::panic;
@@ -657,5 +681,57 @@ mod tests {
         syscall.set_id(Uid::from_raw(0), Gid::from_raw(0)).unwrap();
         let result = validate_spec_for_net_devices(&spec, &*syscall);
         assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_validate_spec_for_uts_namespace() {
+        use oci_spec::runtime::{
+            LinuxBuilder, LinuxNamespaceBuilder, LinuxNamespaceType, SpecBuilder,
+        };
+
+        let sepc_no_uts_with_hostname = SpecBuilder::default()
+            .hostname("some-host")
+            .linux(LinuxBuilder::default().namespaces(vec![]).build().unwrap())
+            .build()
+            .unwrap();
+        assert!(matches!(
+            validate_spec_for_uts_namespace(&sepc_no_uts_with_hostname).unwrap_err(),
+            ErrInvalidSpec::HostnameWithoutUTS
+        ));
+
+        let mut spec_no_uts_with_domainname = SpecBuilder::default()
+            .domainname("some-domain")
+            .linux(LinuxBuilder::default().namespaces(vec![]).build().unwrap())
+            .build()
+            .unwrap();
+        spec_no_uts_with_domainname.set_hostname(None);
+        assert!(matches!(
+            validate_spec_for_uts_namespace(&spec_no_uts_with_domainname).unwrap_err(),
+            ErrInvalidSpec::DomainnameWithoutUTS
+        ));
+
+        let spec_with_uts_and_host_domain_names = SpecBuilder::default()
+            .hostname("my-host")
+            .domainname("my-domain")
+            .linux(
+                LinuxBuilder::default()
+                    .namespaces(vec![
+                        LinuxNamespaceBuilder::default()
+                            .typ(LinuxNamespaceType::Uts)
+                            .build()
+                            .unwrap(),
+                    ])
+                    .build()
+                    .unwrap(),
+            )
+            .build()
+            .unwrap();
+        assert!(validate_spec_for_uts_namespace(&spec_with_uts_and_host_domain_names).is_ok());
+
+        let spec_no_uts_no_host_domain_names = SpecBuilder::default()
+            .linux(LinuxBuilder::default().build().unwrap())
+            .build()
+            .unwrap();
+        assert!(validate_spec_for_uts_namespace(&spec_no_uts_no_host_domain_names).is_ok());
     }
 }

--- a/crates/libcontainer/src/validator.rs
+++ b/crates/libcontainer/src/validator.rs
@@ -16,6 +16,7 @@ impl Validator {
         Self::validate_spec_for_sysctl(spec)?;
         Self::validate_spec_for_scheduler(spec)?;
         Self::validate_spec_for_io_priority(spec)?;
+        Self::validate_spec_for_intel_rdt(spec)?;
 
         Ok(())
     }
@@ -262,13 +263,30 @@ impl Validator {
 
         Ok(())
     }
+
+    fn validate_spec_for_intel_rdt(spec: &Spec) -> Result<(), ErrInvalidSpec> {
+        if let Some(linux) = spec.linux() {
+            if let Some(intel_rdt) = linux.intel_rdt() {
+                if let Some(clos_id) = intel_rdt.clos_id() {
+                    if clos_id == "."
+                        || clos_id == ".."
+                        || (clos_id.len() > 1 && clos_id.contains('/'))
+                    {
+                        return Err(ErrInvalidSpec::InvalidIntelRdtClosId);
+                    }
+                }
+            }
+        }
+
+        Ok(())
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use oci_spec::runtime::{
         IOPriorityClass, LinuxBuilder, LinuxIOPriorityBuilder, LinuxIdMappingBuilder,
-        LinuxNamespaceBuilder, ProcessBuilder, SchedulerBuilder, SpecBuilder,
+        LinuxIntelRdtBuilder, LinuxNamespaceBuilder, ProcessBuilder, SchedulerBuilder, SpecBuilder,
     };
 
     use super::*;
@@ -700,5 +718,113 @@ mod tests {
             .build()
             .unwrap();
         assert!(Validator::validate_spec_for_io_priority(&valid_spec_edge).is_ok());
+    }
+
+    #[test]
+    fn test_validate_spec_for_intel_rdt() {
+        let intel_rdt_traversal_dotdot = LinuxIntelRdtBuilder::default()
+            .clos_id("../escape")
+            .build()
+            .unwrap();
+        let spec_traversal_dotdot = SpecBuilder::default()
+            .linux(
+                LinuxBuilder::default()
+                    .intel_rdt(intel_rdt_traversal_dotdot)
+                    .build()
+                    .unwrap(),
+            )
+            .build()
+            .unwrap();
+        assert!(matches!(
+            Validator::validate_spec_for_intel_rdt(&spec_traversal_dotdot).unwrap_err(),
+            ErrInvalidSpec::InvalidIntelRdtClosId
+        ));
+
+        let intel_rdt_traversal_slash = LinuxIntelRdtBuilder::default()
+            .clos_id("/absolute/path")
+            .build()
+            .unwrap();
+        let spec_traversal_slash = SpecBuilder::default()
+            .linux(
+                LinuxBuilder::default()
+                    .intel_rdt(intel_rdt_traversal_slash)
+                    .build()
+                    .unwrap(),
+            )
+            .build()
+            .unwrap();
+        assert!(matches!(
+            Validator::validate_spec_for_intel_rdt(&spec_traversal_slash).unwrap_err(),
+            ErrInvalidSpec::InvalidIntelRdtClosId
+        ));
+
+        let intel_rdt_valid_id = LinuxIntelRdtBuilder::default()
+            .clos_id("valid-clos-id-123")
+            .build()
+            .unwrap();
+        let spec_valid_id = SpecBuilder::default()
+            .linux(
+                LinuxBuilder::default()
+                    .intel_rdt(intel_rdt_valid_id)
+                    .build()
+                    .unwrap(),
+            )
+            .build()
+            .unwrap();
+        assert!(Validator::validate_spec_for_intel_rdt(&spec_valid_id).is_ok());
+
+        let intel_rdt_traversal_dot = LinuxIntelRdtBuilder::default()
+            .clos_id(".")
+            .build()
+            .unwrap();
+        let spec_traversal_dot = SpecBuilder::default()
+            .linux(
+                LinuxBuilder::default()
+                    .intel_rdt(intel_rdt_traversal_dot)
+                    .build()
+                    .unwrap(),
+            )
+            .build()
+            .unwrap();
+        assert!(matches!(
+            Validator::validate_spec_for_intel_rdt(&spec_traversal_dot).unwrap_err(),
+            ErrInvalidSpec::InvalidIntelRdtClosId
+        ));
+
+        let intel_rdt_traversal_nested = LinuxIntelRdtBuilder::default()
+            .clos_id("some/path")
+            .build()
+            .unwrap();
+        let spec_traversal_nested = SpecBuilder::default()
+            .linux(
+                LinuxBuilder::default()
+                    .intel_rdt(intel_rdt_traversal_nested)
+                    .build()
+                    .unwrap(),
+            )
+            .build()
+            .unwrap();
+        assert!(matches!(
+            Validator::validate_spec_for_intel_rdt(&spec_traversal_nested).unwrap_err(),
+            ErrInvalidSpec::InvalidIntelRdtClosId
+        ));
+
+        let intel_rdt_traversal_trailing = LinuxIntelRdtBuilder::default()
+            .clos_id("clos_id/")
+            .build()
+            .unwrap();
+        let spec_traversal_trailing = SpecBuilder::default()
+            .linux(
+                LinuxBuilder::default()
+                    .intel_rdt(intel_rdt_traversal_trailing)
+                    .build()
+                    .unwrap(),
+            )
+            .build()
+            .unwrap();
+        assert!(matches!(
+            Validator::validate_spec_for_intel_rdt(&spec_traversal_trailing).unwrap_err(),
+            ErrInvalidSpec::InvalidIntelRdtClosId
+        ));
     }
 }

--- a/crates/libcontainer/src/validator.rs
+++ b/crates/libcontainer/src/validator.rs
@@ -15,6 +15,7 @@ impl Validator {
         Self::validate_spec_for_mnt_namespace(spec)?;
         Self::validate_spec_for_sysctl(spec)?;
         Self::validate_spec_for_scheduler(spec)?;
+        Self::validate_spec_for_io_priority(spec)?;
 
         Ok(())
     }
@@ -247,13 +248,27 @@ impl Validator {
 
         Ok(())
     }
+
+    fn validate_spec_for_io_priority(spec: &Spec) -> Result<(), ErrInvalidSpec> {
+        if let Some(process) = spec.process() {
+            if let Some(io_priority) = process.io_priority() {
+                let priority = io_priority.priority();
+
+                if !(0..=7).contains(&priority) {
+                    return Err(ErrInvalidSpec::IoPriority);
+                }
+            }
+        }
+
+        Ok(())
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use oci_spec::runtime::{
-        LinuxBuilder, LinuxIdMappingBuilder, LinuxNamespaceBuilder, ProcessBuilder,
-        SchedulerBuilder, SpecBuilder,
+        IOPriorityClass, LinuxBuilder, LinuxIOPriorityBuilder, LinuxIdMappingBuilder,
+        LinuxNamespaceBuilder, ProcessBuilder, SchedulerBuilder, SpecBuilder,
     };
 
     use super::*;
@@ -615,5 +630,75 @@ mod tests {
                 .unwrap(),
         );
         assert!(Validator::validate_spec_for_scheduler(&spec).is_err());
+    }
+
+    #[test]
+    fn test_validate_spec_for_io_priority() {
+        let valid_io = LinuxIOPriorityBuilder::default()
+            .class(IOPriorityClass::IoprioClassBe)
+            .priority(4)
+            .build()
+            .unwrap();
+        let valid_spec = SpecBuilder::default()
+            .process(
+                ProcessBuilder::default()
+                    .io_priority(valid_io)
+                    .build()
+                    .unwrap(),
+            )
+            .build()
+            .unwrap();
+        assert!(Validator::validate_spec_for_io_priority(&valid_spec).is_ok());
+
+        let invalid_io_high = LinuxIOPriorityBuilder::default()
+            .class(IOPriorityClass::IoprioClassRt)
+            .priority(8)
+            .build()
+            .unwrap();
+        let invalid_spec_high = SpecBuilder::default()
+            .process(
+                ProcessBuilder::default()
+                    .io_priority(invalid_io_high)
+                    .build()
+                    .unwrap(),
+            )
+            .build()
+            .unwrap();
+        assert!(matches!(
+            Validator::validate_spec_for_io_priority(&invalid_spec_high).unwrap_err(),
+            ErrInvalidSpec::IoPriority
+        ));
+
+        let valid_io_low = LinuxIOPriorityBuilder::default()
+            .class(IOPriorityClass::IoprioClassIdle)
+            .priority(0)
+            .build()
+            .unwrap();
+        let valid_spec_low = SpecBuilder::default()
+            .process(
+                ProcessBuilder::default()
+                    .io_priority(valid_io_low)
+                    .build()
+                    .unwrap(),
+            )
+            .build()
+            .unwrap();
+        assert!(Validator::validate_spec_for_io_priority(&valid_spec_low).is_ok());
+
+        let valid_io_edge = LinuxIOPriorityBuilder::default()
+            .class(IOPriorityClass::IoprioClassRt)
+            .priority(7)
+            .build()
+            .unwrap();
+        let valid_spec_edge = SpecBuilder::default()
+            .process(
+                ProcessBuilder::default()
+                    .io_priority(valid_io_edge)
+                    .build()
+                    .unwrap(),
+            )
+            .build()
+            .unwrap();
+        assert!(Validator::validate_spec_for_io_priority(&valid_spec_edge).is_ok());
     }
 }

--- a/crates/libcontainer/src/validator.rs
+++ b/crates/libcontainer/src/validator.rs
@@ -1,7 +1,8 @@
-use std::{collections::HashSet, path::Path};
+use std::collections::HashSet;
+use std::path::Path;
 
 use nix::sys::stat::stat;
-use oci_spec::runtime::{LinuxNamespaceType, Spec};
+use oci_spec::runtime::{LinuxNamespaceType, LinuxSchedulerPolicy, Spec};
 
 use crate::error::ErrInvalidSpec;
 
@@ -13,6 +14,7 @@ impl Validator {
         Self::validate_spec_for_new_user_ns(spec)?;
         Self::validate_spec_for_mnt_namespace(spec)?;
         Self::validate_spec_for_sysctl(spec)?;
+        Self::validate_spec_for_scheduler(spec)?;
 
         Ok(())
     }
@@ -197,12 +199,61 @@ impl Validator {
 
         Ok(())
     }
+
+    fn validate_spec_for_scheduler(spec: &Spec) -> Result<(), ErrInvalidSpec> {
+        // https://man7.org/linux/man-pages/man2/sched_setattr.2.html#top_of_page
+        if let Some(process) = spec.process() {
+            if let Some(scheduler) = process.scheduler() {
+                let policy = scheduler.policy();
+
+                if *policy == LinuxSchedulerPolicy::SchedOther
+                    || *policy == LinuxSchedulerPolicy::SchedBatch
+                {
+                    if let Some(nice) = scheduler.nice() {
+                        if !(-20..=19).contains(nice) {
+                            return Err(ErrInvalidSpec::Scheduler(format!(
+                                "invalid scheduler.nice: '{}', must be within -20 to 19",
+                                nice
+                            )));
+                        }
+                    }
+                }
+
+                if let Some(priority) = scheduler.priority() {
+                    if *priority != 0
+                        && *policy != LinuxSchedulerPolicy::SchedFifo
+                        && *policy != LinuxSchedulerPolicy::SchedRr
+                    {
+                        return Err(ErrInvalidSpec::Scheduler(
+                                "scheduler.priority can only be specified for SchedFIFO or SchedRR policy".to_string(),
+                            ));
+                    }
+                }
+
+                if *policy != LinuxSchedulerPolicy::SchedDeadline
+                    && (scheduler.runtime().is_some_and(|r| r != 0)
+                        || scheduler.deadline().is_some_and(|d| d != 0)
+                        || scheduler.period().is_some_and(|p| p != 0))
+                {
+                    {
+                        return Err(ErrInvalidSpec::Scheduler(
+                            "scheduler runtime/deadline/period can only be specified for SchedDeadline policy"
+                                .to_string(),
+                        ));
+                    }
+                }
+            }
+        }
+
+        Ok(())
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use oci_spec::runtime::{
-        LinuxBuilder, LinuxIdMappingBuilder, LinuxNamespaceBuilder, SpecBuilder,
+        LinuxBuilder, LinuxIdMappingBuilder, LinuxNamespaceBuilder, ProcessBuilder,
+        SchedulerBuilder, SpecBuilder,
     };
 
     use super::*;
@@ -417,5 +468,152 @@ mod tests {
             Validator::validate_spec_for_sysctl(&spec_uts_conflict).unwrap_err(),
             ErrInvalidSpec::SysctlConflictsWithOci(_, _)
         ));
+    }
+
+    #[test]
+    fn test_validate_spec_for_scheduler() {
+        let build_spec = |scheduler| {
+            SpecBuilder::default()
+                .process(
+                    ProcessBuilder::default()
+                        .scheduler(scheduler)
+                        .build()
+                        .unwrap(),
+                )
+                .build()
+                .unwrap()
+        };
+
+        // Valid: SchedOther with Nice 0
+        let spec = build_spec(
+            SchedulerBuilder::default()
+                .policy(LinuxSchedulerPolicy::SchedOther)
+                .nice(0)
+                .build()
+                .unwrap(),
+        );
+        assert!(Validator::validate_spec_for_scheduler(&spec).is_ok());
+
+        // Valid: SchedBatch with Nice 19
+        let spec = build_spec(
+            SchedulerBuilder::default()
+                .policy(LinuxSchedulerPolicy::SchedBatch)
+                .nice(19)
+                .build()
+                .unwrap(),
+        );
+        assert!(Validator::validate_spec_for_scheduler(&spec).is_ok());
+
+        // Invalid: SchedOther with Nice 20 (out of bounds)
+        let spec = build_spec(
+            SchedulerBuilder::default()
+                .policy(LinuxSchedulerPolicy::SchedOther)
+                .nice(20)
+                .build()
+                .unwrap(),
+        );
+        assert!(Validator::validate_spec_for_scheduler(&spec).is_err());
+
+        // Invalid: SchedBatch with Nice -21 (out of bounds)
+        let spec = build_spec(
+            SchedulerBuilder::default()
+                .policy(LinuxSchedulerPolicy::SchedBatch)
+                .nice(-21)
+                .build()
+                .unwrap(),
+        );
+        assert!(Validator::validate_spec_for_scheduler(&spec).is_err());
+
+        // Valid: SchedFifo with Priority 99
+        let spec = build_spec(
+            SchedulerBuilder::default()
+                .policy(LinuxSchedulerPolicy::SchedFifo)
+                .priority(99)
+                .build()
+                .unwrap(),
+        );
+        assert!(Validator::validate_spec_for_scheduler(&spec).is_ok());
+
+        // Valid: SchedRr with Priority 1
+        let spec = build_spec(
+            SchedulerBuilder::default()
+                .policy(LinuxSchedulerPolicy::SchedRr)
+                .priority(1)
+                .build()
+                .unwrap(),
+        );
+        assert!(Validator::validate_spec_for_scheduler(&spec).is_ok());
+
+        // Valid: SchedOther with Priority 0 (0 is allowed for anything)
+        let spec = build_spec(
+            SchedulerBuilder::default()
+                .policy(LinuxSchedulerPolicy::SchedOther)
+                .priority(0)
+                .build()
+                .unwrap(),
+        );
+        assert!(Validator::validate_spec_for_scheduler(&spec).is_ok());
+
+        // Invalid: SchedOther with Priority 1
+        let spec = build_spec(
+            SchedulerBuilder::default()
+                .policy(LinuxSchedulerPolicy::SchedOther)
+                .priority(1)
+                .build()
+                .unwrap(),
+        );
+        assert!(Validator::validate_spec_for_scheduler(&spec).is_err());
+
+        // Invalid: SchedIso with Priority 10
+        let spec = build_spec(
+            SchedulerBuilder::default()
+                .policy(LinuxSchedulerPolicy::SchedIso)
+                .priority(10)
+                .build()
+                .unwrap(),
+        );
+        assert!(Validator::validate_spec_for_scheduler(&spec).is_err());
+
+        // Valid: SchedDeadline with runtime/deadline/period
+        let spec = build_spec(
+            SchedulerBuilder::default()
+                .policy(LinuxSchedulerPolicy::SchedDeadline)
+                .runtime(100_u64)
+                .deadline(200_u64)
+                .period(300_u64)
+                .build()
+                .unwrap(),
+        );
+        assert!(Validator::validate_spec_for_scheduler(&spec).is_ok());
+
+        // Valid: SchedOther with runtime 0 (0 is allowed for anything)
+        let spec = build_spec(
+            SchedulerBuilder::default()
+                .policy(LinuxSchedulerPolicy::SchedOther)
+                .runtime(0_u64)
+                .build()
+                .unwrap(),
+        );
+        assert!(Validator::validate_spec_for_scheduler(&spec).is_ok());
+
+        // Invalid: SchedFifo with runtime 100
+        let spec = build_spec(
+            SchedulerBuilder::default()
+                .policy(LinuxSchedulerPolicy::SchedFifo)
+                .runtime(100_u64)
+                .build()
+                .unwrap(),
+        );
+        assert!(Validator::validate_spec_for_scheduler(&spec).is_err());
+
+        // Invalid: SchedOther with deadline 200
+        let spec = build_spec(
+            SchedulerBuilder::default()
+                .policy(LinuxSchedulerPolicy::SchedOther)
+                .deadline(200_u64)
+                .build()
+                .unwrap(),
+        );
+        assert!(Validator::validate_spec_for_scheduler(&spec).is_err());
     }
 }

--- a/crates/libcontainer/src/validator.rs
+++ b/crates/libcontainer/src/validator.rs
@@ -1,0 +1,154 @@
+use oci_spec::runtime::{LinuxNamespaceType, Spec};
+
+use crate::error::ErrInvalidSpec;
+
+pub struct Validator;
+
+impl Validator {
+    pub fn validate_spec(spec: &Spec) -> Result<(), ErrInvalidSpec> {
+        Self::validate_spec_for_uts_namespace(spec)?;
+        Self::validate_spec_for_new_user_ns(spec)?;
+
+        Ok(())
+    }
+
+    fn validate_spec_for_uts_namespace(spec: &Spec) -> Result<(), ErrInvalidSpec> {
+        let has_uts_namespace = spec
+            .linux()
+            .as_ref()
+            .and_then(|l| l.namespaces().as_ref())
+            .is_some_and(|namespace| {
+                namespace
+                    .iter()
+                    .any(|ns| ns.typ() == LinuxNamespaceType::Uts)
+            });
+
+        if !has_uts_namespace {
+            if spec.hostname().is_some() {
+                return Err(ErrInvalidSpec::HostnameWithoutUTS);
+            }
+
+            if spec.domainname().is_some() {
+                return Err(ErrInvalidSpec::DomainnameWithoutUTS);
+            }
+        }
+
+        Ok(())
+    }
+
+    fn validate_spec_for_new_user_ns(spec: &Spec) -> Result<(), ErrInvalidSpec> {
+        let has_user_namespace = spec
+            .linux()
+            .as_ref()
+            .and_then(|l| l.namespaces().as_ref())
+            .is_some_and(|namespace| {
+                namespace
+                    .iter()
+                    .any(|ns| ns.typ() == LinuxNamespaceType::User)
+            });
+
+        if !has_user_namespace {
+            let has_uid_mappings = spec
+                .linux()
+                .as_ref()
+                .is_some_and(|l| l.uid_mappings().as_ref().is_some_and(|m| !m.is_empty()));
+            let has_gid_mappings = spec
+                .linux()
+                .as_ref()
+                .is_some_and(|l| l.gid_mappings().as_ref().is_some_and(|m| !m.is_empty()));
+
+            if has_uid_mappings || has_gid_mappings {
+                return Err(ErrInvalidSpec::UserMappingsWithoutNamespace);
+            }
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use oci_spec::runtime::{
+        LinuxBuilder, LinuxIdMappingBuilder, LinuxNamespaceBuilder, SpecBuilder,
+    };
+
+    use super::*;
+
+    #[test]
+    fn test_validate_spec_for_uts_namespace() {
+        let sepc_no_uts_with_hostname = SpecBuilder::default()
+            .hostname("some-host")
+            .linux(LinuxBuilder::default().namespaces(vec![]).build().unwrap())
+            .build()
+            .unwrap();
+        assert!(matches!(
+            Validator::validate_spec_for_uts_namespace(&sepc_no_uts_with_hostname).unwrap_err(),
+            ErrInvalidSpec::HostnameWithoutUTS
+        ));
+
+        let mut spec_no_uts_with_domainname = SpecBuilder::default()
+            .domainname("some-domain")
+            .linux(LinuxBuilder::default().namespaces(vec![]).build().unwrap())
+            .build()
+            .unwrap();
+        spec_no_uts_with_domainname.set_hostname(None);
+        assert!(matches!(
+            Validator::validate_spec_for_uts_namespace(&spec_no_uts_with_domainname).unwrap_err(),
+            ErrInvalidSpec::DomainnameWithoutUTS
+        ));
+
+        let spec_with_uts_and_host_domain_names = SpecBuilder::default()
+            .hostname("my-host")
+            .domainname("my-domain")
+            .linux(
+                LinuxBuilder::default()
+                    .namespaces(vec![
+                        LinuxNamespaceBuilder::default()
+                            .typ(LinuxNamespaceType::Uts)
+                            .build()
+                            .unwrap(),
+                    ])
+                    .build()
+                    .unwrap(),
+            )
+            .build()
+            .unwrap();
+        assert!(
+            Validator::validate_spec_for_uts_namespace(&spec_with_uts_and_host_domain_names)
+                .is_ok()
+        );
+
+        let spec_no_uts_no_host_domain_names = SpecBuilder::default()
+            .linux(LinuxBuilder::default().build().unwrap())
+            .build()
+            .unwrap();
+        assert!(
+            Validator::validate_spec_for_uts_namespace(&spec_no_uts_no_host_domain_names).is_ok()
+        );
+    }
+
+    #[test]
+    fn test_validate_user_ns_mappings() {
+        let spec_with_mappings_no_ns = SpecBuilder::default()
+            .linux(
+                LinuxBuilder::default()
+                    .namespaces(vec![])
+                    .uid_mappings(vec![
+                        LinuxIdMappingBuilder::default()
+                            .container_id(0_u32)
+                            .host_id(1000_u32)
+                            .size(1_u32)
+                            .build()
+                            .unwrap(),
+                    ])
+                    .build()
+                    .unwrap(),
+            )
+            .build()
+            .unwrap();
+        assert!(matches!(
+            Validator::validate_spec_for_new_user_ns(&spec_with_mappings_no_ns).unwrap_err(),
+            ErrInvalidSpec::UserMappingsWithoutNamespace
+        ));
+    }
+}

--- a/crates/libcontainer/src/validator.rs
+++ b/crates/libcontainer/src/validator.rs
@@ -1,5 +1,6 @@
-use std::collections::HashSet;
+use std::{collections::HashSet, path::Path};
 
+use nix::sys::stat::stat;
 use oci_spec::runtime::{LinuxNamespaceType, Spec};
 
 use crate::error::ErrInvalidSpec;
@@ -99,16 +100,40 @@ impl Validator {
     }
 
     fn validate_spec_for_sysctl(spec: &Spec) -> Result<(), ErrInvalidSpec> {
+        fn is_host_net_ns(path: &Path) -> Result<bool, nix::Error> {
+            let current_netns = "/proc/self/ns/net";
+
+            let host_stat = stat(current_netns)?;
+            let target_stat = stat(path)?;
+
+            Ok(host_stat.st_dev == target_stat.st_dev && host_stat.st_ino == target_stat.st_ino)
+        }
+
         if let Some(linux) = spec.linux() {
             if let Some(sysctls) = linux.sysctl() {
                 let has_ipc = linux
                     .namespaces()
                     .as_ref()
                     .is_some_and(|ns| ns.iter().any(|n| n.typ() == LinuxNamespaceType::Ipc));
-                let has_net = linux
+                let is_host_net = match linux
                     .namespaces()
                     .as_ref()
-                    .is_some_and(|ns| ns.iter().any(|n| n.typ() == LinuxNamespaceType::Network));
+                    .and_then(|ns| ns.iter().find(|n| n.typ() == LinuxNamespaceType::Network))
+                {
+                    // No NEWNET namespace means it uses the host's
+                    None => true,
+                    Some(ns) => {
+                        match ns.path() {
+                            // No path means a completely fresh, isolated namespace is being created
+                            None => false,
+                            // Empty string is effectively the same as None
+                            Some(path) if path.as_os_str().is_empty() => false,
+                            // A path is provided; we must verify it isn't the host's network namespace
+                            Some(path) => is_host_net_ns(path)
+                                .map_err(|e| ErrInvalidSpec::InvalidNetNsPath(e.to_string()))?,
+                        }
+                    }
+                };
                 let has_uts = linux
                     .namespaces()
                     .as_ref()
@@ -138,7 +163,7 @@ impl Validator {
                     }
 
                     if s.starts_with("net.") {
-                        if !has_net {
+                        if is_host_net {
                             return Err(ErrInvalidSpec::SysctlNotAllowedInHostNet(s));
                         }
                         continue;

--- a/crates/libcontainer/src/validator.rs
+++ b/crates/libcontainer/src/validator.rs
@@ -119,25 +119,6 @@ impl Validator {
                     .namespaces()
                     .as_ref()
                     .is_some_and(|ns| ns.iter().any(|n| n.typ() == LinuxNamespaceType::Ipc));
-                let is_host_net = match linux
-                    .namespaces()
-                    .as_ref()
-                    .and_then(|ns| ns.iter().find(|n| n.typ() == LinuxNamespaceType::Network))
-                {
-                    // No NEWNET namespace means it uses the host's
-                    None => true,
-                    Some(ns) => {
-                        match ns.path() {
-                            // No path means a completely fresh, isolated namespace is being created
-                            None => false,
-                            // Empty string is effectively the same as None
-                            Some(path) if path.as_os_str().is_empty() => false,
-                            // A path is provided; we must verify it isn't the host's network namespace
-                            Some(path) => is_host_net_ns(path)
-                                .map_err(|e| ErrInvalidSpec::InvalidNetNsPath(e.to_string()))?,
-                        }
-                    }
-                };
                 let has_uts = linux
                     .namespaces()
                     .as_ref()
@@ -157,6 +138,9 @@ impl Validator {
                 valid_ipc_sysctls.insert("kernel.shmmni");
                 valid_ipc_sysctls.insert("kernel.shm_rmid_forced");
 
+                let mut is_host_net_cache: Option<bool> = None;
+                let namespaces = linux.namespaces().as_ref();
+
                 for key in sysctls.keys() {
                     let s = key.replace('/', ".");
                     if valid_ipc_sysctls.contains(&s.as_str()) || s.starts_with("fs.mqueue.") {
@@ -167,6 +151,29 @@ impl Validator {
                     }
 
                     if s.starts_with("net.") {
+                        let is_host_net = if let Some(cached_result) = is_host_net_cache {
+                            cached_result
+                        } else {
+                            let computed_result = match namespaces.and_then(|ns| {
+                                ns.iter().find(|n| n.typ() == LinuxNamespaceType::Network)
+                            }) {
+                                // No NEWNET namespace means it uses the host's
+                                None => true,
+                                Some(ns) => match ns.path() {
+                                    // No path means a completely fresh, isolated namespace is being created
+                                    None => false,
+                                    // Empty string is effectively the same as None
+                                    Some(path) if path.as_os_str().is_empty() => false,
+                                    // A path is provided; we must verify it isn't the host's network namespace
+                                    Some(path) => is_host_net_ns(path).map_err(|e| {
+                                        ErrInvalidSpec::InvalidNetNsPath(e.to_string())
+                                    })?,
+                                },
+                            };
+                            is_host_net_cache = Some(computed_result);
+                            computed_result
+                        };
+
                         if is_host_net {
                             return Err(ErrInvalidSpec::SysctlNotAllowedInHostNet(s));
                         }

--- a/crates/libcontainer/src/validator.rs
+++ b/crates/libcontainer/src/validator.rs
@@ -8,6 +8,7 @@ impl Validator {
     pub fn validate_spec(spec: &Spec) -> Result<(), ErrInvalidSpec> {
         Self::validate_spec_for_uts_namespace(spec)?;
         Self::validate_spec_for_new_user_ns(spec)?;
+        Self::validate_spec_for_mnt_namespace(spec)?;
 
         Ok(())
     }
@@ -17,8 +18,8 @@ impl Validator {
             .linux()
             .as_ref()
             .and_then(|l| l.namespaces().as_ref())
-            .is_some_and(|namespace| {
-                namespace
+            .is_some_and(|namespaces| {
+                namespaces
                     .iter()
                     .any(|ns| ns.typ() == LinuxNamespaceType::Uts)
             });
@@ -41,8 +42,8 @@ impl Validator {
             .linux()
             .as_ref()
             .and_then(|l| l.namespaces().as_ref())
-            .is_some_and(|namespace| {
-                namespace
+            .is_some_and(|namespaces| {
+                namespaces
                     .iter()
                     .any(|ns| ns.typ() == LinuxNamespaceType::User)
             });
@@ -59,6 +60,35 @@ impl Validator {
 
             if has_uid_mappings || has_gid_mappings {
                 return Err(ErrInvalidSpec::UserMappingsWithoutNamespace);
+            }
+        }
+
+        Ok(())
+    }
+
+    fn validate_spec_for_mnt_namespace(spec: &Spec) -> Result<(), ErrInvalidSpec> {
+        let has_mnt_namespace = spec
+            .linux()
+            .as_ref()
+            .and_then(|l| l.namespaces().as_ref())
+            .is_some_and(|namespaces| {
+                namespaces
+                    .iter()
+                    .any(|ns| ns.typ() == LinuxNamespaceType::Mount)
+            });
+
+        if !has_mnt_namespace {
+            let has_masked_paths = spec
+                .linux()
+                .as_ref()
+                .is_some_and(|l| l.masked_paths().as_ref().is_some_and(|m| !m.is_empty()));
+            let has_readonly_paths = spec
+                .linux()
+                .as_ref()
+                .is_some_and(|l| l.readonly_paths().as_ref().is_some_and(|m| !m.is_empty()));
+
+            if has_masked_paths || has_readonly_paths {
+                return Err(ErrInvalidSpec::SysEntriesWithoutMntNamespace);
             }
         }
 
@@ -150,5 +180,72 @@ mod tests {
             Validator::validate_spec_for_new_user_ns(&spec_with_mappings_no_ns).unwrap_err(),
             ErrInvalidSpec::UserMappingsWithoutNamespace
         ));
+    }
+
+    #[test]
+    fn test_validate_spec_for_mnt_namespace() {
+        let spec_no_mnt_with_masked = SpecBuilder::default()
+            .linux(
+                LinuxBuilder::default()
+                    .namespaces(vec![])
+                    .masked_paths(vec!["/proc/keys".to_string()])
+                    .build()
+                    .unwrap(),
+            )
+            .build()
+            .unwrap();
+        assert!(matches!(
+            Validator::validate_spec_for_mnt_namespace(&spec_no_mnt_with_masked).unwrap_err(),
+            ErrInvalidSpec::SysEntriesWithoutMntNamespace
+        ));
+
+        let spec_no_mnt_with_readonly = SpecBuilder::default()
+            .linux(
+                LinuxBuilder::default()
+                    .namespaces(vec![])
+                    .readonly_paths(vec!["/proc/sys".to_string()])
+                    .build()
+                    .unwrap(),
+            )
+            .build()
+            .unwrap();
+        assert!(matches!(
+            Validator::validate_spec_for_mnt_namespace(&spec_no_mnt_with_readonly).unwrap_err(),
+            ErrInvalidSpec::SysEntriesWithoutMntNamespace
+        ));
+
+        let spec_with_mnt_and_masked = SpecBuilder::default()
+            .linux(
+                LinuxBuilder::default()
+                    .namespaces(vec![
+                        LinuxNamespaceBuilder::default()
+                            .typ(LinuxNamespaceType::Mount)
+                            .build()
+                            .unwrap(),
+                    ])
+                    .masked_paths(vec!["/proc/keys".to_string()])
+                    .build()
+                    .unwrap(),
+            )
+            .build()
+            .unwrap();
+        assert!(Validator::validate_spec_for_mnt_namespace(&spec_with_mnt_and_masked).is_ok());
+
+        let spec_with_mnt_and_readonly = SpecBuilder::default()
+            .linux(
+                LinuxBuilder::default()
+                    .namespaces(vec![
+                        LinuxNamespaceBuilder::default()
+                            .typ(LinuxNamespaceType::Mount)
+                            .build()
+                            .unwrap(),
+                    ])
+                    .readonly_paths(vec!["/proc/sys".to_string()])
+                    .build()
+                    .unwrap(),
+            )
+            .build()
+            .unwrap();
+        assert!(Validator::validate_spec_for_mnt_namespace(&spec_with_mnt_and_readonly).is_ok());
     }
 }

--- a/crates/libcontainer/src/validator.rs
+++ b/crates/libcontainer/src/validator.rs
@@ -300,13 +300,13 @@ mod tests {
 
     #[test]
     fn test_validate_spec_for_uts_namespace() {
-        let sepc_no_uts_with_hostname = SpecBuilder::default()
+        let spec_no_uts_with_hostname = SpecBuilder::default()
             .hostname("some-host")
             .linux(LinuxBuilder::default().namespaces(vec![]).build().unwrap())
             .build()
             .unwrap();
         assert!(matches!(
-            Validator::validate_spec_for_uts_namespace(&sepc_no_uts_with_hostname).unwrap_err(),
+            Validator::validate_spec_for_uts_namespace(&spec_no_uts_with_hostname).unwrap_err(),
             ErrInvalidSpec::HostnameWithoutUTS
         ));
 

--- a/crates/libcontainer/src/validator.rs
+++ b/crates/libcontainer/src/validator.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 use oci_spec::runtime::{LinuxNamespaceType, Spec};
 
 use crate::error::ErrInvalidSpec;
@@ -9,6 +11,7 @@ impl Validator {
         Self::validate_spec_for_uts_namespace(spec)?;
         Self::validate_spec_for_new_user_ns(spec)?;
         Self::validate_spec_for_mnt_namespace(spec)?;
+        Self::validate_spec_for_sysctl(spec)?;
 
         Ok(())
     }
@@ -89,6 +92,81 @@ impl Validator {
 
             if has_masked_paths || has_readonly_paths {
                 return Err(ErrInvalidSpec::SysEntriesWithoutMntNamespace);
+            }
+        }
+
+        Ok(())
+    }
+
+    fn validate_spec_for_sysctl(spec: &Spec) -> Result<(), ErrInvalidSpec> {
+        if let Some(linux) = spec.linux() {
+            if let Some(sysctls) = linux.sysctl() {
+                let has_ipc = linux
+                    .namespaces()
+                    .as_ref()
+                    .is_some_and(|ns| ns.iter().any(|n| n.typ() == LinuxNamespaceType::Ipc));
+                let has_net = linux
+                    .namespaces()
+                    .as_ref()
+                    .is_some_and(|ns| ns.iter().any(|n| n.typ() == LinuxNamespaceType::Network));
+                let has_uts = linux
+                    .namespaces()
+                    .as_ref()
+                    .is_some_and(|ns| ns.iter().any(|n| n.typ() == LinuxNamespaceType::Uts));
+                let has_user = linux
+                    .namespaces()
+                    .as_ref()
+                    .is_some_and(|ns| ns.iter().any(|n| n.typ() == LinuxNamespaceType::User));
+
+                let mut valid_ipc_sysctls = HashSet::with_capacity(8);
+                valid_ipc_sysctls.insert("kernel.msgmax");
+                valid_ipc_sysctls.insert("kernel.msgmnb");
+                valid_ipc_sysctls.insert("kernel.msgmni");
+                valid_ipc_sysctls.insert("kernel.sem");
+                valid_ipc_sysctls.insert("kernel.shmall");
+                valid_ipc_sysctls.insert("kernel.shmmax");
+                valid_ipc_sysctls.insert("kernel.shmmni");
+                valid_ipc_sysctls.insert("kernel.shm_rmid_forced");
+
+                for key in sysctls.keys() {
+                    let s = key.replace('/', ".");
+                    if valid_ipc_sysctls.contains(&s.as_str()) || s.starts_with("fs.mqueue.") {
+                        if !has_ipc {
+                            return Err(ErrInvalidSpec::SysctlNotAllowedInHostIpc(s));
+                        }
+                        continue;
+                    }
+
+                    if s.starts_with("net.") {
+                        if !has_net {
+                            return Err(ErrInvalidSpec::SysctlNotAllowedInHostNet(s));
+                        }
+                        continue;
+                    }
+
+                    if has_uts {
+                        match s.as_str() {
+                            "kernel.domainname" => continue,
+                            "kernel.hostname" => {
+                                // hostname is supported via an explicit OCI field, so it is denied here
+                                return Err(ErrInvalidSpec::SysctlConflictsWithOci(
+                                    s,
+                                    "hostname".to_string(),
+                                ));
+                            }
+                            _ => {}
+                        }
+                    }
+
+                    if s.starts_with("user.") {
+                        if !has_user {
+                            return Err(ErrInvalidSpec::SysctlNotAllowedInHostUser(s));
+                        }
+                        continue;
+                    }
+
+                    return Err(ErrInvalidSpec::SysctlNotInSeparateNamespace(s));
+                }
             }
         }
 
@@ -247,5 +325,72 @@ mod tests {
             .build()
             .unwrap();
         assert!(Validator::validate_spec_for_mnt_namespace(&spec_with_mnt_and_readonly).is_ok());
+    }
+
+    #[test]
+    fn test_validate_spec_for_sysctl() {
+        use std::collections::HashMap;
+
+        let mut sysctl_ipc = HashMap::new();
+        sysctl_ipc.insert("fs.mqueue.msg_max".to_string(), "10".to_string());
+
+        let spec_no_ipc = SpecBuilder::default()
+            .linux(
+                LinuxBuilder::default()
+                    .namespaces(vec![])
+                    .sysctl(sysctl_ipc)
+                    .build()
+                    .unwrap(),
+            )
+            .build()
+            .unwrap();
+
+        assert!(matches!(
+            Validator::validate_spec_for_sysctl(&spec_no_ipc).unwrap_err(),
+            ErrInvalidSpec::SysctlNotAllowedInHostIpc(_)
+        ));
+
+        let mut sysctl_net = HashMap::new();
+        sysctl_net.insert("net.ipv4.ip_forward".to_string(), "1".to_string());
+
+        let spec_no_net = SpecBuilder::default()
+            .linux(
+                LinuxBuilder::default()
+                    .namespaces(vec![])
+                    .sysctl(sysctl_net)
+                    .build()
+                    .unwrap(),
+            )
+            .build()
+            .unwrap();
+
+        assert!(matches!(
+            Validator::validate_spec_for_sysctl(&spec_no_net).unwrap_err(),
+            ErrInvalidSpec::SysctlNotAllowedInHostNet(_)
+        ));
+
+        let mut sysctl_uts_conflict = HashMap::new();
+        sysctl_uts_conflict.insert("kernel.hostname".to_string(), "bad-host".to_string());
+
+        let spec_uts_conflict = SpecBuilder::default()
+            .linux(
+                LinuxBuilder::default()
+                    .namespaces(vec![
+                        LinuxNamespaceBuilder::default()
+                            .typ(LinuxNamespaceType::Uts)
+                            .build()
+                            .unwrap(),
+                    ])
+                    .sysctl(sysctl_uts_conflict)
+                    .build()
+                    .unwrap(),
+            )
+            .build()
+            .unwrap();
+
+        assert!(matches!(
+            Validator::validate_spec_for_sysctl(&spec_uts_conflict).unwrap_err(),
+            ErrInvalidSpec::SysctlConflictsWithOci(_, _)
+        ));
     }
 }


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of your changes -->

## Type of Change
<!-- Mark the appropriate option with an [x] -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test updates
- [ ] CI/CD related changes
- [ ] Other (please describe):

## Testing
<!-- Describe the tests you ran and/or added to verify your changes -->
- [x] Added new unit tests
- [ ] Added new integration tests
- [x] Ran existing test suite
- [x] Tested manually (please provide steps)

## Related Issues
<!-- Link any related issues using the GitHub issue syntax: #issue-number
If there is no open issue for this, please add details of the problem or open a new issue. -->
Fixes #3553

## Additional Context
<!-- Add any other context about the pull request here -->
case 1: UTS Namespace (description one)
```bash
# before
./target/debug/youki run container
# Succeeds but hostname not applyed

# after
./target/debug/youki run container
ERROR youki: error in executing command: unable to set hostname without a private UTS namespace
```

case 2: User Namespace
```bash
{
...
# no type user but both "uidMappings" and "gidMappings" are populated
"linux": {
    "namespaces": [
      {
        "type": "pid"
      },
      {
        "type": "ipc"
      },
      {
        "type": "uts"
      },
      {
        "type": "mount"
      }
    ],
    "uidMappings": [
      {
        "containerID": 0,
        "hostID": 1000,
        "size": 1
      }
    ],
    "gidMappings": [
      {
        "containerID": 0,
        "hostID": 1000,
        "size": 1
      }
    ]
  }
...
}

./target/debug/youki run container
ERROR youki: error in executing command: user namespace mappings specified, but user namespace isn't enabled in the config
```

case 3: Mount Namespace
```bash
{
...
# no type mount
"linux": {
    "namespaces": [
      {
        "type": "pid"
      },
      {
        "type": "ipc"
      },
      {
        "type": "uts"
      },
      {
        "type": "cgroup"
      }
    ],
    "maskedPaths": [
      "/proc/acpi",
      ...
    ],
    "readonlyPaths": [
      "/proc/bus",
      ...
    ]
  }
...
}

./target/debug/youki run container
ERROR youki: error in executing command: unable to restrict sys entries without a private MNT namespace
```

case 4: Sysctl Namespaces
```bash
{
...
# no type ipc but `sysctl: fs.mqueue.msg_max` is populated
"linux": {
    "sysctl": {
      "fs.mqueue.msg_max": "100"
    },
    "namespaces": [
      {
        "type": "pid"
      },
      {
        "type": "uts"
      },
      {
        "type": "cgroup"
      }
    ],
    "maskedPaths": [
      "/proc/acpi",
      ...
    ],
    "readonlyPaths": [
      "/proc/bus",
      ...
    ]
  }
...
}

./target/debug/youki run container
ERROR youki: error in executing command: sysctl fs.mqueue.msg_max is not allowed in the hosts ipc namespace
```

case 5: Cgroups
youki uses the oci-spec crate, which automatically deserializes the config.json into a strictly-typed Rust struct.
```rust
#[derive(Default, PartialEq, Eq, Clone, Debug, Deserialize, Serialize)]
#[serde(rename_all = "camelCase")]
pub struct Linux {
    // ... other fields ...
    #[serde(skip_serializing_if = "Option::is_none")]
    cgroups_path: Option<PathBuf>,
    // ...
}
```
Because of this rigid deserialization, youki simply accesses it as a single Option<PathBuf> like this:
```rust
let linux = self.spec.linux().as_ref().unwrap();
let cgroups_path = utils::get_cgroup_path(linux.cgroups_path(), &self.container_id);
```
Since the Rust parser strictly enforces that the input is just a single string path, it is completely impossible for youki to be passed an ambiguous state where "both Path and Name/Parent are set." The types don't even exist to allow it.

case 6: Memory Policy
youki performs this logic right before applying the policy in crates/libcontainer/src/process/memory_policy.rs during the validate_memory_policy function