### PR TITLE
fix(libcgroups): add /run/systemd/private fallback for dbus system connection

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -123,6 +123,27 @@ jobs:
       - name: test/k8s/deploy
         run: just test-kind
 
+  k8s-tests-systemd-cgroup:
+    runs-on: ubuntu-24.04
+    needs: [youki-build]
+    timeout-minutes: 40
+    strategy:
+      matrix:
+        arch: [ "x86_64" ]
+        libc: [ "gnu", "musl" ]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Download youki binary
+        uses: actions/download-artifact@v4
+        with:
+          name: youki-${{ matrix.arch }}-${{ matrix.libc }}
+      - name: Add the permission to run
+        run: chmod +x ./youki
+      - name: Install just
+        uses: taiki-e/install-action@just
+      - name: test/k8s/deploy (systemd cgroup)
+        run: just test-kind-systemd-cgroup
+
   oci-validation-go:
     runs-on: ubuntu-24.04
     needs: [youki-build]

--- a/crates/libcgroups/src/systemd/dbus_native/dbus.rs
+++ b/crates/libcgroups/src/systemd/dbus_native/dbus.rs
@@ -15,6 +15,11 @@ use crate::systemd::dbus_native::serialize::{DbusSerialize, Structure, Variant};
 
 const REPLY_BUF_SIZE: usize = 128; // seems good enough tradeoff between extra size and repeated calls
 
+// systemd exposes a private socket for direct communication without a dbus daemon.
+// Used as fallback when the standard system bus socket is unavailable, matching runc behavior.
+// See: https://github.com/coreos/go-systemd/blob/main/dbus/dbus.go (NewSystemdConnectionContext)
+const SYSTEMD_PRIVATE_SOCKET: &str = "/run/systemd/private";
+
 /// NOTE that this is meant for a single-threaded use, and concurrent
 /// usage can cause errors, primarily because then the message received over
 /// socket can be out of order and we need to manager buffer and check with message counter
@@ -127,32 +132,38 @@ fn get_actual_uid() -> Result<u32> {
 }
 
 impl DbusConnection {
-    /// Open a new dbus connection to given address
-    /// authenticating as user with given uid
+    /// Open a new dbus connection to the given address, authenticate, and register with the daemon.
     pub fn new(addr: &str, uid: u32, system: bool) -> Result<Self> {
-        // Use ManuallyDrop to keep the socket open.
-        let socket = std::mem::ManuallyDrop::new(socket::socket(
-            socket::AddressFamily::Unix,
-            socket::SockType::Stream,
-            socket::SockFlag::empty(),
-            None,
-        )?);
-
-        let addr = socket::UnixAddr::new(addr)?;
-        socket::connect(socket.as_raw_fd(), &addr)?;
-        let mut dbus = Self {
-            socket: socket.as_raw_fd(),
-            msg_ctr: AtomicU32::new(0),
-            id: None,
-            system,
-        };
-        dbus.authenticate(uid)?;
-        Ok(dbus)
+        let mut conn = Self::open(addr, uid, system)?;
+        conn.register()?;
+        Ok(conn)
     }
 
     pub fn new_system() -> Result<Self> {
-        let addr = get_system_bus_address()?;
-        Self::new(&addr, 0, true)
+        // Try the standard system bus first (DBUS_SYSTEM_BUS_ADDRESS or well-known path).
+        // and_then chains address lookup + connection so either failure falls through.
+        let standard = get_system_bus_address().and_then(|addr| Self::new(&addr, 0, true));
+        if let Ok(conn) = standard {
+            return Ok(conn);
+        }
+
+        // Fallback: connect directly to systemd without a dbus daemon (root only).
+        // /run/systemd/private is created by systemd itself and exists even when
+        // dbus-daemon is not installed, e.g. in kind nodes.
+        // register() must be skipped because systemd does not implement org.freedesktop.DBus.Hello.
+        if nix::unistd::getuid().is_root() && std::path::Path::new(SYSTEMD_PRIVATE_SOCKET).exists()
+        {
+            tracing::debug!(
+                "system bus unavailable, falling back to systemd private socket {}",
+                SYSTEMD_PRIVATE_SOCKET
+            );
+            return Self::new_direct(SYSTEMD_PRIVATE_SOCKET, true);
+        }
+
+        Err(DbusError::BusAddressError(
+            "could not connect to system bus or systemd private socket".into(),
+        )
+        .into())
     }
 
     pub fn new_session() -> Result<Self> {
@@ -161,28 +172,39 @@ impl DbusConnection {
         Self::new(&addr, uid, false)
     }
 
-    /// Authenticates with dbus using given uid via external strategy
-    /// Must be called on any connection before doing any other communication
-    fn authenticate(&mut self, uid: u32) -> Result<()> {
+    /// Open a socket connection and perform the dbus AUTH/BEGIN exchange.
+    /// The resulting connection is authenticated but not yet registered with a daemon.
+    fn open(addr: &str, uid: u32, system: bool) -> Result<Self> {
+        let socket = std::mem::ManuallyDrop::new(socket::socket(
+            socket::AddressFamily::Unix,
+            socket::SockType::Stream,
+            socket::SockFlag::empty(),
+            None,
+        )?);
+
+        let unix_addr = socket::UnixAddr::new(addr)?;
+        socket::connect(socket.as_raw_fd(), &unix_addr)?;
+        let dbus = Self {
+            socket: socket.as_raw_fd(),
+            msg_ctr: AtomicU32::new(0),
+            id: None,
+            system,
+        };
+
         let mut buf = [0; 64];
 
         // dbus connection always start with a 0 byte sent as first thing
-        socket::send(self.socket, &[0], socket::MsgFlags::empty())?;
+        socket::send(dbus.socket, &[0], socket::MsgFlags::empty())?;
 
         let msg = format!("AUTH EXTERNAL {}\r\n", uid_to_hex_str(uid));
+        socket::send(dbus.socket, msg.as_bytes(), socket::MsgFlags::empty())?;
 
-        // then we send our auth with uid
-        socket::send(self.socket, msg.as_bytes(), socket::MsgFlags::empty())?;
-
-        // we get the reply and check if all went well or not
-        socket::recv(self.socket, &mut buf, socket::MsgFlags::empty())?;
+        socket::recv(dbus.socket, &mut buf, socket::MsgFlags::empty())?;
 
         let reply: Vec<u8> = buf.iter().filter(|v| **v != 0).copied().collect();
-
         // we can use _lossy as we know dbus communication is always ascii
         let reply = String::from_utf8_lossy(&reply);
 
-        // successful auth reply starts with 'ok'
         if !reply.starts_with("OK") {
             return Err(DbusError::AuthenticationErr(format!(
                 "Authentication failed, got message : {}",
@@ -195,15 +217,24 @@ impl DbusConnection {
         // we can also send AGREE_UNIX_FD before this if we need to deal with sending/receiving
         // fds over the connection, but because youki doesn't need it, we can skip that
         socket::send(
-            self.socket,
+            dbus.socket,
             "BEGIN\r\n".as_bytes(),
             socket::MsgFlags::empty(),
         )?;
 
+        Ok(dbus)
+    }
+
+    /// Register this connection with the dbus daemon by calling the Hello method.
+    /// Hello allocates a unique name (e.g. ":1.42") for this connection on the bus.
+    /// Must be called after open() when connecting to a dbus daemon.
+    /// Must NOT be called when connecting directly to systemd via /run/systemd/private,
+    /// since systemd does not implement org.freedesktop.DBus.Hello.
+    fn register(&mut self) -> Result<()> {
         // First thing any dbus client must do after authentication
-        // is to do a hello method call, in order to get a name allocated
-        // if we do any other method call, the connection is assumed to be
-        // invalid and auto disconnected
+        // is to do a hello method call, in order to get a name allocated.
+        // If we do any other method call, the connection is assumed to be
+        // invalid and auto disconnected.
         let headers = vec![
             Header {
                 kind: HeaderKind::Path,
@@ -239,6 +270,16 @@ impl DbusConnection {
         self.id = Some(id);
 
         Ok(())
+    }
+
+    /// Connect directly to /run/systemd/private without going through a dbus daemon.
+    /// uid is always root (0) because /run/systemd/private is only accessible by root,
+    /// and callers must verify this before calling.
+    fn new_direct(addr: &str, system: bool) -> Result<Self> {
+        // open() performs AUTH/BEGIN; register() is intentionally skipped here because
+        // systemd does not implement org.freedesktop.DBus.Hello.
+        // self.id remains None; send_message already handles None by omitting the Sender header.
+        Self::open(addr, 0, system)
     }
 
     /// Helper function to get complete message in chunks

--- a/crates/libcgroups/src/systemd/dbus_native/dbus.rs
+++ b/crates/libcgroups/src/systemd/dbus_native/dbus.rs
@@ -1,11 +1,12 @@
 use std::collections::HashMap;
-use std::io::{IoSlice, IoSliceMut};
-use std::os::fd::AsRawFd;
+use std::io::IoSlice;
+use std::os::fd::{AsFd, AsRawFd};
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicU32, Ordering};
 
 use nix::errno::Errno;
 use nix::sys::socket;
+use nix::sys::time::TimeVal;
 
 use super::client::SystemdClient;
 use super::message::*;
@@ -13,12 +14,23 @@ use super::proxy::Proxy;
 use super::utils::{DbusError, Result, SystemdClientError};
 use crate::systemd::dbus_native::serialize::{DbusSerialize, Structure, Variant};
 
-const REPLY_BUF_SIZE: usize = 128; // seems good enough tradeoff between extra size and repeated calls
-
 // systemd exposes a private socket for direct communication without a dbus daemon.
 // Used as fallback when the standard system bus socket is unavailable, matching runc behavior.
 // See: https://github.com/coreos/go-systemd/blob/main/dbus/dbus.go (NewSystemdConnectionContext)
 const SYSTEMD_PRIVATE_SOCKET: &str = "/run/systemd/private";
+
+/// Per-recv() timeout applied for the lifetime of every dbus connection,
+/// covering both the auth handshake and all subsequent method calls.
+///
+/// Without a timeout, recv() blocks indefinitely when systemd is slow to
+/// respond (e.g. cluster boot with many simultaneous container starts).
+/// When SO_RCVTIMEO fires, recv() returns EAGAIN, which Manager::new()
+/// catches and retries by reconnecting from scratch with exponential backoff.
+///
+/// Note: runc uses go-systemd's context.TODO() for dbus calls, which has no
+/// deadline, leaving the same indefinite-block risk open (runc issue #3904).
+/// This SO_RCVTIMEO approach is youki's equivalent fix.
+const RECV_TIMEOUT_SECS: i64 = 10;
 
 /// NOTE that this is meant for a single-threaded use, and concurrent
 /// usage can cause errors, primarily because then the message received over
@@ -134,8 +146,9 @@ fn get_actual_uid() -> Result<u32> {
 impl DbusConnection {
     /// Open a new dbus connection to the given address, authenticate, and register with the daemon.
     pub fn new(addr: &str, uid: u32, system: bool) -> Result<Self> {
-        let mut conn = Self::open(addr, uid, system)?;
-        conn.register()?;
+        let mut conn = Self::connect(addr, system)?;
+        conn.auth(uid)?;
+        conn.hello()?;
         Ok(conn)
     }
 
@@ -143,18 +156,21 @@ impl DbusConnection {
         // Try the standard system bus first (DBUS_SYSTEM_BUS_ADDRESS or well-known path).
         // and_then chains address lookup + connection so either failure falls through.
         let standard = get_system_bus_address().and_then(|addr| Self::new(&addr, 0, true));
-        if let Ok(conn) = standard {
-            return Ok(conn);
+        match standard {
+            Ok(conn) => return Ok(conn),
+            Err(ref e) => tracing::debug!("standard system bus unavailable: {}", e),
         }
 
         // Fallback: connect directly to systemd without a dbus daemon (root only).
         // /run/systemd/private is created by systemd itself and exists even when
         // dbus-daemon is not installed, e.g. in kind nodes.
+        // Any error from the standard bus (including EACCES) falls through to this path,
+        // matching go-systemd's NewSystemdConnectionContext() behavior.
         // register() must be skipped because systemd does not implement org.freedesktop.DBus.Hello.
         if nix::unistd::getuid().is_root() && std::path::Path::new(SYSTEMD_PRIVATE_SOCKET).exists()
         {
             tracing::debug!(
-                "system bus unavailable, falling back to systemd private socket {}",
+                "falling back to systemd private socket {}",
                 SYSTEMD_PRIVATE_SOCKET
             );
             return Self::new_direct(SYSTEMD_PRIVATE_SOCKET, true);
@@ -172,9 +188,11 @@ impl DbusConnection {
         Self::new(&addr, uid, false)
     }
 
-    /// Open a socket connection and perform the dbus AUTH/BEGIN exchange.
-    /// The resulting connection is authenticated but not yet registered with a daemon.
-    fn open(addr: &str, uid: u32, system: bool) -> Result<Self> {
+    /// Create a Unix socket and connect it to the given dbus address.
+    fn connect(addr: &str, system: bool) -> Result<Self> {
+        // NOTE: DbusConnection should own an OwnedFd instead of ManuallyDrop + RawFd
+        // so that fd ownership is explicit and Drop does not need to close manually.
+        // Tracked in https://github.com/youki-dev/youki/issues/3629
         let socket = std::mem::ManuallyDrop::new(socket::socket(
             socket::AddressFamily::Unix,
             socket::SockType::Stream,
@@ -184,27 +202,45 @@ impl DbusConnection {
 
         let unix_addr = socket::UnixAddr::new(addr)?;
         socket::connect(socket.as_raw_fd(), &unix_addr)?;
-        let dbus = Self {
+
+        // Set SO_RCVTIMEO so that every recv() on this socket times out instead
+        // of blocking indefinitely.  See RECV_TIMEOUT_SECS for rationale.
+        socket::setsockopt(
+            &socket.as_fd(),
+            socket::sockopt::ReceiveTimeout,
+            &TimeVal::new(RECV_TIMEOUT_SECS, 0),
+        )?;
+
+        Ok(Self {
             socket: socket.as_raw_fd(),
             msg_ctr: AtomicU32::new(0),
             id: None,
             system,
-        };
+        })
+    }
 
+    /// Perform the dbus SASL AUTH EXTERNAL / BEGIN exchange.
+    /// Must be called immediately after connect(), before any method calls.
+    fn auth(&mut self, uid: u32) -> Result<()> {
         let mut buf = [0; 64];
 
         // dbus connection always start with a 0 byte sent as first thing
-        socket::send(dbus.socket, &[0], socket::MsgFlags::empty())?;
+        socket::send(self.socket, &[0], socket::MsgFlags::empty())?;
 
         let msg = format!("AUTH EXTERNAL {}\r\n", uid_to_hex_str(uid));
-        socket::send(dbus.socket, msg.as_bytes(), socket::MsgFlags::empty())?;
 
-        socket::recv(dbus.socket, &mut buf, socket::MsgFlags::empty())?;
+        // then we send our auth with uid
+        socket::send(self.socket, msg.as_bytes(), socket::MsgFlags::empty())?;
+
+        // we get the reply and check if all went well or not
+        socket::recv(self.socket, &mut buf, socket::MsgFlags::empty())?;
 
         let reply: Vec<u8> = buf.iter().filter(|v| **v != 0).copied().collect();
+
         // we can use _lossy as we know dbus communication is always ascii
         let reply = String::from_utf8_lossy(&reply);
 
+        // successful auth reply starts with 'ok'
         if !reply.starts_with("OK") {
             return Err(DbusError::AuthenticationErr(format!(
                 "Authentication failed, got message : {}",
@@ -217,24 +253,24 @@ impl DbusConnection {
         // we can also send AGREE_UNIX_FD before this if we need to deal with sending/receiving
         // fds over the connection, but because youki doesn't need it, we can skip that
         socket::send(
-            dbus.socket,
+            self.socket,
             "BEGIN\r\n".as_bytes(),
             socket::MsgFlags::empty(),
         )?;
 
-        Ok(dbus)
+        Ok(())
     }
 
-    /// Register this connection with the dbus daemon by calling the Hello method.
+    /// Send the Hello method call to register this connection with the dbus daemon.
     /// Hello allocates a unique name (e.g. ":1.42") for this connection on the bus.
-    /// Must be called after open() when connecting to a dbus daemon.
+    /// Must be called after connect() + auth() when connecting to a dbus daemon.
     /// Must NOT be called when connecting directly to systemd via /run/systemd/private,
     /// since systemd does not implement org.freedesktop.DBus.Hello.
-    fn register(&mut self) -> Result<()> {
+    fn hello(&mut self) -> Result<()> {
         // First thing any dbus client must do after authentication
-        // is to do a hello method call, in order to get a name allocated.
-        // If we do any other method call, the connection is assumed to be
-        // invalid and auto disconnected.
+        // is to do a hello method call, in order to get a name allocated
+        // if we do any other method call, the connection is assumed to be
+        // invalid and auto disconnected
         let headers = vec![
             Header {
                 kind: HeaderKind::Path,
@@ -276,43 +312,66 @@ impl DbusConnection {
     /// uid is always root (0) because /run/systemd/private is only accessible by root,
     /// and callers must verify this before calling.
     fn new_direct(addr: &str, system: bool) -> Result<Self> {
-        // open() performs AUTH/BEGIN; register() is intentionally skipped here because
-        // systemd does not implement org.freedesktop.DBus.Hello.
+        // connect() + auth() perform socket setup and AUTH/BEGIN.
+        // hello() is intentionally skipped here because systemd does not implement
+        // org.freedesktop.DBus.Hello.
         // self.id remains None; send_message already handles None by omitting the Sender header.
-        Self::open(addr, 0, system)
+        let mut conn = Self::connect(addr, system)?;
+        conn.auth(0)?;
+        Ok(conn)
     }
 
-    /// Helper function to get complete message in chunks
-    /// over the socket. This will loop and collect all of the message
-    /// chunks into a single vector
-    fn receive_complete_response(&self) -> Result<Vec<u8>> {
-        let mut ret = Vec::with_capacity(512);
-        loop {
-            let mut reply: [u8; REPLY_BUF_SIZE] = [0_u8; REPLY_BUF_SIZE];
-            let mut reply_buffer = [IoSliceMut::new(&mut reply[0..])];
-
-            let reply_res = socket::recvmsg::<()>(
-                self.socket,
-                &mut reply_buffer,
-                None,
-                socket::MsgFlags::empty(),
-            );
-
-            let reply_rcvd = match reply_res {
-                Ok(msg) => msg,
-                Err(Errno::EAGAIN) => continue,
+    /// Read exactly `buf.len()` bytes from the socket, retrying on EINTR.
+    fn read_exact(&self, buf: &mut [u8]) -> Result<()> {
+        let mut total = 0;
+        while total < buf.len() {
+            match socket::recv(self.socket, &mut buf[total..], socket::MsgFlags::empty()) {
+                Ok(0) => {
+                    return Err(DbusError::ConnectionError(
+                        "connection closed unexpectedly".into(),
+                    )
+                    .into());
+                }
+                Ok(n) => total += n,
+                Err(Errno::EINTR) => continue,
                 Err(e) => return Err(e.into()),
-            };
-            let received_byte_count = reply_rcvd.bytes;
-
-            ret.extend_from_slice(&reply[0..received_byte_count]);
-
-            if received_byte_count < REPLY_BUF_SIZE {
-                // if received byte count is less than buffer size, then we got all
-                break;
             }
         }
-        Ok(ret)
+        Ok(())
+    }
+
+    /// Read exactly one complete dbus message from the socket.
+    ///
+    /// ```text
+    /// byte  0     : BYTE   endianness flag ('l' = little-endian, 'B' = big-endian)
+    /// byte  1     : BYTE   message type (1=MethodCall 2=MethodReturn 3=Error 4=Signal)
+    /// byte  2     : BYTE   flags
+    /// byte  3     : BYTE   major protocol version
+    /// bytes 4-7   : UINT32 length in bytes of the message body
+    /// bytes 8-11  : UINT32 serial of this message
+    /// bytes 12-15 : UINT32 length in bytes of the header fields array
+    /// bytes 16+   : ARRAY  header fields a(yv), padded to 8-byte boundary
+    /// ...         : body   (body_len bytes)
+    /// ```
+    /// See: https://dbus.freedesktop.org/doc/dbus-specification.html#message-format
+    ///
+    /// Reads the fixed header first to extract body_len and header_array_len,
+    /// then reads the exact remainder with no heuristics.
+    fn read_one_message(&self) -> Result<Vec<u8>> {
+        let mut fixed = [0u8; 16];
+        self.read_exact(&mut fixed)?;
+
+        // byte 0 is the endianness flag; Linux/systemd always sends little-endian ('l').
+        let body_len = u32::from_le_bytes(fixed[4..8].try_into().unwrap()) as usize;
+        let header_array_len = u32::from_le_bytes(fixed[12..16].try_into().unwrap()) as usize;
+        let aligned_header_len = (header_array_len + 7) & !7;
+
+        let mut rest = vec![0u8; aligned_header_len + body_len];
+        self.read_exact(&mut rest)?;
+
+        let mut msg_bytes = fixed.to_vec();
+        msg_bytes.extend_from_slice(&rest);
+        Ok(msg_bytes)
     }
 
     /// function to send message of given type with given headers and body
@@ -347,45 +406,27 @@ impl DbusConnection {
 
         let mut ret = Vec::new();
 
-        // it is possible that while receiving messages, we get some extra/previous message
-        // for method calls, we need to have an error or method return type message, so
-        // we keep looping until we get either of these. see https://github.com/youki-dev/youki/issues/2826
-        // for more detailed analysis.
+        // Read one complete message per iteration. Signals do not terminate
+        // the loop; only MethodReturn or Error ends the wait.
         loop {
-            let reply = self.receive_complete_response()?;
+            let msg_bytes = self.read_one_message()?;
+            let mut ctr = 0;
+            let msg = Message::deserialize(&msg_bytes, &mut ctr)?;
 
-            // note that a single received response can contain multiple
-            // messages, so we must deserialize it piece by piece
-            let mut buf = &reply[..];
-
-            while !buf.is_empty() {
-                let mut ctr = 0;
-                let msg = Message::deserialize(&buf[ctr..], &mut ctr)?;
-                // we reset the buf, because I couldn't figure out how the adjust_counter function
-                // should should be changed to work correctly with non-zero start counter, and this solved that issue
-                buf = &buf[ctr..];
-                ret.push(msg);
-            }
-
-            // in Youki, we only ever do method call apart from initial auth
-            // in case it is, we don't really have a specific message to look
-            // out of, so we take the buffer and break
+            // For non-method-call sends (e.g. AUTH handshake) one read suffices.
             if mtype != MessageType::MethodCall {
+                ret.push(msg);
                 break;
             }
 
-            // check if any of the received message is method return or error type
-            let return_message_count = ret
-                .iter()
-                .filter(|m| {
-                    m.preamble.mtype == MessageType::MethodReturn
-                        || m.preamble.mtype == MessageType::Error
-                })
-                .count();
+            let is_final = msg.preamble.mtype == MessageType::MethodReturn
+                || msg.preamble.mtype == MessageType::Error;
+            ret.push(msg);
 
-            if return_message_count > 0 {
+            if is_final {
                 break;
             }
+            // Signal or other unsolicited message — keep reading.
         }
         Ok(ret)
     }
@@ -537,7 +578,23 @@ impl SystemdClient for DbusConnection {
 }
 
 #[cfg(test)]
+impl DbusConnection {
+    /// Construct a DbusConnection wrapping an already-connected fd, for unit tests.
+    fn for_test(fd: i32) -> Self {
+        Self {
+            system: false,
+            socket: fd,
+            id: None,
+            msg_ctr: AtomicU32::new(0),
+        }
+    }
+}
+
+#[cfg(test)]
 mod tests {
+    use std::os::fd::AsRawFd;
+
+    use nix::sys::socket::{self, AddressFamily, SockFlag, SockType};
     use nix::unistd::getuid;
 
     use super::super::utils::Result;
@@ -553,7 +610,7 @@ mod tests {
 
     #[test]
     #[cfg(feature = "systemd")]
-    fn test_dbus_connection_auth() {
+    fn test_dbus_connection_new() {
         let uid: u32 = getuid().into();
 
         let dbus_pipe_path = format!("/run/user/{}/bus", uid);
@@ -640,5 +697,76 @@ mod tests {
             res,
             Err(SystemdClientError::DBus(DbusError::MethodCallErr(_)))
         ))
+    }
+
+    #[test]
+    fn test_read_exact() {
+        let (a, b) = socket::socketpair(
+            AddressFamily::Unix,
+            SockType::Stream,
+            None,
+            SockFlag::empty(),
+        )
+        .unwrap();
+
+        let data = [1u8, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+        socket::send(a.as_raw_fd(), &data, socket::MsgFlags::empty()).unwrap();
+
+        let conn = DbusConnection::for_test(b.as_raw_fd());
+        let mut buf = [0u8; 10];
+        conn.read_exact(&mut buf).unwrap();
+        assert_eq!(buf, data);
+    }
+
+    #[test]
+    fn test_read_one_message() {
+        // Serialized MethodReturn message captured from real dbus traffic.
+        // body_len=12, header_array_len=63 (aligned to 64), total=92 bytes.
+        let msg_bytes: &[u8] = b"l\x02\x00\x01\x0c\x00\x00\x00\xff\xff\xff\xff?\x00\x00\x00\x05\x01u\x00\x01\x00\x00\x00\x07\x01s\x00\x14\x00\x00\x00org.freedesktop.DBus\x00\x00\x00\x00\x06\x01s\x00\x07\x00\x00\x00:1.2072\x00\x08\x01g\x00\x01s\x00\x00\x07\x00\x00\x00:1.2072\x00";
+
+        let (a, b) = socket::socketpair(
+            AddressFamily::Unix,
+            SockType::Stream,
+            None,
+            SockFlag::empty(),
+        )
+        .unwrap();
+
+        socket::send(a.as_raw_fd(), msg_bytes, socket::MsgFlags::empty()).unwrap();
+
+        let conn = DbusConnection::for_test(b.as_raw_fd());
+        let received = conn.read_one_message().unwrap();
+        assert_eq!(received, msg_bytes);
+    }
+
+    #[test]
+    fn test_read_one_message_respects_boundaries() {
+        // Two messages written back-to-back; each read_one_message call must
+        // return exactly one, with no bytes stolen from the next.
+        //
+        // Signal: body_len=12, header_array_len=143 (aligned to 144), total=172 bytes.
+        let signal_bytes: &[u8] = b"l\x04\x00\x01\x0c\x00\x00\x00\xff\xff\xff\xff\x8f\x00\x00\x00\x07\x01s\x00\x14\x00\x00\x00org.freedesktop.DBus\x00\x00\x00\x00\x06\x01s\x00\x07\x00\x00\x00:1.2072\x00\x01\x01o\x00\x15\x00\x00\x00/org/freedesktop/DBus\x00\x00\x00\x02\x01s\x00\x14\x00\x00\x00org.freedesktop.DBus\x00\x00\x00\x00\x03\x01s\x00\x0c\x00\x00\x00NameAcquired\x00\x00\x00\x00\x08\x01g\x00\x01s\x00\x00\x07\x00\x00\x00:1.2072\x00";
+        // MethodReturn: body_len=12, header_array_len=63 (aligned to 64), total=92 bytes.
+        let reply_bytes: &[u8] = b"l\x02\x00\x01\x0c\x00\x00\x00\xff\xff\xff\xff?\x00\x00\x00\x05\x01u\x00\x01\x00\x00\x00\x07\x01s\x00\x14\x00\x00\x00org.freedesktop.DBus\x00\x00\x00\x00\x06\x01s\x00\x07\x00\x00\x00:1.2072\x00\x08\x01g\x00\x01s\x00\x00\x07\x00\x00\x00:1.2072\x00";
+
+        let (a, b) = socket::socketpair(
+            AddressFamily::Unix,
+            SockType::Stream,
+            None,
+            SockFlag::empty(),
+        )
+        .unwrap();
+
+        let mut combined = signal_bytes.to_vec();
+        combined.extend_from_slice(reply_bytes);
+        socket::send(a.as_raw_fd(), &combined, socket::MsgFlags::empty()).unwrap();
+
+        let conn = DbusConnection::for_test(b.as_raw_fd());
+
+        let first = conn.read_one_message().unwrap();
+        assert_eq!(first, signal_bytes);
+
+        let second = conn.read_one_message().unwrap();
+        assert_eq!(second, reply_bytes);
     }
 }

--- a/crates/libcgroups/src/systemd/dbus_native/utils.rs
+++ b/crates/libcgroups/src/systemd/dbus_native/utils.rs
@@ -44,13 +44,15 @@ pub enum DbusError {
     BusctlError(String),
     #[error("could not parse uid from busctl: {0}")]
     UidError(ParseIntError),
+    #[error("nix error: {0}")]
+    Nix(nix::Error),
 }
 
 pub type Result<T> = std::result::Result<T, SystemdClientError>;
 
 impl From<nix::Error> for SystemdClientError {
     fn from(err: nix::Error) -> SystemdClientError {
-        DbusError::ConnectionError(err.to_string()).into()
+        DbusError::Nix(err).into()
     }
 }
 

--- a/crates/libcgroups/src/systemd/manager.rs
+++ b/crates/libcgroups/src/systemd/manager.rs
@@ -4,7 +4,7 @@ use std::fmt::{Debug, Display};
 use std::fs::{self};
 use std::path::Component::RootDir;
 use std::path::{Path, PathBuf};
-use std::time::{Duration, Instant};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use nix::NixPath;
 use nix::unistd::Pid;
@@ -27,6 +27,10 @@ use crate::systemd::dbus_native::serialize::Variant;
 use crate::systemd::io::Io;
 use crate::systemd::unified::Unified;
 use crate::v2::manager::{Manager as FsManager, V2ManagerError};
+
+const CONNECT_MAX_RETRIES: u32 = 7;
+const CONNECT_BASE_DELAY_MS: u64 = 100;
+const CONNECT_JITTER_DIVISOR: u64 = 8; // jitter up to 1/8 of delay (~12.5%)
 
 const CGROUP_CONTROLLERS: &str = "cgroup.controllers";
 const CGROUP_SUBTREE_CONTROL: &str = "cgroup.subtree_control";
@@ -190,31 +194,120 @@ impl Manager {
         use_system: bool,
         cgroup_wait_timeout_duration: Duration,
     ) -> Result<Self, SystemdManagerError> {
+        use super::dbus_native::utils::DbusError;
+
         let mut destructured_path: CgroupsPath = cgroups_path.as_path().try_into()?;
         ensure_parent_unit(&mut destructured_path, use_system);
 
-        let client = match use_system {
-            true => DbusConnection::new_system()?,
-            false => DbusConnection::new_session()?,
+        // EAGAIN from a recv() that timed out via SO_RCVTIMEO (set in dbus::connect()).
+        let is_eagain = |e: &SystemdManagerError| {
+            matches!(
+                e,
+                SystemdManagerError::SystemdClient(SystemdClientError::DBus(
+                    DbusError::Nix(errno)
+                )) if *errno == nix::errno::Errno::EAGAIN
+            )
         };
 
-        let (cgroups_path, delegation_boundary) =
-            Self::construct_cgroups_path(&destructured_path, &client)?;
-        let full_path = root_path.join_safely(&cgroups_path)?;
-        let fs_manager = FsManager::new(root_path.clone(), cgroups_path.clone())?;
+        // Exponential backoff: base * 2^attempt + jitter (~12.5%).
+        // At most ~15 seconds of total sleep across CONNECT_MAX_RETRIES attempts.
+        let backoff = |retry: u32| -> Duration {
+            let delay_ms = CONNECT_BASE_DELAY_MS << retry;
+            let jitter_ms = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .map(|d| d.subsec_nanos() as u64 % (1 + delay_ms / CONNECT_JITTER_DIVISOR))
+                .unwrap_or(0);
+            Duration::from_millis(delay_ms + jitter_ms)
+        };
 
-        Ok(Manager {
-            root_path,
-            cgroups_path,
-            full_path,
-            container_name,
-            unit_name: Self::get_unit_name(&destructured_path),
-            destructured_path,
-            client,
-            fs_manager,
-            delegation_boundary,
-            cgroup_wait_timeout_duration,
-        })
+        let try_connect = || -> Result<DbusConnection, SystemdManagerError> {
+            if use_system {
+                Ok(DbusConnection::new_system()?)
+            } else {
+                Ok(DbusConnection::new_session()?)
+            }
+        };
+
+        // Retry loop covering both connection (auth) and initial method calls.
+        // EAGAIN can arrive during either phase; after a timeout the socket is
+        // in an inconsistent state, so we drop it and reconnect from scratch.
+        let mut last_err = None;
+        for retry in 0..CONNECT_MAX_RETRIES {
+            // Step 1 — connect + auth (+ Hello for daemon bus).
+            let client = match try_connect() {
+                Ok(c) => c,
+                Err(e) if !is_eagain(&e) => return Err(e),
+                Err(e) => {
+                    let is_last = retry + 1 == CONNECT_MAX_RETRIES;
+                    if is_last {
+                        tracing::debug!(
+                            "dbus connect EAGAIN on attempt {}/{}, giving up",
+                            retry + 1,
+                            CONNECT_MAX_RETRIES
+                        );
+                    } else {
+                        tracing::debug!(
+                            "dbus connect EAGAIN on attempt {}/{}, retrying after backoff",
+                            retry + 1,
+                            CONNECT_MAX_RETRIES
+                        );
+                        std::thread::sleep(backoff(retry));
+                    }
+                    last_err = Some(e);
+                    continue;
+                }
+            };
+
+            // Step 2 — initial method calls to discover the cgroup path.
+            // On EAGAIN, client is dropped here and the next iteration reconnects.
+            match Self::construct_cgroups_path(&destructured_path, &client) {
+                Ok((cgroups_path, delegation_boundary)) => {
+                    let full_path = root_path.join_safely(&cgroups_path)?;
+                    let fs_manager = FsManager::new(root_path.clone(), cgroups_path.clone())?;
+                    return Ok(Manager {
+                        root_path,
+                        cgroups_path,
+                        full_path,
+                        container_name,
+                        unit_name: Self::get_unit_name(&destructured_path),
+                        destructured_path,
+                        client,
+                        fs_manager,
+                        delegation_boundary,
+                        cgroup_wait_timeout_duration,
+                    });
+                }
+                Err(e) if !is_eagain(&e) => return Err(e),
+                Err(e) => {
+                    let is_last = retry + 1 == CONNECT_MAX_RETRIES;
+                    if is_last {
+                        tracing::debug!(
+                            "dbus setup EAGAIN on attempt {}/{}, giving up",
+                            retry + 1,
+                            CONNECT_MAX_RETRIES
+                        );
+                    } else {
+                        tracing::debug!(
+                            "dbus setup EAGAIN on attempt {}/{}, reconnecting after backoff",
+                            retry + 1,
+                            CONNECT_MAX_RETRIES
+                        );
+                        std::thread::sleep(backoff(retry));
+                    }
+                    last_err = Some(e);
+                }
+            }
+        }
+
+        let err_msg = last_err
+            .as_ref()
+            .map(|e| e.to_string())
+            .unwrap_or_else(|| "unknown error".to_string());
+        Err(SystemdClientError::DBus(DbusError::ConnectionError(format!(
+            "dbus connection failed after {} retries: {}",
+            CONNECT_MAX_RETRIES, err_msg
+        )))
+        .into())
     }
 
     /// get_unit_name returns the unit (scope) name from the path provided by the user

--- a/justfile
+++ b/justfile
@@ -2,6 +2,7 @@ alias build := youki-release
 alias youki := youki-dev
 
 KIND_CLUSTER_NAME := 'youki'
+KIND_SYSTEMD_CLUSTER_NAME := 'youki-systemd'
 
 cwd := justfile_directory()
 
@@ -92,7 +93,7 @@ kind-cluster: bin-kind
     set -euo pipefail
 
     mkdir -p tests/k8s/_out/
-    docker buildx build -f tests/k8s/Dockerfile --iidfile=tests/k8s/_out/img --load .
+    docker buildx build -f tests/k8s/Dockerfile --target kind-node --iidfile=tests/k8s/_out/img --load .
     image=$(cat tests/k8s/_out/img)
     bin/kind create cluster --name {{ KIND_CLUSTER_NAME }} --image=$image
 
@@ -102,6 +103,23 @@ test-kind: kind-cluster
     kubectl --context=kind-{{ KIND_CLUSTER_NAME }} wait deployment nginx-deployment --for condition=Available=True --timeout=90s
     kubectl --context=kind-{{ KIND_CLUSTER_NAME }} get pods -o wide
     kubectl --context=kind-{{ KIND_CLUSTER_NAME }} delete -f tests/k8s/deploy.yaml
+
+[private]
+kind-cluster-systemd-cgroup: bin-kind
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    mkdir -p tests/k8s/_out/
+    docker buildx build -f tests/k8s/Dockerfile --target kind-node-systemd-cgroup --iidfile=tests/k8s/_out/img-systemd --load .
+    image=$(cat tests/k8s/_out/img-systemd)
+    bin/kind create cluster --name {{ KIND_SYSTEMD_CLUSTER_NAME }} --image=$image
+
+# run youki with kind and systemd cgroup enabled (regression test for dbus socket path)
+test-kind-systemd-cgroup: kind-cluster-systemd-cgroup
+    kubectl --context=kind-{{ KIND_SYSTEMD_CLUSTER_NAME }} apply -f tests/k8s/deploy.yaml
+    kubectl --context=kind-{{ KIND_SYSTEMD_CLUSTER_NAME }} wait deployment nginx-deployment --for condition=Available=True --timeout=90s
+    kubectl --context=kind-{{ KIND_SYSTEMD_CLUSTER_NAME }} get pods -o wide
+    kubectl --context=kind-{{ KIND_SYSTEMD_CLUSTER_NAME }} delete -f tests/k8s/deploy.yaml
 
 # Bin
 
@@ -114,6 +132,10 @@ bin-kind:
 # Clean kind test env
 clean-test-kind:
 	kind delete cluster --name {{ KIND_CLUSTER_NAME }}
+
+# Clean kind test env (systemd cgroup variant)
+clean-test-kind-systemd-cgroup:
+	kind delete cluster --name {{ KIND_SYSTEMD_CLUSTER_NAME }}
 
 # misc
 

--- a/tests/k8s/Dockerfile
+++ b/tests/k8s/Dockerfile
@@ -21,7 +21,7 @@ ENV PATH="/root/.cargo/bin:${PATH}"
 WORKDIR /youki
 # Copy source code and build with required features
 COPY . .
-RUN cargo build --release -p youki --features "v1 v2"
+RUN cargo build --release -p youki --features "v1 v2 systemd"
 
 FROM scratch AS shim
 COPY --from=youki-build /youki/target/release/youki /
@@ -34,17 +34,25 @@ RUN curl -sSLf https://kind.sigs.k8s.io/dl/${KIND_VERSION}/kind-linux-${TARGETAR
 FROM scratch AS kind-bin
 COPY --from=kind-fetch /root/kind /kind
 
-FROM kind-base
+FROM kind-base AS kind-node-base
 RUN <<EOF
 set -e
 echo '[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.youki]' >> /etc/containerd/config.toml
 echo '  runtime_type = "io.containerd.runc.v2"' >> /etc/containerd/config.toml
 echo '   [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.youki.options]' >> /etc/containerd/config.toml
 echo '     BinaryName = "/usr/local/bin/youki"' >> /etc/containerd/config.toml
-sed -i 's,SystemdCgroup = true,,' /etc/containerd/config.toml
 EOF
 # Install runtime dependency for youki
 RUN apt-get update && apt-get install -y --no-install-recommends libseccomp2 \
     && rm -rf /var/lib/apt/lists/*
 COPY --link --from=shim /* /usr/local/bin/
+
+# Default node image: SystemdCgroup disabled for all runtimes (cgroupfs driver)
+FROM kind-node-base AS kind-node
+RUN sed -i 's,SystemdCgroup = true,,' /etc/containerd/config.toml
+
+# Node image: SystemdCgroup enabled for all runtimes including youki.
+# kindest/node has no dbus; this tests the /run/systemd/private fallback in youki.
+FROM kind-node-base AS kind-node-systemd-cgroup
+RUN echo '     SystemdCgroup = true' >> /etc/containerd/config.toml
 


### PR DESCRIPTION
## Description

When systemd is PID 1 but `dbus-daemon` is not installed (e.g. kind nodes, minimal container images), nginx pods using `runtimeClassName: youki` with `SystemdCgroup = true` would hang for ~4 minutes before failing. There were two independent root causes:

### Root cause 1 — standard bus unavailable

The standard system bus socket `/run/dbus/system_bus_socket` does not exist on kind nodes. The previous `new_system()` unconditionally tried this path and failed immediately.

**Fix:** `new_system()` now falls back to `/run/systemd/private` when:
1. The standard system bus connection fails, AND
2. The process is root, AND
3. `/run/systemd/private` exists

This matches the behavior of [go-systemd's `NewSystemdConnectionContext()`](https://github.com/coreos/go-systemd/blob/main/dbus/dbus.go).

`new_direct()` is added to connect via the private socket, skipping the `Hello` method call that systemd does not implement on `/run/systemd/private`.

### Root cause 2 — indefinite recv() block under concurrent load

`/run/systemd/private` accepts connections but can be slow to respond when many containers start simultaneously (e.g. a Deployment with 5+ replicas). Without a timeout, `recv()` blocks indefinitely on the socket, causing youki to hang until the kubelet kills the pod sandbox creation.

**Fix:** `SO_RCVTIMEO=10s` is set on every dbus socket immediately after connect, covering both the AUTH handshake and all subsequent method calls. When `SO_RCVTIMEO` fires, `recv()` returns `EAGAIN`.

A unified retry loop in `Manager::new()` (7 retries, exponential backoff ~100ms×2ⁿ + jitter, ~15s max) catches `EAGAIN` from either the connection phase or the initial method calls (`control_cgroup_root()`), drops the socket, and reconnects from scratch.

> **Note:** runc uses `context.TODO()` for dbus calls via go-systemd, leaving the same indefinite-block risk open ([runc#3904](https://github.com/opencontainers/runc/issues/3904)). The `SO_RCVTIMEO` approach is youki's equivalent fix.

### Additional improvements

- **`read_one_message()`** replaces `receive_complete_response()`: the old implementation used a heuristic ("if received bytes < buffer size, we're done") that could truncate large messages. The new implementation reads the fixed 16-byte dbus header, extracts `body_len` and `header_array_len`, then reads the exact remainder.
- **`new_system()`** logs the standard bus error via `tracing::debug!` before falling back, improving diagnostics.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test updates
- [x] CI/CD related changes
- [ ] Other (please describe):

## Testing
- [x] Added new unit tests
- [x] Added new integration tests
- [x] Ran existing test suite
- [ ] Tested manually (please provide steps)

## Related Issues

Fixes #3524
