### PR TITLE
fix(libcontainer): inherit init env for startContainer hooks

### DIFF
--- a/crates/libcontainer/src/container/container_delete.rs
+++ b/crates/libcontainer/src/container/container_delete.rs
@@ -98,11 +98,17 @@ impl Container {
                     })?;
 
                     if let Some(hooks) = config.hooks.as_ref() {
-                        hooks::run_hooks(hooks.poststop().as_ref(), Some(&self.state), None, None)
-                            .map_err(|err| {
-                                tracing::error!(err = ?err, "failed to run post stop hooks");
-                                err
-                            })?;
+                        hooks::run_hooks(
+                            hooks.poststop().as_ref(),
+                            Some(&self.state),
+                            None,
+                            None,
+                            None,
+                        )
+                        .map_err(|err| {
+                            tracing::error!(err = ?err, "failed to run post stop hooks");
+                            err
+                        })?;
                     }
                 }
                 Err(err) => {

--- a/crates/libcontainer/src/container/container_start.rs
+++ b/crates/libcontainer/src/container/container_start.rs
@@ -59,6 +59,7 @@ impl Container {
                 Some(&self.state),
                 Some(&self.root),
                 None,
+                None,
             )
             .map_err(|err| {
                 tracing::error!("failed to run post start hooks: {}", err);

--- a/crates/libcontainer/src/hooks.rs
+++ b/crates/libcontainer/src/hooks.rs
@@ -39,6 +39,7 @@ pub fn run_hooks(
     // TODO: Remove the following parameters. To comply with the OCI State, hooks should only depend on structures defined in oci-spec-rs. Cleaning these up ensures proper functional isolation.
     cwd: Option<&Path>,
     pid: Option<Pid>,
+    inherited_envs: Option<&HashMap<String, String>>,
 ) -> Result<()> {
     let base_state = state.ok_or(HookError::MissingContainerState)?;
 
@@ -78,7 +79,7 @@ pub fn run_hooks(
             let envs: HashMap<String, String> = if let Some(env) = hook.env() {
                 utils::parse_env(env)
             } else {
-                HashMap::new()
+                inherited_envs.cloned().unwrap_or_default()
             };
             tracing::debug!("run_hooks envs: {:?}", envs);
 
@@ -195,7 +196,7 @@ mod test {
     fn test_run_hook() -> Result<()> {
         {
             let default_container: Container = Default::default();
-            run_hooks(None, Some(&default_container.state), None, None)
+            run_hooks(None, Some(&default_container.state), None, None, None)
                 .context("Failed simple test")?;
         }
 
@@ -205,8 +206,14 @@ mod test {
 
             let hook = HookBuilder::default().path("true").build()?;
             let hooks = Some(vec![hook]);
-            run_hooks(hooks.as_ref(), Some(&default_container.state), None, None)
-                .context("Failed true")?;
+            run_hooks(
+                hooks.as_ref(),
+                Some(&default_container.state),
+                None,
+                None,
+                None,
+            )
+            .context("Failed true")?;
         }
 
         {
@@ -226,8 +233,14 @@ mod test {
                 .env(vec![String::from("key=value")])
                 .build()?;
             let hooks = Some(vec![hook]);
-            run_hooks(hooks.as_ref(), Some(&default_container.state), None, None)
-                .context("Failed printenv test")?;
+            run_hooks(
+                hooks.as_ref(),
+                Some(&default_container.state),
+                None,
+                None,
+                None,
+            )
+            .context("Failed printenv test")?;
         }
 
         {
@@ -249,6 +262,7 @@ mod test {
                 hooks.as_ref(),
                 Some(&default_container.state),
                 Some(tmp.path()),
+                None,
                 None,
             )
             .context("Failed pwd test")?;
@@ -272,8 +286,38 @@ mod test {
                 Some(&default_container.state),
                 None,
                 Some(expected_pid),
+                None,
             )
             .context("Failed pid test")?;
+        }
+
+        {
+            assert!(
+                is_command_in_path("printenv"),
+                "The printenv was not found."
+            );
+            let default_container: Container = Default::default();
+            let mut inherited_envs = HashMap::new();
+            inherited_envs.insert("ONE".to_string(), "two".to_string());
+            inherited_envs.insert("HOME".to_string(), "/root".to_string());
+
+            let hook = HookBuilder::default()
+                .path("bash")
+                .args(vec![
+                    String::from("bash"),
+                    String::from("-c"),
+                    String::from("test \"$ONE\" = two && test \"$HOME\" = /root"),
+                ])
+                .build()?;
+            let hooks = Some(vec![hook]);
+            run_hooks(
+                hooks.as_ref(),
+                Some(&default_container.state),
+                None,
+                None,
+                Some(&inherited_envs),
+            )
+            .context("Failed inherited env test")?;
         }
 
         Ok(())
@@ -296,7 +340,13 @@ mod test {
             .timeout(1)
             .build()?;
         let hooks = Some(vec![hook]);
-        match run_hooks(hooks.as_ref(), Some(&default_container.state), None, None) {
+        match run_hooks(
+            hooks.as_ref(),
+            Some(&default_container.state),
+            None,
+            None,
+            None,
+        ) {
             Ok(_) => {
                 bail!(
                     "The test expects the hook to error out with timeout. Should not execute cleanly"

--- a/crates/libcontainer/src/process/container_main_process.rs
+++ b/crates/libcontainer/src/process/container_main_process.rs
@@ -167,6 +167,7 @@ pub fn container_main_process(container_args: &ContainerArgs) -> Result<(Pid, bo
                     Some(&container_for_hooks.state),
                     None,
                     Some(init_pid),
+                    None,
                 )
                 .map_err(|err| {
                     tracing::error!("failed to run prestart hooks: {}", err);
@@ -178,6 +179,7 @@ pub fn container_main_process(container_args: &ContainerArgs) -> Result<(Pid, bo
                     Some(&container_for_hooks.state),
                     None,
                     Some(init_pid),
+                    None,
                 )
                 .map_err(|err| {
                     tracing::error!("failed to run create runtime hooks: {}", err);

--- a/crates/libcontainer/src/process/init/process.rs
+++ b/crates/libcontainer/src/process/init/process.rs
@@ -109,6 +109,7 @@ pub fn container_init_process(
                 ctx.container.map(|c| &c.state),
                 None,
                 None,
+                None,
             )
             .map_err(|err| {
                 tracing::error!(?err, "failed to run create container hooks");
@@ -415,11 +416,12 @@ pub fn container_init_process(
         tracing::warn!("seccomp not available, unable to set seccomp privileges!")
     }
 
-    // add HOME into envs if not exists
+    // start_container hooks inherit the same environment as the container init
+    // process, including a synthesized HOME when the spec omits it.
     set_home_env_if_not_exists(&mut ctx.envs, ctx.process.user().uid().into());
 
     args.executor.validate(ctx.spec)?;
-    args.executor.setup_envs(ctx.envs)?;
+    args.executor.setup_envs(ctx.envs.clone())?;
 
     // Notify main process that the init process is ready to execute the
     // payload.  Note, because we are already inside the pid namespace, the pid
@@ -458,6 +460,7 @@ pub fn container_init_process(
                 ctx.container.map(|c| &c.state),
                 None,
                 None,
+                Some(&ctx.envs),
             )
             .map_err(|err| {
                 tracing::error!(?err, "failed to run start container hooks");


### PR DESCRIPTION
## Description
startContainer hooks now inherit the init process env when the hook does not set `env`, same as `runc`.

Before this, the hook was spawned with an empty env, so stuff like `ONE`, `FOO`, and `HOME` just vanished. Kinda sneaky bug, but very real.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Test updates

## Testing
- [x] Added new unit tests
- [x] Ran existing test suite
`cargo check -p libcontainer --no-default-features --features v2`

`cargo test -p libcontainer --no-default-features --features v2 hooks::test::test_run_hook -- --nocapture`

`cargo test -p libcontainer --no-default-features --features v2 hooks::test::test_run_hook_timeout -- --nocapture`

Manual repro from the bug report:

```sh
cat >"rootfs/check-env.sh" <<'EOF2'
#!/bin/sh -ue
test "$ONE" = two
test "$FOO" = bar
echo "$HOME"
EOF2
chmod +x rootfs/check-env.sh
```

```json
"process": {
  "args": ["/bin/true"],
  "env": [
    "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
    "ONE=two",
    "FOO=bar"
  ]
},
"hooks": {
  "startContainer": [
    { "path": "/check-env.sh" }
  ]
}
```

Before this patch, `youki run -b tutorial a` blows up with `ONE: parameter not set`.
After this patch, the hook sees the init env like `runc` does.

## Related Issues
Fixes #3380
Related to #3178

## Additional Context
This keeps explicit hook `env` behavior as-is. The inheritance only kicks in when the hook does not define `env`.
