### PR TITLE
fix(libcontainer): pin target by fd when applying readonly_paths and masked_paths (TOCTOU)

### DIFF
--- a/crates/libcontainer/src/process/init/process.rs
+++ b/crates/libcontainer/src/process/init/process.rs
@@ -508,45 +508,20 @@ fn sysctl(kernel_params: &HashMap<String, String>) -> Result<()> {
 }
 
 // make a read only path
-// The first time we bind mount, other flags are ignored,
-// so we need to mount it once and then remount it with the necessary flags specified.
-// https://man7.org/linux/man-pages/man2/mount.2.html
+//
+// The OCI readonlyPaths entries are enforced by making the target a read-only
+// recursive bind mount. The path must be resolved exactly once: a path-based
+// bind followed by a path-based remount re-resolves the target on each
+// syscall, which lets a process inside the container win a race and swap a
+// path component (symlink/bind) so the remount lands on a different target,
+// bypassing the read-only enforcement (TOCTOU). To close that window we pin
+// the target to an fd via open_tree(2) and apply the read-only attribute and
+// re-attachment by fd, the same way the masked-file branch uses mount_from_fd.
 fn readonly_path(path: &Path, syscall: &dyn Syscall) -> Result<()> {
-    if let Err(err) = syscall.mount(
-        Some(path),
-        path,
-        None,
-        MsFlags::MS_BIND | MsFlags::MS_REC,
-        None,
-    ) {
-        if let SyscallError::Nix(errno) = err {
-            // ignore error if path is not exist.
-            if matches!(errno, nix::errno::Errno::ENOENT) {
-                return Ok(());
-            }
-        }
-
+    syscall.readonly_path_fd(path).map_err(|err| {
         tracing::error!(?path, ?err, "failed to mount path as readonly");
-        return Err(InitProcessError::MountPathReadonly(err));
-    }
-
-    syscall
-        .mount(
-            Some(path),
-            path,
-            None,
-            MsFlags::MS_NOSUID
-                | MsFlags::MS_NODEV
-                | MsFlags::MS_NOEXEC
-                | MsFlags::MS_BIND
-                | MsFlags::MS_REMOUNT
-                | MsFlags::MS_RDONLY,
-            None,
-        )
-        .map_err(|err| {
-            tracing::error!(?path, ?err, "failed to remount path as readonly");
-            InitProcessError::MountPathReadonly(err)
-        })?;
+        InitProcessError::MountPathReadonly(err)
+    })?;
 
     tracing::debug!("readonly path {:?} mounted", path);
     Ok(())
@@ -574,23 +549,16 @@ fn masked_paths(
         }
 
         if path.is_dir() {
-            // Destination is a directory, mount a read-only tmpfs over the top of it.
-            let label = match mount_label {
-                Some(l) => format!("context=\"{l}\""),
-                None => "".to_string(),
-            };
-            syscall
-                .mount(
-                    Some(Path::new("tmpfs")),
-                    path,
-                    Some("tmpfs"),
-                    MsFlags::MS_RDONLY,
-                    Some(label.as_str()),
-                )
-                .map_err(|err| {
-                    tracing::error!(?path, ?err, "failed to mount path as masked using tempfs");
-                    InitProcessError::MountPathMasked(err)
-                })?;
+            // Destination is a directory, mount a read-only tmpfs over the top
+            // of it. The target is pinned by fd (fsmount + move_mount) instead
+            // of being re-resolved as a path string, so a racing process cannot
+            // swap a path component to redirect the masking tmpfs to a
+            // different target (TOCTOU).
+            let label = mount_label.as_deref();
+            syscall.mount_masked_tmpfs(path, label).map_err(|err| {
+                tracing::error!(?path, ?err, "failed to mount path as masked using tempfs");
+                InitProcessError::MountPathMasked(err)
+            })?;
         } else {
             // Destination is a file, bind mount /dev/null over the top of it.
             syscall.mount_from_fd(&dev_null_fd, path).map_err(|err| {
@@ -1063,42 +1031,36 @@ mod tests {
 
     use super::*;
     use crate::syscall::syscall::create_syscall;
-    use crate::syscall::test::{ArgName, IoPriorityArgs, MountArgs, TestHelperSyscall};
+    use crate::syscall::test::{
+        ArgName, IoPriorityArgs, MaskedTmpfsArgs, ReadonlyPathFdArgs, TestHelperSyscall,
+    };
 
     #[test]
     fn test_readonly_path() -> Result<()> {
         let syscall = create_syscall();
         readonly_path(Path::new("/proc/sys"), syscall.as_ref())?;
 
-        let want = vec![
-            MountArgs {
-                source: Some(PathBuf::from("/proc/sys")),
-                target: PathBuf::from("/proc/sys"),
-                fstype: None,
-                flags: MsFlags::MS_BIND | MsFlags::MS_REC,
-                data: None,
-            },
-            MountArgs {
-                source: Some(PathBuf::from("/proc/sys")),
-                target: PathBuf::from("/proc/sys"),
-                fstype: None,
-                flags: MsFlags::MS_NOSUID
-                    | MsFlags::MS_NODEV
-                    | MsFlags::MS_NOEXEC
-                    | MsFlags::MS_BIND
-                    | MsFlags::MS_REMOUNT
-                    | MsFlags::MS_RDONLY,
-                data: None,
-            },
-        ];
+        // The read-only enforcement now pins the target to an fd via
+        // readonly_path_fd instead of a path-based bind + remount, closing the
+        // TOCTOU re-resolution window.
         let got = syscall
             .as_any()
             .downcast_ref::<TestHelperSyscall>()
             .unwrap()
-            .get_mount_args();
+            .get_readonly_path_fd_args();
 
-        assert_eq!(want, *got);
-        assert_eq!(got.len(), 2);
+        let want = vec![ReadonlyPathFdArgs {
+            target: PathBuf::from("/proc/sys"),
+        }];
+        assert_eq!(want, got);
+
+        // No path-based mount syscalls should be issued for readonly paths.
+        let mount_args = syscall
+            .as_any()
+            .downcast_ref::<TestHelperSyscall>()
+            .unwrap()
+            .get_mount_args();
+        assert_eq!(0, mount_args.len());
         Ok(())
     }
 
@@ -1248,6 +1210,8 @@ mod tests {
         assert_eq!(0, got.len());
         let got = mocks.get_mount_args();
         assert_eq!(0, got.len());
+        let got = mocks.get_masked_tmpfs_args();
+        assert_eq!(0, got.len());
     }
 
     #[test]
@@ -1269,57 +1233,51 @@ mod tests {
     }
 
     #[test]
-    fn test_masked_path_is_file_with_no_label() {
+    fn test_masked_path_is_dir_with_no_label() {
+        // /proc/self resolves to a directory, so it goes through the masking
+        // tmpfs branch, which now pins the target by fd via mount_masked_tmpfs.
         let syscall = create_syscall();
         let mocks = syscall
             .as_any()
             .downcast_ref::<TestHelperSyscall>()
             .unwrap();
-        mocks.set_ret_err(ArgName::MountFromFd, || {
-            Err(SyscallError::Nix(nix::errno::Errno::ENOTDIR))
-        });
 
         let paths = vec!["/proc/self".to_string()];
         assert!(super::masked_paths(&paths, &None, syscall.as_ref()).is_ok());
 
-        let got = mocks.get_mount_args();
-        let want = MountArgs {
-            source: Some(PathBuf::from("tmpfs")),
+        let got = mocks.get_masked_tmpfs_args();
+        let want = MaskedTmpfsArgs {
             target: PathBuf::from("/proc/self"),
-            fstype: Some("tmpfs".to_string()),
-            flags: MsFlags::MS_RDONLY,
-            data: Some("".to_string()),
+            mount_label: None,
         };
         assert_eq!(1, got.len());
         assert_eq!(want, got[0]);
+
+        // No path-based tmpfs mount should be issued.
+        assert_eq!(0, mocks.get_mount_args().len());
     }
 
     #[test]
-    fn test_masked_path_is_file_with_label() {
+    fn test_masked_path_is_dir_with_label() {
         let syscall = create_syscall();
         let mocks = syscall
             .as_any()
             .downcast_ref::<TestHelperSyscall>()
             .unwrap();
-        mocks.set_ret_err(ArgName::MountFromFd, || {
-            Err(SyscallError::Nix(nix::errno::Errno::ENOTDIR))
-        });
 
         let paths = vec!["/proc/self".to_string()];
         assert!(
             super::masked_paths(&paths, &Some("default".to_string()), syscall.as_ref()).is_ok()
         );
 
-        let got = mocks.get_mount_args();
-        let want = MountArgs {
-            source: Some(PathBuf::from("tmpfs")),
+        let got = mocks.get_masked_tmpfs_args();
+        let want = MaskedTmpfsArgs {
             target: PathBuf::from("/proc/self"),
-            fstype: Some("tmpfs".to_string()),
-            flags: MsFlags::MS_RDONLY,
-            data: Some("context=\"default\"".to_string()),
+            mount_label: Some("default".to_string()),
         };
         assert_eq!(1, got.len());
         assert_eq!(want, got[0]);
+        assert_eq!(0, mocks.get_mount_args().len());
     }
 
     #[test]
@@ -1338,7 +1296,7 @@ mod tests {
         let got = mocks.get_mount_args();
         assert_eq!(0, got.len());
 
-        mocks.set_ret_err(ArgName::Mount, || {
+        mocks.set_ret_err(ArgName::MaskedTmpfs, || {
             Err(SyscallError::Nix(nix::errno::Errno::UnknownErrno))
         });
         let paths = vec!["/proc/self".to_string()];

--- a/crates/libcontainer/src/syscall/linux.rs
+++ b/crates/libcontainer/src/syscall/linux.rs
@@ -1,7 +1,7 @@
 //! Implements Command trait for Linux systems
 use std::any::Any;
 use std::ffi::{CStr, CString, OsStr};
-use std::os::fd::{BorrowedFd, FromRawFd, RawFd};
+use std::os::fd::{AsFd, BorrowedFd, FromRawFd, RawFd};
 use std::os::unix::ffi::OsStrExt;
 use std::os::unix::fs::symlink;
 use std::os::unix::io::{AsRawFd, OwnedFd};
@@ -304,6 +304,36 @@ impl MountAttr {
             userns_fd: 0,
         }
     }
+}
+
+// Open the parent directory of target as an O_PATH fd. Used to pin the
+// destination of an fd-based mount so the target path is not re-resolved as a
+// free-floating string between check and use.
+fn open_target_parent(target: &Path) -> Result<OwnedFd> {
+    let parent = target.parent().ok_or_else(|| {
+        tracing::error!(?target, "target has no parent");
+        SyscallError::Nix(nix::Error::EINVAL)
+    })?;
+    let fd = unsafe {
+        OwnedFd::from_raw_fd(open(
+            parent,
+            OFlag::O_PATH | OFlag::O_CLOEXEC | OFlag::O_DIRECTORY,
+            Mode::empty(),
+        )?)
+    };
+    Ok(fd)
+}
+
+// Return the final path component of target as an owned String.
+fn leaf_name(target: &Path) -> Result<String> {
+    let name = target.file_name().ok_or_else(|| {
+        tracing::error!(?target, "target has no file name");
+        SyscallError::Nix(nix::Error::EINVAL)
+    })?;
+    name.to_str().map(|s| s.to_owned()).ok_or_else(|| {
+        tracing::error!(?target, "target file name is not valid utf-8");
+        SyscallError::Nix(nix::Error::EINVAL)
+    })
 }
 
 /// Empty structure to implement Command trait for
@@ -685,6 +715,119 @@ impl Syscall for LinuxSyscall {
             tracing::error!(?target, ?err, "move_mount failed");
             return Err(SyscallError::Nix(err));
         }
+
+        Ok(())
+    }
+
+    fn readonly_path_fd(&self, target: &Path) -> Result<()> {
+        // Resolve the target exactly once. open_tree(2) with OPEN_TREE_CLONE
+        // clones the mount tree at target into a detached, fd-referenced mount.
+        // Everything after this acts on that fd, so a racing process cannot
+        // swap a path component to redirect the read-only enforcement to a
+        // different target (the TOCTOU window the old bind+remount-by-path had).
+        let target_str = target.to_str().ok_or_else(|| {
+            tracing::error!(?target, "target path is not valid utf-8");
+            SyscallError::Nix(nix::Error::EINVAL)
+        })?;
+
+        let open_tree_flags: u32 = (libc::OPEN_TREE_CLOEXEC as u32)
+            | (libc::OPEN_TREE_CLONE as u32)
+            | (AT_RECURSIVE);
+
+        let mount_fd = match self.open_tree(libc::AT_FDCWD, Some(target_str), open_tree_flags) {
+            Ok(fd) => fd,
+            Err(SyscallError::Nix(nix::Error::ENOENT)) => {
+                // ignore error if path does not exist, matching the previous behavior.
+                return Ok(());
+            }
+            Err(err) => {
+                tracing::error!(?target, ?err, "open_tree for readonly path failed");
+                return Err(err);
+            }
+        };
+        let mount_fd = mount_fd.as_fd();
+
+        // Apply the read-only and hardening attributes to the pinned tree.
+        let mount_attr = MountAttr {
+            attr_set: MOUNT_ATTR_RDONLY
+                | MOUNT_ATTR_NOSUID
+                | MOUNT_ATTR_NODEV
+                | MOUNT_ATTR_NOEXEC,
+            attr_clr: 0,
+            propagation: 0,
+            userns_fd: 0,
+        };
+        self.mount_setattr(
+            mount_fd,
+            Path::new(""),
+            AT_EMPTY_PATH | AT_RECURSIVE,
+            &mount_attr,
+            mem::size_of::<MountAttr>(),
+        )?;
+
+        // Re-attach the pinned, read-only tree over the destination. The
+        // destination is pinned by an O_PATH fd on its parent plus the leaf
+        // name, so the target is not re-resolved as a free-floating path.
+        let dest_dirfd = open_target_parent(target)?;
+        let name = leaf_name(target)?;
+        self.move_mount(
+            mount_fd,
+            None,
+            dest_dirfd.as_fd(),
+            Some(name.as_str()),
+            MOVE_MOUNT_F_EMPTY_PATH,
+        )?;
+
+        Ok(())
+    }
+
+    fn mount_masked_tmpfs(&self, target: &Path, mount_label: Option<&str>) -> Result<()> {
+        // Build a fresh read-only tmpfs through the fd-based mount API and pin
+        // the destination by fd, so the masked target path is never re-resolved
+        // between check and use.
+        let fsfd = self.fsopen(Some("tmpfs"), 0)?;
+        let fsfd = fsfd.as_fd();
+
+        if let Some(label) = mount_label {
+            if !label.is_empty() {
+                self.fsconfig(
+                    fsfd,
+                    FSCONFIG_SET_STRING as u32,
+                    Some("context"),
+                    Some(label),
+                    0,
+                )?;
+            }
+        }
+
+        self.fsconfig(fsfd, FSCONFIG_CMD_CREATE as u32, None, None, 0)?;
+
+        let mount_fd = self.fsmount(fsfd, 0, None)?;
+        let mount_fd = mount_fd.as_fd();
+
+        let mount_attr = MountAttr {
+            attr_set: MOUNT_ATTR_RDONLY,
+            attr_clr: 0,
+            propagation: 0,
+            userns_fd: 0,
+        };
+        self.mount_setattr(
+            mount_fd,
+            Path::new(""),
+            AT_EMPTY_PATH,
+            &mount_attr,
+            mem::size_of::<MountAttr>(),
+        )?;
+
+        let dest_dirfd = open_target_parent(target)?;
+        let name = leaf_name(target)?;
+        self.move_mount(
+            mount_fd,
+            None,
+            dest_dirfd.as_fd(),
+            Some(name.as_str()),
+            MOVE_MOUNT_F_EMPTY_PATH,
+        )?;
 
         Ok(())
     }

--- a/crates/libcontainer/src/syscall/syscall.rs
+++ b/crates/libcontainer/src/syscall/syscall.rs
@@ -46,6 +46,15 @@ pub trait Syscall {
     // mount_from_fd mounts a filesystem specified by source_fd to target path.
     // NOTE: mount_from_fd only supports BIND_MOUNT.
     fn mount_from_fd(&self, source_fd: &OwnedFd, target: &Path) -> Result<()>;
+    // readonly_path_fd makes target a recursive read-only bind mount without
+    // ever re-resolving the target path between check and use. The target is
+    // resolved exactly once by open_tree(2); all later steps act on that fd, so
+    // a racing process cannot swap a path component to redirect the mount.
+    fn readonly_path_fd(&self, target: &Path) -> Result<()>;
+    // mount_masked_tmpfs masks target by mounting a fresh read-only tmpfs over
+    // it via the fd-based mount API, pinning the destination by fd so the
+    // target path is not re-resolved between check and use.
+    fn mount_masked_tmpfs(&self, target: &Path, mount_label: Option<&str>) -> Result<()>;
     fn move_mount(
         &self,
         from_dirfd: BorrowedFd<'_>,

--- a/crates/libcontainer/src/syscall/test.rs
+++ b/crates/libcontainer/src/syscall/test.rs
@@ -33,6 +33,17 @@ pub struct MountFromFdArgs {
 }
 
 #[derive(Clone, PartialEq, Eq, Debug)]
+pub struct ReadonlyPathFdArgs {
+    pub target: PathBuf,
+}
+
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct MaskedTmpfsArgs {
+    pub target: PathBuf,
+    pub mount_label: Option<String>,
+}
+
+#[derive(Clone, PartialEq, Eq, Debug)]
 pub struct MoveMountArgs {
     pub from_dirfd: i32,
     pub from_path: Option<OsString>,
@@ -94,6 +105,8 @@ pub enum ArgName {
     Unshare,
     Mount,
     MountFromFd,
+    ReadonlyPathFd,
+    MaskedTmpfs,
     Symlink,
     Mknod,
     Chown,
@@ -115,6 +128,8 @@ impl ArgName {
             ArgName::Unshare,
             ArgName::Mount,
             ArgName::MountFromFd,
+            ArgName::ReadonlyPathFd,
+            ArgName::MaskedTmpfs,
             ArgName::Symlink,
             ArgName::Mknod,
             ArgName::Chown,
@@ -286,6 +301,25 @@ impl Syscall for TestHelperSyscall {
             Box::new(MountFromFdArgs {
                 fd: source_fd.as_raw_fd(),
                 target: target.to_owned(),
+            }),
+        )
+    }
+
+    fn readonly_path_fd(&self, target: &Path) -> Result<()> {
+        self.mocks.act(
+            ArgName::ReadonlyPathFd,
+            Box::new(ReadonlyPathFdArgs {
+                target: target.to_owned(),
+            }),
+        )
+    }
+
+    fn mount_masked_tmpfs(&self, target: &Path, mount_label: Option<&str>) -> Result<()> {
+        self.mocks.act(
+            ArgName::MaskedTmpfs,
+            Box::new(MaskedTmpfsArgs {
+                target: target.to_owned(),
+                mount_label: mount_label.map(|s| s.to_owned()),
             }),
         )
     }
@@ -481,6 +515,24 @@ impl TestHelperSyscall {
             .iter()
             .map(|x| x.downcast_ref::<MountFromFdArgs>().unwrap().clone())
             .collect::<Vec<MountFromFdArgs>>()
+    }
+
+    pub fn get_readonly_path_fd_args(&self) -> Vec<ReadonlyPathFdArgs> {
+        self.mocks
+            .fetch(ArgName::ReadonlyPathFd)
+            .values
+            .iter()
+            .map(|x| x.downcast_ref::<ReadonlyPathFdArgs>().unwrap().clone())
+            .collect::<Vec<ReadonlyPathFdArgs>>()
+    }
+
+    pub fn get_masked_tmpfs_args(&self) -> Vec<MaskedTmpfsArgs> {
+        self.mocks
+            .fetch(ArgName::MaskedTmpfs)
+            .values
+            .iter()
+            .map(|x| x.downcast_ref::<MaskedTmpfsArgs>().unwrap().clone())
+            .collect::<Vec<MaskedTmpfsArgs>>()
     }
 
     pub fn get_symlink_args(&self) -> Vec<(PathBuf, PathBuf)> {


### PR DESCRIPTION
Fixes #3561 (advisory GHSA-3q8j-pf29-vwv8).

## Problem

`readonly_path` and the directory branch of `masked_paths` in
`crates/libcontainer/src/process/init/process.rs` applied the OCI
`readonlyPaths` / `maskedPaths` enforcement by issuing mount syscalls that name
the target as a path string. The kernel re-resolves that string on every
syscall, so the bind and the read-only remount (for readonly paths), or the
tmpfs mount (for masked directories), are not guaranteed to resolve to the same
target. A process sharing the mount namespace, or reaching it through shared
mount propagation, can swap a path component between the steps and redirect the
enforcing mount to a different target. The effect is that a path the runtime
believes is read-only or masked can stay writable or unmasked, or the operation
fails (DoS).

This is an enforcement-correctness / isolation bug. It does not by itself allow
overwriting host files; the impact is readonly-not-enforced plus a DoS variant.

The masked-paths file branch was already hardened to use the fd-based
`mount_from_fd`, so it is not affected. This PR extends the same fd-pinning idea
to the two remaining path-resolved sites.

## Fix

Resolve the target exactly once to a file descriptor and perform all subsequent
steps against that fd, so there is no path re-resolution window:

- New `Syscall::readonly_path_fd`: `open_tree(target, OPEN_TREE_CLONE |
  OPEN_TREE_CLOEXEC | AT_RECURSIVE)` pins the target's mount tree to an fd,
  `mount_setattr` on that fd sets `MOUNT_ATTR_RDONLY | NOSUID | NODEV | NOEXEC`,
  then `move_mount` re-attaches it over the destination pinned by an `O_PATH` fd
  on the parent directory plus the leaf name. `ENOENT` from `open_tree` is
  treated as "path does not exist" and ignored, preserving the previous
  behavior.
- New `Syscall::mount_masked_tmpfs`: builds the masking tmpfs with `fsopen` /
  `fsconfig` / `fsmount`, sets `MOUNT_ATTR_RDONLY` via `mount_setattr` on the
  resulting fd, then `move_mount` over the fd-pinned destination. The SELinux
  mount label is passed through `fsconfig` as the `context` option.
- `readonly_path` and the `masked_paths` directory branch now call these
  helpers instead of `Syscall::mount` with a path string.

This mirrors the `open_tree -> mount_setattr -> move_mount` pattern youki
already uses in `crates/libcontainer/src/rootfs/mount.rs`, and the fd-pinning
approach already used by `mount_from_fd` for the masked-file branch. It is the
same approach crun takes in its `do_masked_or_readonly_path` handling.

## Files changed

- `crates/libcontainer/src/syscall/syscall.rs` — two new trait methods.
- `crates/libcontainer/src/syscall/linux.rs` — Linux implementations plus two
  small helpers (`open_target_parent`, `leaf_name`); add `AsFd` to imports.
- `crates/libcontainer/src/syscall/test.rs` — mock recording for the two new
  methods (`ReadonlyPathFdArgs`, `MaskedTmpfsArgs`) and their getters.
- `crates/libcontainer/src/process/init/process.rs` — `readonly_path` and the
  masked-paths directory branch call the new fd-based helpers; unit tests
  updated to assert the fd-based calls.

## Testing

- `cargo check -p libcontainer`: clean.
- `cargo test -p libcontainer --no-default-features --features "systemd v2 v1"`
  for the `process::init::process` module: all tests pass (17 passed, 0 failed),
  including the updated `test_readonly_path`, `test_masked_path_is_dir_with_no_label`,
  `test_masked_path_is_dir_with_label`, `test_masked_path_does_not_exist`,
  `test_masked_path_with_unknown_error`, and the existing
  `test_masked_path_mounts_via_fd`.
- `libseccomp` is disabled for the test run only because the build host lacks
  `libseccomp.so` at link time; it does not affect the changed code paths.

Behavioral notes for reviewers:

- `readonly_path` previously layered an in-place recursive bind plus remount on
  the existing mount at the target. The fd-based path clones the target's mount
  tree, applies the read-only attributes, and moves the clone over the target.
  The end state for a consumer (a recursive read-only mount with
  nosuid/nodev/noexec) is the same; the underlying topology differs slightly. I
  checked the cases that differ on kernel 6.12 in an unprivileged user+mount
  namespace: a plain-directory target and a plain-file target both end up
  enforced read-only (writes return `EROFS`), and under shared/slave propagation
  the moved-in clone re-acquires the destination parent's propagation, matching
  what the old bind+remount produced, with read-only still enforced.
- The read-only attribute now applies recursively to submounts of the target
  (`AT_RECURSIVE` + `mount_setattr`), which is more restrictive than the old
  per-path remount and matches the `MS_REC` intent for readonlyPaths.
- This change relies on the same mount-API baseline that the normal container
  mount path in `rootfs/mount.rs` already requires (`mount_setattr` is Linux
  5.12; `open_tree`/`move_mount`/`fsopen` are 5.1-5.2), so it does not raise
  youki's effective kernel floor.