### PR TITLE
bump oci-spec 0.10.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -92,7 +92,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -103,7 +103,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1556,7 +1556,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3108,7 +3108,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3215,9 +3215,9 @@ dependencies = [
 
 [[package]]
 name = "oci-spec"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8445a2631507cec628a15fdd6154b54a3ab3f20ed4fe9d73a3b8b7a4e1ba03a"
+checksum = "3df6f876ad774d6a676f7e968f5c3edacc32f90e65fe680a8b686235396556fb"
 dependencies = [
  "const_format",
  "derive_builder",
@@ -4337,7 +4337,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4874,7 +4874,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5040,7 +5040,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5059,7 +5059,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6932,7 +6932,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ netlink-packet-route = "0.26.0"
 netlink-sys = "0.8.8"
 nix = "0.29.0"
 num_cpus = "1.17"
+oci-spec = { version = "0.10.0", features = ["runtime"] }
 pathrs = "0.2.4"
 pentacle = "1.1.0"
 pkg-config = "0.3.33"

--- a/crates/libcgroups/Cargo.toml
+++ b/crates/libcgroups/Cargo.toml
@@ -23,7 +23,7 @@ cgroupsv2_devices = ["rbpf", "libbpf-sys", "errno", "libc", "nix/dir"]
 nix = { workspace = true, features = ["signal", "user", "fs"] }
 procfs = { workspace = true }
 pathrs = { workspace = true }
-oci-spec = { version = "~0.9.0", features = ["runtime"] }
+oci-spec = { workspace = true }
 fixedbitset = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 rbpf = { workspace = true, optional = true }
@@ -35,7 +35,7 @@ tracing = { workspace = true, features = ["attributes"] }
 
 [dev-dependencies]
 anyhow = { workspace = true }
-oci-spec = { version = "~0.9.0", features = ["proptests", "runtime"] }
+oci-spec = { workspace = true, features = ["proptests"] }
 quickcheck = { workspace = true }
 mockall = { workspace = true, features = [] }
 clap = { workspace = true, features = ["std", "color", "help", "usage", "error-context", "suggestions"] }

--- a/crates/libcontainer/Cargo.toml
+++ b/crates/libcontainer/Cargo.toml
@@ -25,7 +25,7 @@ chrono = { workspace = true, features = ["clock", "serde"] }
 fastrand = { workspace = true }
 libc = { workspace = true }
 nix = { workspace = true, features = ["socket", "sched", "mount", "mman", "resource", "dir", "term", "hostname", "personality"] }
-oci-spec = { version = "0.9.0", features = ["runtime"] }
+oci-spec = { workspace = true }
 procfs = { workspace = true }
 prctl = { workspace = true }
 libcgroups = { path = "../libcgroups", default-features = false, version = "0.6.0" } # MARK: Version
@@ -44,7 +44,7 @@ netlink-packet-core = { workspace = true }
 pathrs = { workspace = true }
 
 [dev-dependencies]
-oci-spec = { version = "~0.9.0", features = ["proptests", "runtime"] }
+oci-spec = { workspace = true, features = ["proptests"] }
 quickcheck = { workspace = true }
 serial_test = { workspace = true }
 tempfile = { workspace = true }

--- a/crates/libcontainer/src/seccomp/mod.rs
+++ b/crates/libcontainer/src/seccomp/mod.rs
@@ -72,6 +72,12 @@ fn translate_arch(arch: Arch) -> ScmpArch {
         Arch::ScmpArchS390 => ScmpArch::S390,
         Arch::ScmpArchS390x => ScmpArch::S390X,
         Arch::ScmpArchRiscv64 => ScmpArch::Riscv64,
+        Arch::ScmpArchParisc => ScmpArch::Parisc,
+        Arch::ScmpArchParisc64 => ScmpArch::Parisc64,
+        Arch::ScmpArchLoongarch64 => ScmpArch::Loongarch64,
+        Arch::ScmpArchM68k => ScmpArch::M68k,
+        Arch::ScmpArchSh => ScmpArch::Sh,
+        Arch::ScmpArchSheb => ScmpArch::Sheb,
     }
 }
 

--- a/crates/youki/Cargo.toml
+++ b/crates/youki/Cargo.toml
@@ -44,7 +44,7 @@ wasi-common = { workspace = true, optional = true }
 tracing = { workspace = true, features = ["attributes"] }
 tracing-subscriber = { workspace = true, features = ["json", "env-filter"] }
 tracing-journald = { workspace = true }
-oci-spec = { version = "0.9.0", features = ["runtime"] }
+oci-spec = { workspace = true }
 rust-criu = { workspace = true }
 
 [dev-dependencies]

--- a/tests/contest/contest/Cargo.toml
+++ b/tests/contest/contest/Cargo.toml
@@ -10,7 +10,7 @@ libcgroups = { path = "../../../crates/libcgroups" }
 libcontainer = { path = "../../../crates/libcontainer" }
 nix = { workspace = true }
 num_cpus = { workspace = true }
-oci-spec = { version = "0.9.0", features = ["runtime"] }
+oci-spec = { workspace = true }
 pnet_datalink = { workspace = true }
 procfs = { workspace = true }
 rand = { workspace = true }

--- a/tests/contest/runtimetest/Cargo.toml
+++ b/tests/contest/runtimetest/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.1"
 edition = "2024"
 
 [dependencies]
-oci-spec = { version = "0.9.0", features = ["runtime"] }
+oci-spec = { workspace = true }
 nix = { workspace = true }
 anyhow = { workspace = true }
 libc = { workspace = true } # TODO (YJDoc2) upgrade to latest


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of your changes -->

Related: https://github.com/youki-dev/youki/pull/3566

- Bump `oci-spec` from `0.9.0` to `0.10.0`
- Add support for the seccomp architectures newly introduced in `oci-spec` 0.10.0
- Move `oci-spec` to `[workspace.dependencies]` so its version is declared in one place

## Type of Change
<!-- Mark the appropriate option with an [x] -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test updates
- [ ] CI/CD related changes
- [x] Other (please describe): bump oci-spec

## Testing
<!-- Describe the tests you ran and/or added to verify your changes -->
- [ ] Added new unit tests
- [ ] Added new integration tests
- [x] Ran existing test suite
- [ ] Tested manually (please provide steps)

## Related Issues
<!-- Link any related issues using the GitHub issue syntax: #issue-number
If there is no open issue for this, please add details of the problem or open a new issue. -->
Fixes #

## Additional Context
<!-- Add any other context about the pull request here -->
