### PR TITLE
fix(wasmedge): replace unwrap with proper error propagation in exec

### DIFF
--- a/crates/youki/src/workload/wasmedge.rs
+++ b/crates/youki/src/workload/wasmedge.rs
@@ -44,8 +44,12 @@ impl Executor for WasmedgeExecutor {
                 .map_err(|err| ExecutorError::Other(format!("failed to create store: {}", err)))?,
         );
 
-        let module = Module::from_file(None, cmd).unwrap();
-        vm.register_module(Some("main"), module).unwrap();
+        let module = Module::from_file(None, cmd).map_err(|err| {
+            ExecutorError::Other(format!("failed to load wasm module: {:?}", err))
+        })?;
+        vm.register_module(Some("main"), module).map_err(|err| {
+            ExecutorError::Other(format!("failed to register wasm module: {:?}", err))
+        })?;
 
         vm.run_func(Some("main"), "_start", params!())
             .map_err(|err| match *err {


### PR DESCRIPTION
## Description

Two `.unwrap()` calls in `WasmedgeExecutor::exec` can straight-up panic instead of returning an error. `Module::from_file` and `vm.register_module` both fail in practice (bad path, invalid wasm binary, etc) but the code just crashes the process. Every other fallible call in the same function already uses `map_err`, these two were missed.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Testing

- [x] Ran existing test suite

To reproduce: use the `wasm-wasmedge` executor with a container spec that has `run.oci.handler: wasm` annotation, point it at a non-existent or invalid wasm file. youki panics instead of returning a proper error to the runtime caller.

## Related Issues

no open issue found for this

## Additional Context

Changed both calls to `.map_err(|err| ExecutorError::Other(...))` to match the pattern used for `WasiModule::create` and `Store::new` right above them.