### PR TITLE
using lima instead of vagrant file

### DIFF
--- a/justfile
+++ b/justfile
@@ -5,8 +5,22 @@ KIND_CLUSTER_NAME := 'youki'
 KIND_SYSTEMD_CLUSTER_NAME := 'youki-systemd'
 KIND_DEPLOY_CLUSTER_NAME := 'youki-deploy'
 YOUKI_INSTALLER_IMAGE := 'youki-installer:latest'
+DEV_VM_NAME := 'fedora'
 
 cwd := justfile_directory()
+
+destroy_vm:
+  limactl stop -f {{ DEV_VM_NAME }} && limactl remove {{ DEV_VM_NAME }}
+
+# creates a vm using LimaCTL for youki-development
+create_vm:
+  #!/bin/bash
+
+  ScriptDirectory=$(pwd)/experiment/selinux
+  SourceDirectory=$(pwd)
+  limactl start --progress scripts/vms/fedora.yaml --debug \
+    --param ScriptDirectory="$ScriptDirectory" \
+    --param SourceDirectory="$SourceDirectory"
 
 # build
 
@@ -38,7 +52,7 @@ install:
 # run integration tests
 test-integration: test-oci test-contest
 
-# run all tests except rust-oci 
+# run all tests except rust-oci
 test-all: test-basic test-features test-oci containerd-test # currently not doing rust-oci here
 
 # run basic tests

--- a/scripts/vms/fedora.yaml
+++ b/scripts/vms/fedora.yaml
@@ -1,0 +1,72 @@
+# Lima configuration for SELinux development environment with Fedora
+containerd:
+  system: false
+  user: false
+
+base:
+  - url: https://raw.githubusercontent.com/lima-vm/lima/refs/heads/master/templates/_images/fedora-43.yaml
+
+cpus: 4
+memory: "4gb"
+
+provision:
+  - mode: system
+    script: |
+      #!/bin/bash
+      set -eux
+      # Execute the mounted system provisioning script
+      SCRIPT_PATH="/tmp/provision_scripts/provision_system.sh"
+      if [ -f "${SCRIPT_PATH}" ]; then
+        echo "Executing ${SCRIPT_PATH}..."
+        bash "${SCRIPT_PATH}"
+        echo "Finished executing ${SCRIPT_PATH}."
+      else
+        echo "ERROR - ${SCRIPT_PATH} not found!"
+        exit 1
+      fi
+  - mode: user
+    script: |
+      #!/bin/bash
+      set -eux
+      USER_LOG_FILE="/tmp/user_provision.log"
+      exec > >(tee -a "${USER_LOG_FILE}") 2>&1 # Log to file and console
+      export PATH="$HOME/.cargo/bin:$PATH"
+
+      if ! command -v cargo &> /dev/null; then
+        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --no-modify-path --default-toolchain stable
+        if [ -f "$HOME/.cargo/env" ]; then
+            source "$HOME/.cargo/env"
+        fi
+        if ! command -v cargo &> /dev/null; then
+            echo "Cargo still not available after rustup install. Exiting."
+            exit 1
+        fi
+        echo "Rust/Cargo installed successfully."
+        cargo --version
+      else
+        echo "Rust/Cargo is already installed."
+        cargo --version
+        if [ -f "$HOME/.cargo/env" ]; then # Ensure sourced for current script if already present
+             source "$HOME/.cargo/env"
+        fi
+      fi
+
+      echo "Ensuring $HOME/.cargo/env is sourced in .bashrc for future logins..."
+      if ! grep -q 'source "$HOME/.cargo/env"' "$HOME/.bashrc"; then
+        echo 'source "$HOME/.cargo/env"' >> "$HOME/.bashrc"
+      fi
+
+user:
+  home: "/home/{{.User}}"
+
+mounts:
+  - location: "{{.Param.ScriptDirectory}}" # Mount the directory containing the script
+    mountPoint: "/tmp/provision_scripts" # Mount to a directory in VM
+    writable: false
+  - location: "{{.Param.SourceDirectory}}"
+    mountPoint: "/home/{{.User}}/youki"
+    writable: true
+
+param:
+  ScriptDirectory: ~/youki/experiment/selinux
+  SourceDirectory: ~/youki


### PR DESCRIPTION
## Description

This PR adds files
- scripts/vms/fedora.yaml
- scripts/vms/ubuntu.yaml
- scripts/lima-install.sh
and updates `justfile` to make it so that you can create and destroy a fedora
that can be used for development purpose using the limactl toolkit

## Type of Change
<!-- Mark the appropriate option with an [x] -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test updates
- [ ] CI/CD related changes
- [ ] Other (please describe):

## Testing
<!-- Describe the tests you ran and/or added to verify your changes -->
- [ ] Added new unit tests
- [ ] Added new integration tests
- [ ] Ran existing test suite
- [ ] Tested manually (please provide steps)

## Related Issues
<!-- Link any related issues using the GitHub issue syntax: #issue-number
If there is no open issue for this, please add details of the problem or open a new issue. -->
Fixes #3139 

## Additional Context
<!-- Add any other context about the pull request here -->
