### PR TITLE
fix: reject hostname without a private UTS namespace

### DIFF
--- a/crates/libcontainer/src/container/init_builder.rs
+++ b/crates/libcontainer/src/container/init_builder.rs
@@ -228,6 +228,7 @@ impl InitContainerBuilder {
 
         let syscall = create_syscall();
         utils::validate_spec_for_new_user_ns(spec, &*syscall)?;
+        utils::validate_spec_for_hostname(spec)?;
         utils::validate_spec_for_net_devices(spec, &*syscall)
             .map_err(LibcontainerError::NetDevicesError)?;
 

--- a/crates/libcontainer/src/container/tenant_builder.rs
+++ b/crates/libcontainer/src/container/tenant_builder.rs
@@ -444,6 +444,7 @@ impl TenantContainerBuilder {
 
         let syscall = create_syscall();
         utils::validate_spec_for_new_user_ns(spec, &*syscall)?;
+        utils::validate_spec_for_hostname(spec)?;
         utils::validate_spec_for_net_devices(spec, &*syscall)
             .map_err(LibcontainerError::NetDevicesError)?;
 

--- a/crates/libcontainer/src/error.rs
+++ b/crates/libcontainer/src/error.rs
@@ -108,6 +108,8 @@ pub enum ErrInvalidSpec {
     ConsoleSocketRequired,
     #[error("cannot use console socket if youki will not detach or allocate tty")]
     InvalidConsoleSocket,
+    #[error("unable to set hostname without a private UTS namespace")]
+    HostnameRequiresPrivateUtsNamespace,
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/crates/libcontainer/src/utils.rs
+++ b/crates/libcontainer/src/utils.rs
@@ -14,7 +14,7 @@ use nix::sys::statfs::{Statfs, fstatfs};
 use nix::unistd::{Uid, User};
 use oci_spec::runtime::{LinuxNamespaceType, Spec};
 
-use crate::error::{LibcontainerError, MissingSpecError};
+use crate::error::{ErrInvalidSpec, LibcontainerError, MissingSpecError};
 use crate::syscall::syscall::Syscall;
 use crate::user_ns::UserNamespaceConfig;
 
@@ -380,6 +380,32 @@ pub fn validate_spec_for_net_devices(
     Ok(())
 }
 
+pub fn validate_spec_for_hostname(spec: &Spec) -> Result<(), ErrInvalidSpec> {
+    let Some(hostname) = spec.hostname() else {
+        return Ok(());
+    };
+
+    if hostname.is_empty() {
+        return Ok(());
+    }
+
+    let has_private_uts_namespace = spec
+        .linux()
+        .as_ref()
+        .and_then(|linux| linux.namespaces().as_deref())
+        .is_some_and(|namespaces| {
+            namespaces
+                .iter()
+                .any(|ns| ns.typ() == LinuxNamespaceType::Uts && ns.path().is_none())
+        });
+
+    if !has_private_uts_namespace {
+        return Err(ErrInvalidSpec::HostnameRequiresPrivateUtsNamespace);
+    }
+
+    Ok(())
+}
+
 /// Validates mount destinations and warns about deprecated relative paths.
 /// Follows the OCI Runtime Spec requirement that mount destinations SHOULD be absolute.
 /// Relative paths are deprecated but still accepted for backward compatibility.
@@ -657,5 +683,90 @@ mod tests {
         syscall.set_id(Uid::from_raw(0), Gid::from_raw(0)).unwrap();
         let result = validate_spec_for_net_devices(&spec, &*syscall);
         assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_hostname_requires_private_uts_namespace_when_linux_is_missing() {
+        let spec = SpecBuilder::default()
+            .hostname("youki".to_string())
+            .build()
+            .unwrap();
+
+        let err = validate_spec_for_hostname(&spec).unwrap_err();
+        assert!(matches!(
+            err,
+            ErrInvalidSpec::HostnameRequiresPrivateUtsNamespace
+        ));
+    }
+
+    #[test]
+    fn test_hostname_requires_private_uts_namespace_when_uts_is_missing() {
+        let linux = LinuxBuilder::default().build().unwrap();
+        let spec = SpecBuilder::default()
+            .hostname("youki".to_string())
+            .linux(linux)
+            .build()
+            .unwrap();
+
+        let err = validate_spec_for_hostname(&spec).unwrap_err();
+        assert!(matches!(
+            err,
+            ErrInvalidSpec::HostnameRequiresPrivateUtsNamespace
+        ));
+    }
+
+    #[test]
+    fn test_hostname_requires_private_uts_namespace_when_joining_existing_uts() {
+        let linux = LinuxBuilder::default()
+            .namespaces(vec![
+                LinuxNamespaceBuilder::default()
+                    .typ(LinuxNamespaceType::Uts)
+                    .path(PathBuf::from("/proc/1/ns/uts"))
+                    .build()
+                    .unwrap(),
+            ])
+            .build()
+            .unwrap();
+        let spec = SpecBuilder::default()
+            .hostname("youki".to_string())
+            .linux(linux)
+            .build()
+            .unwrap();
+
+        let err = validate_spec_for_hostname(&spec).unwrap_err();
+        assert!(matches!(
+            err,
+            ErrInvalidSpec::HostnameRequiresPrivateUtsNamespace
+        ));
+    }
+
+    #[test]
+    fn test_hostname_with_private_uts_namespace_is_valid() {
+        let linux = LinuxBuilder::default()
+            .namespaces(vec![
+                LinuxNamespaceBuilder::default()
+                    .typ(LinuxNamespaceType::Uts)
+                    .build()
+                    .unwrap(),
+            ])
+            .build()
+            .unwrap();
+        let spec = SpecBuilder::default()
+            .hostname("youki".to_string())
+            .linux(linux)
+            .build()
+            .unwrap();
+
+        assert!(validate_spec_for_hostname(&spec).is_ok());
+    }
+
+    #[test]
+    fn test_empty_hostname_without_private_uts_namespace_is_valid() {
+        let spec = SpecBuilder::default()
+            .hostname(String::new())
+            .build()
+            .unwrap();
+
+        assert!(validate_spec_for_hostname(&spec).is_ok());
     }
 }


### PR DESCRIPTION
## Description
Reject a non-empty `hostname` unless the spec creates a private UTS namespace. Before this, youki would accept the config and then quietly ignore the hostname, which is kinda misleading. Empty hostname still stays valid, same as `runc`.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test updates
- [ ] CI/CD related changes
- [ ] Other (please describe):

## Testing
- [x] Added new unit tests
- [ ] Added new integration tests
- [ ] Ran existing test suite
- [ ] Tested manually (please provide steps)

Checked with `cargo check -p libcontainer` and `cargo check -p libcontainer --tests`.
Local `cargo test` is blocked here because `libseccomp` is missing, rip.

## Related Issues
Fixes #3553

## Additional Context
Repro:
1. Set `"hostname": "youki"` in `config.json`, but do not add a private `uts` namespace under `linux.namespaces`.
2. Run `youki run ctr`.
3. Before this patch it succeeds, but the hostname is ignored.
4. After this patch it fails with `unable to set hostname without a private UTS namespace`.

Related: #3556 is doing a broader validator pass too.
