### PR TITLE
test(contest): add update cgroup v2 common limits integration test

### DIFF
--- a/tests/contest/contest/src/main.rs
+++ b/tests/contest/contest/src/main.rs
@@ -58,6 +58,7 @@ use crate::tests::seccomp_notify::get_seccomp_notify_test;
 use crate::tests::sysctl::get_sysctl_test;
 use crate::tests::tlb::get_tlb_test;
 use crate::tests::uid_mappings::get_uid_mappings_test;
+use crate::tests::update::get_update_test;
 use crate::utils::support::{set_runtime_path, set_runtimetest_path};
 
 #[derive(Parser, Debug)]
@@ -179,6 +180,7 @@ fn main() -> Result<()> {
     let prohibit_symlink = get_prohibit_symlink_test();
     let net_devices = get_net_devices_test();
     let checkpoint_restore = get_checkpoint_restore_tests();
+    let update = get_update_test();
 
     tm.add_test_group(Box::new(cl));
     tm.add_test_group(Box::new(cc));
@@ -237,6 +239,7 @@ fn main() -> Result<()> {
     tm.add_test_group(Box::new(prohibit_symlink));
     tm.add_test_group(Box::new(io_priority_test));
     tm.add_test_group(Box::new(checkpoint_restore));
+    tm.add_test_group(Box::new(update));
     tm.add_cleanup(Box::new(cgroups::cleanup_v1));
     tm.add_cleanup(Box::new(cgroups::cleanup_v2));
 

--- a/tests/contest/contest/src/tests/mod.rs
+++ b/tests/contest/contest/src/tests/mod.rs
@@ -48,3 +48,4 @@ pub mod seccomp_notify;
 pub mod sysctl;
 pub mod tlb;
 pub mod uid_mappings;
+pub mod update;

--- a/tests/contest/contest/src/tests/update/common.rs
+++ b/tests/contest/contest/src/tests/update/common.rs
@@ -1,6 +1,259 @@
-use test_framework::TestResult;
+use std::fs;
+use std::path::Path;
 
-pub(crate) fn update_common_limits_test() -> TestResult {
-    TestResult::Skipped
+use anyhow::{Context, Result, anyhow};
+use oci_spec::runtime::{
+    LinuxMemoryBuilder, LinuxPidsBuilder, LinuxResourcesBuilder, ProcessBuilder, Spec, SpecBuilder,
+};
+use test_framework::{TestResult, test_result};
+
+use super::check_cgroup_value;
+use crate::utils::test_utils::check_container_created;
+use crate::utils::{
+    start_container, test_outside_container, update_container, update_container_with_stdin,
+};
+
+const CGROUP_NAME: &str = "update_common_limits";
+
+fn create_spec() -> Result<Spec> {
+    let memory = LinuxMemoryBuilder::default()
+        .limit(33554432)
+        .reservation(25165824)
+        .build()
+        .context("failed to build memory spec")?;
+
+    let pids = LinuxPidsBuilder::default()
+        .limit(20)
+        .build()
+        .context("failed to build pids spec")?;
+
+    let resources = LinuxResourcesBuilder::default()
+        .memory(memory)
+        .pids(pids)
+        .build()
+        .context("failed to build resources spec")?;
+
+    let mut spec = SpecBuilder::default()
+        .process(
+            ProcessBuilder::default()
+                .args(vec!["sleep".to_string(), "1000".to_string()])
+                .build()?,
+        )
+        .build()
+        .context("failed to build spec")?;
+
+    if let Some(linux) = spec.linux_mut() {
+        linux.set_cgroups_path(Some(Path::new("/runtime-test").join(CGROUP_NAME)));
+        linux.set_resources(Some(resources));
+    }
+
+    Ok(spec)
 }
 
+pub(crate) fn update_common_limits_test() -> TestResult {
+    let spec = test_result!(create_spec());
+
+    test_outside_container(&spec, &|data| {
+        test_result!(check_container_created(&data));
+
+        let id = &data.id;
+        let dir = &data.bundle;
+
+        let start_result = start_container(id, dir).unwrap().wait().unwrap();
+
+        if !start_result.success() {
+            return TestResult::Failed(anyhow!("container start failed"));
+        }
+
+        let cgroup_path = Path::new("/sys/fs/cgroup/runtime-test").join(CGROUP_NAME);
+        let have_swap = cgroup_path.join("memory.swap.max").exists();
+
+        // check that initial values were properly set
+        test_result!(check_cgroup_value(&cgroup_path, "memory.max", "33554432"));
+        test_result!(check_cgroup_value(&cgroup_path, "memory.low", "25165824"));
+        test_result!(check_cgroup_value(&cgroup_path, "pids.max", "20"));
+
+        // update cpuset (only on multi-core systems)
+        let content = fs::read_to_string("/proc/cpuinfo").expect("read /proc/cpuinfo failed");
+        let cpu_count = content
+            .lines()
+            .filter(|l| l.starts_with("processor"))
+            .count();
+        if cpu_count > 1 {
+            update_container(id, dir, &["--cpuset-cpus", "1"])
+                .unwrap()
+                .wait()
+                .unwrap();
+            test_result!(check_cgroup_value(&cgroup_path, "cpuset.cpus", "1"));
+        }
+
+        // update memory limit
+        update_container(id, dir, &["--memory", "67108864"])
+            .unwrap()
+            .wait()
+            .unwrap();
+        test_result!(check_cgroup_value(&cgroup_path, "memory.max", "67108864"));
+
+        update_container(id, dir, &["--memory", "50M"])
+            .unwrap()
+            .wait()
+            .unwrap();
+        test_result!(check_cgroup_value(&cgroup_path, "memory.max", "52428800"));
+
+        // update memory soft limit
+        update_container(id, dir, &["--memory-reservation", "33554432"])
+            .unwrap()
+            .wait()
+            .unwrap();
+        test_result!(check_cgroup_value(&cgroup_path, "memory.low", "33554432"));
+
+        // run swap memory tests if swap is available
+        if have_swap {
+            // remove memory swap limit
+            update_container(id, dir, &["--memory-swap", "-1"])
+                .unwrap()
+                .wait()
+                .unwrap();
+            test_result!(check_cgroup_value(&cgroup_path, "memory.swap.max", "max"));
+
+            // update memory swap
+            // --memory-swap sets total of swap & memory
+            // for cgroupv2, memory and swap can only be set together
+            update_container(
+                id,
+                dir,
+                &["--memory", "52428800", "--memory-swap", "96468992"],
+            )
+            .unwrap()
+            .wait()
+            .unwrap();
+            // for cgroup v2, memory.swap.max is swap only (does not include mem)
+            test_result!(check_cgroup_value(
+                &cgroup_path,
+                "memory.swap.max",
+                &(96468992 - 52428800).to_string()
+            ));
+        }
+
+        // try to remove memory limit
+        update_container(id, dir, &["--memory", "-1"])
+            .unwrap()
+            .wait()
+            .unwrap();
+        // check memory & swap limit is gone
+        test_result!(check_cgroup_value(&cgroup_path, "memory.max", "max"));
+        if have_swap {
+            test_result!(check_cgroup_value(&cgroup_path, "memory.swap.max", "max"));
+        }
+
+        // update pids limit
+        update_container(id, dir, &["--pids-limit", "10"])
+            .unwrap()
+            .wait()
+            .unwrap();
+        test_result!(check_cgroup_value(&cgroup_path, "pids.max", "10"));
+
+        // remove pids limit
+        update_container(id, dir, &["--pids-limit", "-1"])
+            .unwrap()
+            .wait()
+            .unwrap();
+        test_result!(check_cgroup_value(&cgroup_path, "pids.max", "max"));
+
+        // Test bulk updates via JSON (stdin and file)
+        let json = serde_json::json!({
+            "memory":{"limit": 33554432, "reservation": 25165824},
+            "cpu": {"shares": 100, "quota": 500000, "period": 1000000, "cpus": "0"},
+            "pids": {"limit": 20}
+        })
+        .to_string();
+
+        // via stdin
+        update_container_with_stdin(id, dir, &["-r", "-"], &json)
+            .unwrap()
+            .wait()
+            .unwrap();
+        test_result!(check_cgroup_value(&cgroup_path, "cpuset.cpus", "0"));
+        test_result!(check_cgroup_value(&cgroup_path, "memory.max", "33554432"));
+        test_result!(check_cgroup_value(&cgroup_path, "memory.low", "25165824"));
+        test_result!(check_cgroup_value(&cgroup_path, "pids.max", "20"));
+
+        // redo all the changes at once
+        update_container(
+            id,
+            dir,
+            &[
+                "--cpu-period",
+                "900000",
+                "--cpu-quota",
+                "600000",
+                "--cpu-share",
+                "200",
+                "--memory",
+                "67108864",
+                "--memory-reservation",
+                "33554432",
+                "--pids-limit",
+                "10",
+            ],
+        )
+        .unwrap()
+        .wait()
+        .unwrap();
+
+        test_result!(check_cgroup_value(&cgroup_path, "memory.max", "67108864"));
+        test_result!(check_cgroup_value(&cgroup_path, "memory.low", "33554432"));
+        test_result!(check_cgroup_value(&cgroup_path, "pids.max", "10"));
+
+        // via file
+        let json_path = dir.join("update_resources.json");
+        fs::write(&json_path, &json).unwrap();
+
+        update_container(id, dir, &["-r", json_path.to_str().unwrap()])
+            .unwrap()
+            .wait()
+            .unwrap();
+
+        test_result!(check_cgroup_value(&cgroup_path, "cpuset.cpus", "0"));
+        test_result!(check_cgroup_value(&cgroup_path, "memory.max", "33554432"));
+        test_result!(check_cgroup_value(&cgroup_path, "memory.low", "25165824"));
+        test_result!(check_cgroup_value(&cgroup_path, "pids.max", "20"));
+
+        // Regression test for https://github.com/opencontainers/runc/pull/592
+        if have_swap {
+            update_container(id, dir, &["--memory", "30M", "--memory-swap", "50M"])
+                .unwrap()
+                .wait()
+                .unwrap();
+
+            test_result!(check_cgroup_value(
+                &cgroup_path,
+                "memory.max",
+                &(30 * 1024 * 1024).to_string()
+            ));
+            test_result!(check_cgroup_value(
+                &cgroup_path,
+                "memory.swap.max",
+                &(20 * 1024 * 1024).to_string()
+            ));
+
+            update_container(id, dir, &["--memory", "60M", "--memory-swap", "80M"])
+                .unwrap()
+                .wait()
+                .unwrap();
+
+            test_result!(check_cgroup_value(
+                &cgroup_path,
+                "memory.max",
+                &(60 * 1024 * 1024).to_string()
+            ));
+            test_result!(check_cgroup_value(
+                &cgroup_path,
+                "memory.swap.max",
+                &(20 * 1024 * 1024).to_string()
+            ));
+        }
+
+        TestResult::Passed
+    })
+}

--- a/tests/contest/contest/src/tests/update/common.rs
+++ b/tests/contest/contest/src/tests/update/common.rs
@@ -1,0 +1,6 @@
+use test_framework::TestResult;
+
+pub(crate) fn update_common_limits_test() -> TestResult {
+    TestResult::Skipped
+}
+

--- a/tests/contest/contest/src/tests/update/mod.rs
+++ b/tests/contest/contest/src/tests/update/mod.rs
@@ -1,0 +1,32 @@
+mod common;
+
+use anyhow::Context;
+use oci_spec::runtime::{ProcessBuilder, Spec, SpecBuilder};
+use test_framework::{Test, TestGroup};
+
+fn create_spec(process: Option<ProcessBuilder>) -> anyhow::Result<Spec> {
+    let p = process.unwrap_or_default().args(
+        ["sleep", "1000"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect::<Vec<String>>(),
+    );
+    SpecBuilder::default()
+        .process(p.build()?)
+        .build()
+        .context("failed to create spec")
+}
+
+pub fn get_update_test() -> TestGroup {
+    let mut test_group = TestGroup::new("update");
+
+    let update_cgroup_v1_v2_common_limits_test = Test::new(
+        "update_cgroup_v1_v2_common_limits_test",
+        Box::new(common::update_common_limits_test),
+    );
+
+    test_group.add(vec![
+        Box::new(update_cgroup_v1_v2_common_limits_test),
+    ]);
+    test_group
+}

--- a/tests/contest/contest/src/tests/update/mod.rs
+++ b/tests/contest/contest/src/tests/update/mod.rs
@@ -1,32 +1,49 @@
 mod common;
 
-use anyhow::Context;
-use oci_spec::runtime::{ProcessBuilder, Spec, SpecBuilder};
-use test_framework::{Test, TestGroup};
+use std::fs;
+use std::path::Path;
 
-fn create_spec(process: Option<ProcessBuilder>) -> anyhow::Result<Spec> {
-    let p = process.unwrap_or_default().args(
-        ["sleep", "1000"]
-            .iter()
-            .map(|s| s.to_string())
-            .collect::<Vec<String>>(),
-    );
-    SpecBuilder::default()
-        .process(p.build()?)
-        .build()
-        .context("failed to create spec")
+use anyhow::Context;
+use nix::sys::statfs::{CGROUP2_SUPER_MAGIC, statfs};
+use test_framework::{ConditionalTest, TestGroup};
+
+use crate::utils::is_runtime_youki;
+
+pub(super) fn is_cgroup_v2() -> bool {
+    statfs("/sys/fs/cgroup")
+        .map(|stat| stat.filesystem_type() == CGROUP2_SUPER_MAGIC)
+        .unwrap_or(false)
+}
+
+pub(super) fn check_cgroup_value(base: &Path, file: &str, expected: &str) -> anyhow::Result<()> {
+    let path = base.join(file);
+    let got =
+        fs::read_to_string(&path).with_context(|| format!("failed to read {}", path.display()))?;
+    let got = got.trim();
+
+    if got != expected {
+        anyhow::bail!("{}: expected {}, got {}", path.display(), expected, got);
+    }
+    Ok(())
+}
+
+// youki update only supports --pids-limit and --resources (JSON) via CLI.
+// other flags (--memory, --cpuset-cpus, etc.) are not implemented yet.
+// https://github.com/youki-dev/youki/blob/b55b14491ebddf66a29d109d0270b450e020fa32/crates/youki/src/commands/update.rs#L26
+// TODO: remove is_runtime_runc() condition when youki supports full update CLI & support test for cgroup_v1
+fn can_run() -> bool {
+    !is_runtime_youki() && is_cgroup_v2()
 }
 
 pub fn get_update_test() -> TestGroup {
     let mut test_group = TestGroup::new("update");
 
-    let update_cgroup_v1_v2_common_limits_test = Test::new(
-        "update_cgroup_v1_v2_common_limits_test",
+    let update_cgroup_v2_common_limits_test = ConditionalTest::new(
+        "update_cgroup_v2_common_limits_test",
+        Box::new(can_run),
         Box::new(common::update_common_limits_test),
     );
 
-    test_group.add(vec![
-        Box::new(update_cgroup_v1_v2_common_limits_test),
-    ]);
+    test_group.add(vec![Box::new(update_cgroup_v2_common_limits_test)]);
     test_group
 }

--- a/tests/contest/contest/src/utils/mod.rs
+++ b/tests/contest/contest/src/utils/mod.rs
@@ -11,5 +11,5 @@ pub use test_utils::{
     checkpoint_container, create_container, criu_has_feature, criu_installed, delete_container,
     exec_container, get_container_pid, get_state, handle_console_socket, kill_container,
     restore_container, start_container, test_inside_container, test_outside_container,
-    try_checkpoint_container, wait_container_running, wait_for_state,
+    try_checkpoint_container, update_container, wait_container_running, wait_for_state,
 };

--- a/tests/contest/contest/src/utils/mod.rs
+++ b/tests/contest/contest/src/utils/mod.rs
@@ -11,5 +11,6 @@ pub use test_utils::{
     checkpoint_container, create_container, criu_has_feature, criu_installed, delete_container,
     exec_container, get_container_pid, get_state, handle_console_socket, kill_container,
     restore_container, start_container, test_inside_container, test_outside_container,
-    try_checkpoint_container, update_container, wait_container_running, wait_for_state,
+    try_checkpoint_container, update_container, update_container_with_stdin,
+    wait_container_running, wait_for_state,
 };

--- a/tests/contest/contest/src/utils/test_utils.rs
+++ b/tests/contest/contest/src/utils/test_utils.rs
@@ -281,6 +281,16 @@ pub fn pause_container<P: AsRef<Path>>(id: &str, dir: P) -> Result<Child> {
     Ok(res)
 }
 
+pub fn update_container<P: AsRef<Path>>(id: &str, dir: P, args: &[&str]) -> Result<Child> {
+    let res = runtime_command(dir)
+        .arg("update")
+        .args(args)
+        .arg(id)
+        .spawn()
+        .context("could not update container")?;
+    Ok(res)
+}
+
 pub fn resume_container<P: AsRef<Path>>(id: &str, dir: P) -> Result<Child> {
     let res = runtime_command(dir)
         .arg("resume")

--- a/tests/contest/contest/src/utils/test_utils.rs
+++ b/tests/contest/contest/src/utils/test_utils.rs
@@ -2,6 +2,7 @@
 //! Similar to https://github.com/opencontainers/runtime-tools/blob/master/validation/util/test.go
 use std::collections::HashMap;
 use std::ffi::OsStr;
+use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, ExitStatus, Stdio};
 use std::thread::sleep;
@@ -289,6 +290,28 @@ pub fn update_container<P: AsRef<Path>>(id: &str, dir: P, args: &[&str]) -> Resu
         .spawn()
         .context("could not update container")?;
     Ok(res)
+}
+
+pub fn update_container_with_stdin<P: AsRef<Path>>(
+    id: &str,
+    dir: P,
+    args: &[&str],
+    stdin_data: &str,
+) -> Result<Child> {
+    let mut child = runtime_command(dir)
+        .arg("update")
+        .args(args)
+        .arg(id)
+        .stdin(Stdio::piped())
+        .spawn()
+        .context("could not update container")?;
+    child
+        .stdin
+        .take()
+        .expect("stdin was piped")
+        .write_all(stdin_data.as_bytes())
+        .context("failed to write to stdin")?;
+    Ok(child)
 }
 
 pub fn resume_container<P: AsRef<Path>>(id: &str, dir: P) -> Result<Child> {


### PR DESCRIPTION

This PR implements the update cgroup v2 common limits integration test in `contest`,
as part of #3576.

Ported from runc's `update.bats` "update cgroup v1/v2 common limits" test,
scoped to cgroup v2 + cgroupfs driver only.
cgroup v1 and systemd cgroup driver support are TODO.

## Description
<!-- Provide a clear and concise description of your changes -->

Adds the foundational structure for `update` integration tests following the
same pattern as `exec` tests:

- `update_container()` and `update_container_with_stdin()` utilities in `test_utils.rs`
- `check_cgroup_value()` and `is_cgroup_v2()` helpers in `mod.rs`
- Full test logic in `common.rs`:
  - verify initial memory.max, memory.low, and pids.max
  - update and verify cpuset (multi-core only)
  - update and verify memory limit (bytes and suffix notation)
  - update and verify memory reservation
  - update and verify swap limits (if swap available)
  - update and verify pids limit
  - bulk update via JSON from stdin and file
  - regression test for opencontainers/runc#592


## Type of Change
<!-- Mark the appropriate option with an [x] -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test updates
- [ ] CI/CD related changes
- [ ] Other (please describe):

## Testing
<!-- Describe the tests you ran and/or added to verify your changes -->
- [ ] Added new unit tests
- [x] Added new integration tests
- [ ] Ran existing test suite
- [ ] Tested manually (please provide steps)

## Related Issues
<!-- Link any related issues using the GitHub issue syntax: #issue-number
If there is no open issue for this, please add details of the problem or open a new issue. -->
 #3576 

## Additional Context
<!-- Add any other context about the pull request here -->
### test result 
#### runc version 1.5.0-rc.2
```bash
~/youki$ sudo RUNTIME_KIND=runc ./scripts/contest.sh ../runc update
# Start group update
1 / 1 : update_cgroup_v2_common_limits_test : ok
# End group update

Validation successful for runtime ../runc
```
#### youki version: 0.6.0
```bash
~/youki$ sudo ./scripts/contest.sh ./target/release/youki update
# Start group update
1 / 1 : update_cgroup_v2_common_limits_test : skipped
# End group update

Validation successful for runtime ./target/release/youki
```