### PR TITLE
chore: update rust to v1.96.0

### DIFF
--- a/experiment/seccomp/rust-toolchain.toml
+++ b/experiment/seccomp/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
 profile="default"
-channel="1.92.0"
+channel="1.96.0"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
 profile="default"
-channel="1.92.0"
+channel="1.96.0"


### PR DESCRIPTION
## Description
Updates the rust version to v1.96.0 released on 28th May 2026

## Type of Change
<!-- Mark the appropriate option with an [x] -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test updates
- [ ] CI/CD related changes
- [x] Other (please describe): Rust version update

## Testing
<!-- Describe the tests you ran and/or added to verify your changes -->
- [ ] Added new unit tests
- [ ] Added new integration tests
- [x] Ran existing test suite
- [ ] Tested manually (please provide steps)

## Related Issues
Couple of PRs like #3585 and #3583 are failing because some new dependencies require rust > 1.93.0, so I have updated it to latest stable release

## Additional Context
N/A
