### PR TITLE
test(contest): add cpu update integration tests for cgroup v2

### DIFF
--- a/tests/contest/contest/src/tests/update/cpu.rs
+++ b/tests/contest/contest/src/tests/update/cpu.rs
@@ -1,0 +1,183 @@
+use std::path::Path;
+
+use anyhow::{Context, Result, anyhow};
+use oci_spec::runtime::{
+    LinuxCpuBuilder, LinuxResources, LinuxResourcesBuilder, ProcessBuilder, Spec, SpecBuilder,
+};
+use test_framework::{TestResult, test_result};
+
+use super::check_cgroup_value;
+use crate::utils::test_utils::check_container_created;
+use crate::utils::{start_container, test_outside_container, update_container};
+
+fn create_spec(cgroup_name: &str, resources: Option<LinuxResources>) -> Result<Spec> {
+    let mut spec = SpecBuilder::default()
+        .process(
+            ProcessBuilder::default()
+                .args(vec!["sleep".to_string(), "1000".to_string()])
+                .build()?,
+        )
+        .build()
+        .context("failed to build spec")?;
+
+    if let Some(linux) = spec.linux_mut() {
+        linux.set_cgroups_path(Some(Path::new("/runtime-test").join(cgroup_name)));
+        linux.set_resources(resources);
+    }
+
+    Ok(spec)
+}
+
+pub(crate) fn cpu_burst_test() -> TestResult {
+    const CGROUP_NAME: &str = "cpu_burst";
+    let spec = test_result!(create_spec(CGROUP_NAME, None));
+
+    test_outside_container(&spec, &|data| {
+        test_result!(check_container_created(&data));
+
+        let id = &data.id;
+        let dir = &data.bundle;
+
+        let start_result = start_container(id, dir).unwrap().wait().unwrap();
+
+        if !start_result.success() {
+            return TestResult::Failed(anyhow!("container start failed"));
+        }
+        let cgroup_path = Path::new("/sys/fs/cgroup/runtime-test").join(CGROUP_NAME);
+
+        test_result!(check_cgroup_value(&cgroup_path, "cpu.max.burst", "0"));
+
+        update_container(
+            id,
+            dir,
+            &["--cpu-period", "900000", "--cpu-burst", "500000"],
+        )
+        .unwrap()
+        .wait()
+        .unwrap();
+        test_result!(check_cgroup_value(&cgroup_path, "cpu.max.burst", "500000"));
+
+        // issue: https://github.com/opencontainers/runc/issues/4210
+        // for systemd, cpu-burst value will be cleared, it's a known issue.
+        update_container(id, dir, &["--memory", "100M"])
+            .unwrap()
+            .wait()
+            .unwrap();
+        test_result!(check_cgroup_value(&cgroup_path, "cpu.max.burst", "500000"));
+
+        update_container(id, dir, &["--cpu-period", "900000", "--cpu-burst", "0"])
+            .unwrap()
+            .wait()
+            .unwrap();
+        test_result!(check_cgroup_value(&cgroup_path, "cpu.max.burst", "0"));
+
+        TestResult::Passed
+    })
+}
+
+// "set cpu period with no quota"
+pub(crate) fn set_cpu_period_without_quota_test() -> TestResult {
+    const CGROUP_NAME: &str = "cpu_period_no_quota";
+    let cpu = test_result!(
+        LinuxCpuBuilder::default()
+            .period(1000000_u64)
+            .build()
+            .context("failed to build cpu resources")
+    );
+
+    let resources = test_result!(
+        LinuxResourcesBuilder::default()
+            .cpu(cpu)
+            .build()
+            .context("failed to build resources spec")
+    );
+
+    let spec = test_result!(create_spec(CGROUP_NAME, Some(resources)));
+
+    test_outside_container(&spec, &|data| {
+        test_result!(check_container_created(&data));
+
+        let id = &data.id;
+        let dir = &data.bundle;
+
+        let start_result = start_container(id, dir).unwrap().wait().unwrap();
+
+        if !start_result.success() {
+            return TestResult::Failed(anyhow!("container start failed"));
+        }
+
+        let cgroup_path = Path::new("/sys/fs/cgroup/runtime-test").join(CGROUP_NAME);
+
+        test_result!(check_cgroup_value(&cgroup_path, "cpu.max", "max 1000000"));
+
+        TestResult::Passed
+    })
+}
+
+// set cpu period with no quota (invalid period)
+pub(crate) fn set_cpu_period_without_quota_invalid_test() -> TestResult {
+    const CGROUP_NAME: &str = "cpu_period_invalid";
+    let cpu = test_result!(
+        LinuxCpuBuilder::default()
+            .period(100_u64)
+            .build()
+            .context("failed to build cpu resources")
+    );
+
+    let resources = test_result!(
+        LinuxResourcesBuilder::default()
+            .cpu(cpu)
+            .build()
+            .context("failed to build resources spec")
+    );
+
+    let spec = test_result!(create_spec(CGROUP_NAME, Some(resources)));
+
+    test_outside_container(&spec, &|data| {
+        if check_container_created(&data).is_ok() {
+            return TestResult::Failed(anyhow!(
+                "expected container creation to fail with invalid cpu period"
+            ));
+        }
+        TestResult::Passed
+    })
+}
+
+pub(crate) fn set_cpu_quota_without_period_test() -> TestResult {
+    const CGROUP_NAME: &str = "cpu_quota_no_period";
+    let cpu = test_result!(
+        LinuxCpuBuilder::default()
+            .quota(5000)
+            .build()
+            .context("failed to build cpu resources")
+    );
+
+    let resources = test_result!(
+        LinuxResourcesBuilder::default()
+            .cpu(cpu)
+            .build()
+            .context("failed to build resources spec")
+    );
+
+    let spec = test_result!(create_spec(CGROUP_NAME, Some(resources)));
+
+    test_outside_container(&spec, &|data| {
+        test_result!(check_container_created(&data));
+
+        let id = &data.id;
+        let dir = &data.bundle;
+
+        let start_result = start_container(id, dir).unwrap().wait().unwrap();
+
+        if !start_result.success() {
+            return TestResult::Failed(anyhow!("container start failed"));
+        }
+
+        let cgroup_path = Path::new("/sys/fs/cgroup/runtime-test").join(CGROUP_NAME);
+
+        // cpu period defaults to 100000 (100ms) when not specified
+        test_result!(check_cgroup_value(&cgroup_path, "cpu.max", "5000 100000"));
+
+        TestResult::Passed
+    })
+}

--- a/tests/contest/contest/src/tests/update/cpu.rs
+++ b/tests/contest/contest/src/tests/update/cpu.rs
@@ -6,9 +6,9 @@ use oci_spec::runtime::{
 };
 use test_framework::{TestResult, test_result};
 
-use super::check_cgroup_value;
+use super::{check_cgroup_value, update_container_and_wait};
 use crate::utils::test_utils::check_container_created;
-use crate::utils::{start_container, test_outside_container, update_container};
+use crate::utils::{start_container, test_outside_container};
 
 fn create_spec(cgroup_name: &str, resources: Option<LinuxResources>) -> Result<Spec> {
     let mut spec = SpecBuilder::default()
@@ -47,28 +47,22 @@ pub(crate) fn cpu_burst_test() -> TestResult {
 
         test_result!(check_cgroup_value(&cgroup_path, "cpu.max.burst", "0"));
 
-        update_container(
+        test_result!(update_container_and_wait(
             id,
             dir,
             &["--cpu-period", "900000", "--cpu-burst", "500000"],
-        )
-        .unwrap()
-        .wait()
-        .unwrap();
+        ));
         test_result!(check_cgroup_value(&cgroup_path, "cpu.max.burst", "500000"));
 
-        // issue: https://github.com/opencontainers/runc/issues/4210
-        // for systemd, cpu-burst value will be cleared, it's a known issue.
-        update_container(id, dir, &["--memory", "100M"])
-            .unwrap()
-            .wait()
-            .unwrap();
+        // Ensure a memory-only update does not reset cpu.max.burst.
+        test_result!(update_container_and_wait(id, dir, &["--memory", "100M"]));
         test_result!(check_cgroup_value(&cgroup_path, "cpu.max.burst", "500000"));
 
-        update_container(id, dir, &["--cpu-period", "900000", "--cpu-burst", "0"])
-            .unwrap()
-            .wait()
-            .unwrap();
+        test_result!(update_container_and_wait(
+            id,
+            dir,
+            &["--cpu-period", "900000", "--cpu-burst", "0"],
+        ));
         test_result!(check_cgroup_value(&cgroup_path, "cpu.max.burst", "0"));
 
         TestResult::Passed

--- a/tests/contest/contest/src/tests/update/mod.rs
+++ b/tests/contest/contest/src/tests/update/mod.rs
@@ -4,11 +4,11 @@ mod cpu;
 use std::fs;
 use std::path::Path;
 
-use anyhow::Context;
+use anyhow::{Context, Result, anyhow};
 use nix::sys::statfs::{CGROUP2_SUPER_MAGIC, statfs};
 use test_framework::{ConditionalTest, TestGroup};
 
-use crate::utils::is_runtime_youki;
+use crate::utils::{is_runtime_youki, update_container};
 
 pub(super) fn is_cgroup_v2() -> bool {
     statfs("/sys/fs/cgroup")
@@ -25,6 +25,22 @@ pub(super) fn check_cgroup_value(base: &Path, file: &str, expected: &str) -> any
     if got != expected {
         anyhow::bail!("{}: expected {}, got {}", path.display(), expected, got);
     }
+    Ok(())
+}
+
+pub(super) fn update_container_and_wait<P: AsRef<Path>>(
+    id: &str,
+    dir: P,
+    args: &[&str],
+) -> Result<()> {
+    let status = update_container(id, dir, args)?
+        .wait()
+        .context("failed to wait for container update")?;
+
+    if !status.success() {
+        return Err(anyhow!("container update failed with status: {status}"));
+    }
+
     Ok(())
 }
 

--- a/tests/contest/contest/src/tests/update/mod.rs
+++ b/tests/contest/contest/src/tests/update/mod.rs
@@ -1,4 +1,5 @@
 mod common;
+mod cpu;
 
 use std::fs;
 use std::path::Path;
@@ -27,11 +28,16 @@ pub(super) fn check_cgroup_value(base: &Path, file: &str, expected: &str) -> any
     Ok(())
 }
 
-// youki update only supports --pids-limit and --resources (JSON) via CLI.
-// other flags (--memory, --cpuset-cpus, etc.) are not implemented yet.
+// can_run checks if the test environment supports cgroup v2.
+fn can_run() -> bool {
+    is_cgroup_v2()
+}
+// can_run_update checks if the test environment supports cgroup v2
+// and the runtime supports the update command with all CLI flags.
+// youki only supports --pids-limit and --resources (JSON) via update CLI.
 // https://github.com/youki-dev/youki/blob/b55b14491ebddf66a29d109d0270b450e020fa32/crates/youki/src/commands/update.rs#L26
 // TODO: remove is_runtime_runc() condition when youki supports full update CLI & support test for cgroup_v1
-fn can_run() -> bool {
+fn can_run_update() -> bool {
     !is_runtime_youki() && is_cgroup_v2()
 }
 
@@ -40,10 +46,40 @@ pub fn get_update_test() -> TestGroup {
 
     let update_cgroup_v2_common_limits_test = ConditionalTest::new(
         "update_cgroup_v2_common_limits_test",
-        Box::new(can_run),
+        Box::new(can_run_update),
         Box::new(common::update_common_limits_test),
     );
 
-    test_group.add(vec![Box::new(update_cgroup_v2_common_limits_test)]);
+    let cpu_burst_test = ConditionalTest::new(
+        "cpu_burst_test",
+        Box::new(can_run_update),
+        Box::new(cpu::cpu_burst_test),
+    );
+
+    let set_cpu_period_without_quota_test = ConditionalTest::new(
+        "set_cpu_period_without_quota_test",
+        Box::new(can_run),
+        Box::new(cpu::set_cpu_period_without_quota_test),
+    );
+
+    let set_cpu_period_without_quota_invalid_test = ConditionalTest::new(
+        "set_cpu_period_without_quota_invalid_test",
+        Box::new(can_run),
+        Box::new(cpu::set_cpu_period_without_quota_invalid_test),
+    );
+
+    let set_cpu_quota_without_period_test = ConditionalTest::new(
+        "set_cpu_quota_without_period_test",
+        Box::new(can_run),
+        Box::new(cpu::set_cpu_quota_without_period_test),
+    );
+
+    test_group.add(vec![
+        Box::new(update_cgroup_v2_common_limits_test),
+        Box::new(cpu_burst_test),
+        Box::new(set_cpu_period_without_quota_test),
+        Box::new(set_cpu_period_without_quota_invalid_test),
+        Box::new(set_cpu_quota_without_period_test),
+    ]);
     test_group
 }


### PR DESCRIPTION
This PR adds CPU update integration tests for cgroup v2 in `contest`, as part of #3576.
Ported from runc's `update.bats`, scoped to cgroup v2 + cgroupfs driver only.

## Description
<!-- Provide a clear and concise description of your changes -->
Adds `tests/contest/contest/src/tests/update/cpu.rs` with 4 test cases:

- **cpu burst**: verify `cpu.max.burst` is updated and reset correctly
- **set cpu period without quota**: verify `cpu.max` defaults to `max <period>` when no quota is set
- **set cpu period without quota (invalid period)**: verify container creation fails with an invalid period value
- **set cpu quota without period**: verify `cpu.max` uses the default period (100000) when only quota is set

Tests that use `update_container` are skipped for youki, as youki's update command currently only supports `--pids-limit` and `--resources` (JSON).

Each test uses a unique `cgroupsPath` to avoid conflicts during parallel test execution.

## Type of Change
<!-- Mark the appropriate option with an [x] -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test updates
- [ ] CI/CD related changes
- [ ] Other (please describe):

## Testing
<!-- Describe the tests you ran and/or added to verify your changes -->
- [ ] Added new unit tests
- [x] Added new integration tests
- [ ] Ran existing test suite
- [ ] Tested manually (please provide steps)

## Related Issues
<!-- Link any related issues using the GitHub issue syntax: #issue-number
If there is no open issue for this, please add details of the problem or open a new issue. -->
#3576 

## Additional Context
<!-- Add any other context about the pull request here -->
### youki version 0.6.0
```
$ sudo RUNTIME_KIND=youki ./scripts/contest.sh target/release/youki update
  # Start group update
  1 / 5 : cpu_burst_test : skipped
          test cannot run in the current environment (run_all, parallel)
  2 / 5 : set_cpu_period_without_quota_invalid_test : ok
  3 / 5 : set_cpu_period_without_quota_test : ok
  4 / 5 : set_cpu_quota_without_period_test : ok
  5 / 5 : update_cgroup_v2_common_limits_test : skipped
          test cannot run in the current environment (run_all, parallel)
  # End group update

  Validation successful for runtime target/release/youki
```
### runc version 1.5.0-rc.2
```
$ sudo RUNTIME_KIND=runc ./scripts/contest.sh runc update
  # Start group update
  1 / 5 : cpu_burst_test : ok
  2 / 5 : set_cpu_period_without_quota_invalid_test : ok
  3 / 5 : set_cpu_period_without_quota_test : ok
  4 / 5 : set_cpu_quota_without_period_test : ok
  5 / 5 : update_cgroup_v2_common_limits_test : ok
  # End group update

  Validation successful for runtime runc
```