### PR TITLE
test(contest): add update pids limit integration test

### DIFF
--- a/tests/contest/contest/src/tests/update/mod.rs
+++ b/tests/contest/contest/src/tests/update/mod.rs
@@ -1,5 +1,6 @@
 mod common;
 mod cpu;
+mod pids_limit;
 
 use std::fs;
 use std::path::Path;
@@ -66,6 +67,12 @@ pub fn get_update_test() -> TestGroup {
         Box::new(common::update_common_limits_test),
     );
 
+    let update_pids_limit_test = ConditionalTest::new(
+        "update_pids_limit_test",
+        Box::new(can_run),
+        Box::new(pids_limit::update_pids_limit_test),
+    );
+
     let cpu_burst_test = ConditionalTest::new(
         "cpu_burst_test",
         Box::new(can_run_update),
@@ -92,6 +99,7 @@ pub fn get_update_test() -> TestGroup {
 
     test_group.add(vec![
         Box::new(update_cgroup_v2_common_limits_test),
+        Box::new(update_pids_limit_test),
         Box::new(cpu_burst_test),
         Box::new(set_cpu_period_without_quota_test),
         Box::new(set_cpu_period_without_quota_invalid_test),

--- a/tests/contest/contest/src/tests/update/mod.rs
+++ b/tests/contest/contest/src/tests/update/mod.rs
@@ -53,6 +53,8 @@ fn can_run() -> bool {
 // and the runtime supports the update command with all CLI flags.
 // youki only supports --pids-limit and --resources (JSON) via update CLI.
 // https://github.com/youki-dev/youki/blob/b55b14491ebddf66a29d109d0270b450e020fa32/crates/youki/src/commands/update.rs#L26
+// but --pids-limit is temporarily skipped because its behavior is incorrect.
+// See https://github.com/youki-dev/youki/issues/3594.
 // TODO: remove is_runtime_runc() condition when youki supports full update CLI & support test for cgroup_v1
 fn can_run_update() -> bool {
     !is_runtime_youki() && is_cgroup_v2()
@@ -69,7 +71,7 @@ pub fn get_update_test() -> TestGroup {
 
     let update_pids_limit_test = ConditionalTest::new(
         "update_pids_limit_test",
-        Box::new(can_run),
+        Box::new(can_run_update),
         Box::new(pids_limit::update_pids_limit_test),
     );
 

--- a/tests/contest/contest/src/tests/update/pids_limit.rs
+++ b/tests/contest/contest/src/tests/update/pids_limit.rs
@@ -1,0 +1,84 @@
+use std::path::Path;
+
+use anyhow::{Context, Result, anyhow};
+use oci_spec::runtime::{
+    LinuxPidsBuilder, LinuxResourcesBuilder, ProcessBuilder, Spec, SpecBuilder,
+};
+use test_framework::{TestResult, test_result};
+
+use super::check_cgroup_value;
+use crate::utils::test_utils::check_container_created;
+use crate::utils::{start_container, test_outside_container, update_container};
+
+fn create_spec(cgroup_name: &str) -> Result<Spec> {
+    let pids = LinuxPidsBuilder::default()
+        .limit(20)
+        .build()
+        .context("failed to build pids spec")?;
+
+    let resources = LinuxResourcesBuilder::default()
+        .pids(pids)
+        .build()
+        .context("failed to build resources spec")?;
+
+    let mut spec = SpecBuilder::default()
+        .process(
+            ProcessBuilder::default()
+                .args(vec!["sleep".to_string(), "1000".to_string()])
+                .build()?,
+        )
+        .build()
+        .context("failed to build spec")?;
+
+    if let Some(linux) = spec.linux_mut() {
+        linux.set_cgroups_path(Some(Path::new("/runtime-test").join(cgroup_name)));
+        linux.set_resources(Some(resources));
+    }
+
+    Ok(spec)
+}
+
+pub(crate) fn update_pids_limit_test() -> TestResult {
+    const CGROUP_NAME: &str = "update_pids_limit";
+    let spec = test_result!(create_spec(CGROUP_NAME));
+
+    test_outside_container(&spec, &|data| {
+        test_result!(check_container_created(&data));
+
+        let id = &data.id;
+        let dir = &data.bundle;
+
+        let start_result = start_container(id, dir).unwrap().wait().unwrap();
+        if !start_result.success() {
+            return TestResult::Failed(anyhow!("container start failed"));
+        }
+
+        let cgroup_path = Path::new("/sys/fs/cgroup/runtime-test").join(CGROUP_NAME);
+
+        // check the initial values were properly set
+        test_result!(check_cgroup_value(&cgroup_path, "pids.max", "20"));
+
+        // update pids.limit to a specific value
+        update_container(id, dir, &["--pids-limit", "12345"])
+            .unwrap()
+            .wait()
+            .unwrap();
+        test_result!(check_cgroup_value(&cgroup_path, "pids.max", "12345"));
+
+        // update pids.limit to -1, pids.max will become `max`
+        update_container(id, dir, &["--pids-limit", "-1"])
+            .unwrap()
+            .wait()
+            .unwrap();
+        test_result!(check_cgroup_value(&cgroup_path, "pids.max", "max"));
+
+        // update pids.limit to 0, pids.max will become 1
+        update_container(id, dir, &["--pids-limit", "0"])
+            .unwrap()
+            .wait()
+            .unwrap();
+        test_result!(check_cgroup_value(&cgroup_path, "pids.max", "1"));
+
+        TestResult::Passed
+    })
+}

--- a/tests/contest/contest/src/tests/update/pids_limit.rs
+++ b/tests/contest/contest/src/tests/update/pids_limit.rs
@@ -73,6 +73,8 @@ pub(crate) fn update_pids_limit_test() -> TestResult {
         test_result!(check_cgroup_value(&cgroup_path, "pids.max", "max"));
 
         // update pids.limit to 0, pids.max will become 1
+        // runc maps 0 to 1, because pids.max=0 would prevent any task from being created in the cgroup, making the container unusable
+        // this test follows runc's behavior
         update_container(id, dir, &["--pids-limit", "0"])
             .unwrap()
             .wait()


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of your changes -->

## Type of Change
<!-- Mark the appropriate option with an [x] -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test updates
- [ ] CI/CD related changes
- [ ] Other (please describe):

## Testing
<!-- Describe the tests you ran and/or added to verify your changes -->
- [ ] Added new unit tests
- [x] Added new integration tests
- [ ] Ran existing test suite
- [ ] Tested manually (please provide steps)

## Related Issues
<!-- Link any related issues using the GitHub issue syntax: #issue-number
If there is no open issue for this, please add details of the problem or open a new issue. -->
Imprement #3576 

## Additional Context
<!-- Add any other context about the pull request here -->

As noted in #3594, the test for `--update pids-limit` fails, so skipped it.

I have confirmed that the test passes in runc.
```
$ just validate-contest-runc update
sudo RUNTIME_KIND="runc" /home/user/youki/scripts/contest.sh runc update
/usr/sbin/runc
# Start group update
1 / 2 : update_cgroup_v2_common_limits_test : ok
2 / 2 : update_pids_limit_test : ok
# End group update
```

This integration test was created based on the following description in [updates.bats](https://github.com/opencontainers/runc/blob/main/tests/integration/update.bats).
https://github.com/opencontainers/runc/blob/da3d022b06dd96a898f6d0cc1df2773df91ea035/tests/integration/update.bats#L330-L359

