### PR TITLE
test: convert mount_into_container and cgroup_v2 tests to fd-based mock

### DIFF
--- a/crates/libcontainer/src/rootfs/mount.rs
+++ b/crates/libcontainer/src/rootfs/mount.rs
@@ -1030,13 +1030,48 @@ mod tests {
     use anyhow::{Context, Ok, Result};
 
     use super::*;
-    use crate::syscall::test::{ArgName, MountArgs, TestHelperSyscall};
+    use crate::syscall::test::{ArgName, FsconfigArgs, FsopenArgs, TestHelperSyscall};
+
+    fn helper_syscall(m: &Mount) -> &TestHelperSyscall {
+        m.syscall
+            .as_any()
+            .downcast_ref::<TestHelperSyscall>()
+            .unwrap()
+    }
+
+    // Helpers to build the expected fsconfig calls of the fd-based mount flow.
+    fn fsc_str(key: &str, val: &str) -> FsconfigArgs {
+        FsconfigArgs {
+            cmd: linux::FSCONFIG_SET_STRING as u32,
+            key: Some(key.to_string()),
+            val: Some(val.to_string()),
+            aux: 0,
+        }
+    }
+
+    fn fsc_flag(key: &str) -> FsconfigArgs {
+        FsconfigArgs {
+            cmd: linux::FSCONFIG_SET_FLAG as u32,
+            key: Some(key.to_string()),
+            val: None,
+            aux: 0,
+        }
+    }
+
+    fn fsc_create() -> FsconfigArgs {
+        FsconfigArgs {
+            cmd: linux::FSCONFIG_CMD_CREATE as u32,
+            key: None,
+            val: None,
+            aux: 0,
+        }
+    }
 
     #[test]
-    #[ignore] // TODO: fix fd-based test
     fn test_mount_into_container() -> Result<()> {
         let tmp_dir = tempfile::tempdir()?;
         {
+            // Non-bind mount (devpts) uses the fsopen/fsconfig/fsmount flow.
             let m = Mount::new();
             let mount = &SpecMountBuilder::default()
                 .destination(PathBuf::from("/dev/pts"))
@@ -1063,25 +1098,48 @@ mod tests {
                 .is_ok()
             );
 
-            let want = vec![MountArgs {
-                source: Some(PathBuf::from("devpts")),
-                target: tmp_dir.path().join("dev/pts"),
-                fstype: Some("devpts".to_string()),
-                flags: MsFlags::MS_NOSUID | MsFlags::MS_NOEXEC,
-                data: Some(
-                    "newinstance,ptmxmode=0666,mode=0620,gid=5,context=\"defaults\"".to_string(),
-                ),
-            }];
-            let got = &m
-                .syscall
-                .as_any()
-                .downcast_ref::<TestHelperSyscall>()
-                .unwrap()
-                .get_mount_args();
-            assert_eq!(want, *got);
-            assert_eq!(got.len(), 1);
+            let s = helper_syscall(&m);
+
+            assert_eq!(
+                s.get_fsopen_args(),
+                vec![FsopenArgs {
+                    fsname: Some("devpts".to_string()),
+                    flags: 0,
+                }]
+            );
+
+            // source, then each mount option, then the create command. The
+            // SELinux mount label is only applied when SELinux is enabled.
+            let mut want_fsconfig = vec![
+                fsc_str("source", "devpts"),
+                fsc_flag("newinstance"),
+                fsc_str("ptmxmode", "0666"),
+                fsc_str("mode", "0620"),
+                fsc_str("gid", "5"),
+            ];
+            if Path::new("/sys/fs/selinux").exists() {
+                want_fsconfig.push(fsc_str("context", "defaults"));
+            }
+            want_fsconfig.push(fsc_create());
+            assert_eq!(s.get_fsconfig_args(), want_fsconfig);
+
+            let setattr = s.get_mount_setattr_args();
+            assert_eq!(setattr.len(), 1);
+            assert_eq!(
+                setattr[0].attr_set,
+                linux::MOUNT_ATTR_NOSUID | linux::MOUNT_ATTR_NOEXEC
+            );
+
+            let mv = s.get_move_mount_args();
+            assert_eq!(mv.len(), 1);
+            assert_eq!(
+                mv[0].to_dirfd_path.as_deref(),
+                Some(tmp_dir.path().join("dev/pts").as_path())
+            );
         }
         {
+            // Read-only bind mount uses the open_tree flow; the read-only flag
+            // is applied via mount_setattr (no separate remount).
             let m = Mount::new();
             let mount = &SpecMountBuilder::default()
                 .destination(PathBuf::from("/dev/null"))
@@ -1101,31 +1159,26 @@ mod tests {
                     .is_ok()
             );
 
-            let want = vec![
-                MountArgs {
-                    source: Some(tmp_dir.path().join("null")),
-                    target: tmp_dir.path().join("dev/null"),
-                    fstype: Some("bind".to_string()),
-                    flags: MsFlags::MS_RDONLY,
-                    data: Some("".to_string()),
-                },
-                // remount one
-                MountArgs {
-                    source: None,
-                    target: tmp_dir.path().join("dev/null"),
-                    fstype: None,
-                    flags: MsFlags::MS_RDONLY | MsFlags::MS_REMOUNT,
-                    data: None,
-                },
-            ];
-            let got = &m
-                .syscall
-                .as_any()
-                .downcast_ref::<TestHelperSyscall>()
-                .unwrap()
-                .get_mount_args();
-            assert_eq!(want, *got);
-            assert_eq!(got.len(), 2);
+            let s = helper_syscall(&m);
+
+            let open_tree = s.get_open_tree_args();
+            assert_eq!(open_tree.len(), 1);
+            assert_eq!(
+                open_tree[0].path.as_deref(),
+                Some(tmp_dir.path().join("null").to_str().unwrap())
+            );
+            assert_eq!(open_tree[0].flags & linux::AT_RECURSIVE, 0);
+
+            let setattr = s.get_mount_setattr_args();
+            assert_eq!(setattr.len(), 1);
+            assert_eq!(setattr[0].attr_set, linux::MOUNT_ATTR_RDONLY);
+
+            let mv = s.get_move_mount_args();
+            assert_eq!(mv.len(), 1);
+            assert_eq!(
+                mv[0].to_dirfd_path.as_deref(),
+                Some(tmp_dir.path().join("dev/null").as_path())
+            );
         }
         {
             // Socket file bind-mount
@@ -1144,23 +1197,29 @@ mod tests {
                     .is_ok()
             );
 
-            let want = vec![MountArgs {
-                source: Some(tmp_dir.path().join("tmp.sock")),
-                target: tmp_dir.path().join("tmp.sock"),
-                fstype: Some("bind".to_string()),
-                flags: MsFlags::empty(),
-                data: Some("".to_string()),
-            }];
-            let got = &m
-                .syscall
-                .as_any()
-                .downcast_ref::<TestHelperSyscall>()
-                .unwrap()
-                .get_mount_args();
-            assert_eq!(want, *got);
-            assert_eq!(got.len(), 2);
+            let s = helper_syscall(&m);
+
+            let open_tree = s.get_open_tree_args();
+            assert_eq!(open_tree.len(), 1);
+            assert_eq!(
+                open_tree[0].path.as_deref(),
+                Some(tmp_dir.path().join("tmp.sock").to_str().unwrap())
+            );
+            assert_eq!(open_tree[0].flags & linux::AT_RECURSIVE, 0);
+
+            let setattr = s.get_mount_setattr_args();
+            assert_eq!(setattr.len(), 1);
+            assert_eq!(setattr[0].attr_set, 0);
+
+            let mv = s.get_move_mount_args();
+            assert_eq!(mv.len(), 1);
+            assert_eq!(
+                mv[0].to_dirfd_path.as_deref(),
+                Some(tmp_dir.path().join("tmp.sock").as_path())
+            );
         }
         {
+            // EINVAL on the first attempt is retried once and then succeeds.
             let m = Mount::new();
             let mount = &SpecMountBuilder::default()
                 .destination(PathBuf::from("/tmp/retry"))
@@ -1169,23 +1228,21 @@ mod tests {
                 .build()?;
             let mount_option_config = parse_mount(mount)?;
 
-            let syscall = m
-                .syscall
-                .as_any()
-                .downcast_ref::<TestHelperSyscall>()
-                .unwrap();
-            syscall.set_ret_err(ArgName::Mount, || {
+            let syscall = helper_syscall(&m);
+            syscall.set_ret_err(ArgName::Fsopen, || {
                 Err(crate::syscall::SyscallError::Nix(nix::errno::Errno::EINVAL))
             });
-            syscall.set_ret_err_times(ArgName::Mount, 1);
+            syscall.set_ret_err_times(ArgName::Fsopen, 1);
 
             assert!(
                 m.mount_into_container(mount, tmp_dir.path(), &mount_option_config, None)
                     .is_ok()
             );
-            assert_eq!(syscall.get_mount_args().len(), 1);
+            // The failed first fsopen isn't recorded; only the retried one is.
+            assert_eq!(syscall.get_fsopen_args().len(), 1);
         }
         {
+            // EINVAL on both attempts gives up.
             let m = Mount::new();
             let mount = &SpecMountBuilder::default()
                 .destination(PathBuf::from("/tmp/retry"))
@@ -1194,23 +1251,20 @@ mod tests {
                 .build()?;
             let mount_option_config = parse_mount(mount)?;
 
-            let syscall = m
-                .syscall
-                .as_any()
-                .downcast_ref::<TestHelperSyscall>()
-                .unwrap();
-            syscall.set_ret_err(ArgName::Mount, || {
+            let syscall = helper_syscall(&m);
+            syscall.set_ret_err(ArgName::Fsopen, || {
                 Err(crate::syscall::SyscallError::Nix(nix::errno::Errno::EINVAL))
             });
-            syscall.set_ret_err_times(ArgName::Mount, 2);
+            syscall.set_ret_err_times(ArgName::Fsopen, 2);
 
             assert!(
                 m.mount_into_container(mount, tmp_dir.path(), &mount_option_config, None)
                     .is_err()
             );
-            assert_eq!(syscall.get_mount_args().len(), 0);
+            assert_eq!(syscall.get_fsopen_args().len(), 0);
         }
         {
+            // EBUSY is retried up to MAX_EBUSY_MOUNT_ATTEMPTS times.
             let m = Mount::new();
             let mount = &SpecMountBuilder::default()
                 .destination(PathBuf::from("/tmp/retry"))
@@ -1219,23 +1273,20 @@ mod tests {
                 .build()?;
             let mount_option_config = parse_mount(mount)?;
 
-            let syscall = m
-                .syscall
-                .as_any()
-                .downcast_ref::<TestHelperSyscall>()
-                .unwrap();
-            syscall.set_ret_err(ArgName::Mount, || {
+            let syscall = helper_syscall(&m);
+            syscall.set_ret_err(ArgName::Fsopen, || {
                 Err(crate::syscall::SyscallError::Nix(nix::errno::Errno::EBUSY))
             });
-            syscall.set_ret_err_times(ArgName::Mount, MAX_EBUSY_MOUNT_ATTEMPTS as usize - 1);
+            syscall.set_ret_err_times(ArgName::Fsopen, MAX_EBUSY_MOUNT_ATTEMPTS as usize - 1);
 
             assert!(
                 m.mount_into_container(mount, tmp_dir.path(), &mount_option_config, None)
                     .is_ok()
             );
-            assert_eq!(syscall.get_mount_args().len(), 1);
+            assert_eq!(syscall.get_fsopen_args().len(), 1);
         }
         {
+            // EBUSY beyond MAX_EBUSY_MOUNT_ATTEMPTS gives up.
             let m = Mount::new();
             let mount = &SpecMountBuilder::default()
                 .destination(PathBuf::from("/tmp/retry"))
@@ -1244,21 +1295,17 @@ mod tests {
                 .build()?;
             let mount_option_config = parse_mount(mount)?;
 
-            let syscall = m
-                .syscall
-                .as_any()
-                .downcast_ref::<TestHelperSyscall>()
-                .unwrap();
-            syscall.set_ret_err(ArgName::Mount, || {
+            let syscall = helper_syscall(&m);
+            syscall.set_ret_err(ArgName::Fsopen, || {
                 Err(crate::syscall::SyscallError::Nix(nix::errno::Errno::EBUSY))
             });
-            syscall.set_ret_err_times(ArgName::Mount, MAX_EBUSY_MOUNT_ATTEMPTS as usize);
+            syscall.set_ret_err_times(ArgName::Fsopen, MAX_EBUSY_MOUNT_ATTEMPTS as usize);
 
             assert!(
                 m.mount_into_container(mount, tmp_dir.path(), &mount_option_config, None)
                     .is_err()
             );
-            assert_eq!(syscall.get_mount_args().len(), 0);
+            assert_eq!(syscall.get_fsopen_args().len(), 0);
         }
 
         Ok(())
@@ -1352,201 +1399,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "v1")]
-    #[ignore] // TODO: fix fd-based test
-    fn test_namespaced_subsystem_success() -> Result<()> {
-        let tmp = tempfile::tempdir().unwrap();
-        let container_cgroup = Path::new("/container_cgroup");
-
-        let mounter = Mount::new();
-
-        let spec_cgroup_mount = SpecMountBuilder::default()
-            .destination(container_cgroup)
-            .source("cgroup")
-            .typ("cgroup")
-            .build()
-            .context("failed to build cgroup mount")?;
-
-        let mount_opts = MountOptions {
-            root: tmp.path(),
-            label: None,
-            cgroup_ns: true,
-        };
-
-        let subsystem_name = "cpu";
-
-        mounter
-            .setup_namespaced_subsystem(&spec_cgroup_mount, &mount_opts, subsystem_name, false)
-            .context("failed to setup namespaced subsystem")?;
-
-        let expected = MountArgs {
-            source: Some(PathBuf::from("cgroup")),
-            target: tmp
-                .path()
-                .join_safely(container_cgroup)?
-                .join(subsystem_name),
-            fstype: Some("cgroup".to_owned()),
-            flags: MsFlags::MS_NOEXEC | MsFlags::MS_NOSUID | MsFlags::MS_NODEV,
-            data: Some("cpu".to_owned()),
-        };
-
-        let got = mounter
-            .syscall
-            .as_any()
-            .downcast_ref::<TestHelperSyscall>()
-            .unwrap()
-            .get_mount_args();
-
-        assert_eq!(got.len(), 1);
-        assert_eq!(expected, got[0]);
-
-        Ok(())
-    }
-
-    #[test]
-    #[cfg(feature = "v1")]
-    #[ignore] // TODO: fix fd-based test
-    fn test_emulated_subsystem_success() -> Result<()> {
-        // arrange
-        let tmp = tempfile::tempdir().unwrap();
-        let host_cgroup_mount = tmp.path().join("host_cgroup");
-        let host_cgroup = host_cgroup_mount.join("cpu/container1");
-        fs::create_dir_all(&host_cgroup)?;
-
-        let container_cgroup = Path::new("/container_cgroup");
-        let mounter = Mount::new();
-
-        let spec_cgroup_mount = SpecMountBuilder::default()
-            .destination(container_cgroup)
-            .source("cgroup")
-            .typ("cgroup")
-            .build()
-            .context("failed to build cgroup mount")?;
-
-        let mount_opts = MountOptions {
-            root: tmp.path(),
-            label: None,
-            cgroup_ns: false,
-        };
-
-        let subsystem_name = "cpu";
-        let mut process_cgroups = HashMap::new();
-        process_cgroups.insert("cpu".to_owned(), "container1".to_owned());
-
-        // act
-        mounter
-            .setup_emulated_subsystem(
-                &spec_cgroup_mount,
-                &mount_opts,
-                subsystem_name,
-                false,
-                &host_cgroup_mount.join(subsystem_name),
-                &process_cgroups,
-            )
-            .context("failed to setup emulated subsystem")?;
-
-        // assert
-        let expected = MountArgs {
-            source: Some(host_cgroup),
-            target: tmp
-                .path()
-                .join_safely(container_cgroup)?
-                .join(subsystem_name),
-            fstype: Some("bind".to_owned()),
-            flags: MsFlags::MS_BIND | MsFlags::MS_REC,
-            data: Some("".to_owned()),
-        };
-
-        let got = mounter
-            .syscall
-            .as_any()
-            .downcast_ref::<TestHelperSyscall>()
-            .unwrap()
-            .get_mount_args();
-
-        assert_eq!(got.len(), 1);
-        assert_eq!(expected, got[0]);
-
-        Ok(())
-    }
-
-    #[test]
-    #[cfg(feature = "v1")]
-    #[ignore] // TODO: fix fd-based test
-    fn test_mount_cgroup_v1() -> Result<()> {
-        // arrange
-        let tmp = tempfile::tempdir()?;
-        let container_cgroup = PathBuf::from("/sys/fs/cgroup");
-
-        let spec_cgroup_mount = SpecMountBuilder::default()
-            .destination(&container_cgroup)
-            .source("cgroup")
-            .typ("cgroup")
-            .build()
-            .context("failed to build cgroup mount")?;
-
-        let mount_opts = MountOptions {
-            root: tmp.path(),
-            label: None,
-            cgroup_ns: true,
-        };
-
-        let mounter = Mount::new();
-
-        // act
-        mounter
-            .mount_cgroup_v1(&spec_cgroup_mount, &mount_opts)
-            .context("failed to mount cgroup v1")?;
-
-        // assert
-        let mut got = mounter
-            .syscall
-            .as_any()
-            .downcast_ref::<TestHelperSyscall>()
-            .unwrap()
-            .get_mount_args()
-            .into_iter();
-
-        let host_mounts = libcgroups::v1::util::list_subsystem_mount_points()?;
-        assert_eq!(got.len(), host_mounts.len() + 1);
-
-        let expected = MountArgs {
-            source: Some(PathBuf::from("tmpfs".to_owned())),
-            target: tmp.path().join_safely(&container_cgroup)?,
-            fstype: Some("tmpfs".to_owned()),
-            flags: MsFlags::MS_NOEXEC | MsFlags::MS_NOSUID | MsFlags::MS_NODEV,
-            data: Some("mode=755".to_owned()),
-        };
-        assert_eq!(expected, got.next().unwrap());
-
-        for (host_mount, act) in host_mounts.iter().zip(got) {
-            let subsystem_name = host_mount.file_name().and_then(|f| f.to_str()).unwrap();
-            let expected = MountArgs {
-                source: Some(PathBuf::from("cgroup".to_owned())),
-                target: tmp
-                    .path()
-                    .join_safely(&container_cgroup)?
-                    .join(subsystem_name),
-                fstype: Some("cgroup".to_owned()),
-                flags: MsFlags::MS_NOEXEC | MsFlags::MS_NOSUID | MsFlags::MS_NODEV,
-                data: Some(
-                    if subsystem_name == "systemd" {
-                        format!("name={subsystem_name}")
-                    } else {
-                        subsystem_name.to_string()
-                    }
-                    .to_owned(),
-                ),
-            };
-            assert_eq!(expected, act);
-        }
-
-        Ok(())
-    }
-
-    #[test]
     #[cfg(feature = "v2")]
-    #[ignore] // TODO: fix fd-based test
     fn test_mount_cgroup_v2() -> Result<()> {
         // arrange
         let tmp = tempfile::tempdir().unwrap();
@@ -1579,23 +1432,35 @@ mod tests {
             .context("failed to mount cgroup v2")?;
 
         // assert
-        let expected = MountArgs {
-            source: Some(PathBuf::from("cgroup".to_owned())),
-            target: tmp.path().join_safely(container_cgroup)?,
-            fstype: Some("cgroup2".to_owned()),
-            flags: MsFlags::MS_NOEXEC | MsFlags::MS_NOSUID | MsFlags::MS_NODEV,
-            data: Some("".to_owned()),
-        };
+        let s = helper_syscall(&mounter);
 
-        let got = mounter
-            .syscall
-            .as_any()
-            .downcast_ref::<TestHelperSyscall>()
-            .unwrap()
-            .get_mount_args();
+        // cgroup v2 is a non-bind mount (cgroup2 filesystem).
+        assert_eq!(
+            s.get_fsopen_args(),
+            vec![FsopenArgs {
+                fsname: Some("cgroup2".to_string()),
+                flags: 0,
+            }]
+        );
+        // No mount data, so only the source and the create command.
+        assert_eq!(
+            s.get_fsconfig_args(),
+            vec![fsc_str("source", "cgroup"), fsc_create()]
+        );
 
-        assert_eq!(got.len(), 1);
-        assert_eq!(expected, got[0]);
+        let setattr = s.get_mount_setattr_args();
+        assert_eq!(setattr.len(), 1);
+        assert_eq!(
+            setattr[0].attr_set,
+            linux::MOUNT_ATTR_NOEXEC | linux::MOUNT_ATTR_NOSUID | linux::MOUNT_ATTR_NODEV
+        );
+
+        let mv = s.get_move_mount_args();
+        assert_eq!(mv.len(), 1);
+        assert_eq!(
+            mv[0].to_dirfd_path.as_deref(),
+            Some(tmp.path().join_safely(container_cgroup)?.as_path())
+        );
 
         Ok(())
     }

--- a/crates/libcontainer/src/syscall/test.rs
+++ b/crates/libcontainer/src/syscall/test.rs
@@ -2,6 +2,7 @@ use std::any::Any;
 use std::cell::{Ref, RefCell, RefMut};
 use std::collections::HashMap;
 use std::ffi::{OsStr, OsString};
+use std::fs::{File, read_link};
 use std::os::fd::{AsRawFd, BorrowedFd, RawFd};
 use std::os::unix::io::OwnedFd;
 use std::path::{Path, PathBuf};
@@ -38,6 +39,7 @@ pub struct MoveMountArgs {
     pub from_path: Option<OsString>,
     pub to_dirfd: i32,
     pub to_path: Option<OsString>,
+    pub to_dirfd_path: Option<PathBuf>,
     pub flags: u32,
 }
 
@@ -45,6 +47,39 @@ pub struct MoveMountArgs {
 pub struct FsopenArgs {
     pub fsname: Option<String>,
     pub flags: u32,
+}
+
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct FsconfigArgs {
+    pub cmd: u32,
+    pub key: Option<String>,
+    pub val: Option<String>,
+    pub aux: libc::c_int,
+}
+
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct FsmountArgs {
+    pub flags: u32,
+    pub attr_flags: Option<u64>,
+}
+
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct OpenTreeArgs {
+    pub dirfd: i32,
+    pub path: Option<String>,
+    pub flags: u32,
+}
+
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct MountSetattrArgs {
+    pub dirfd: i32,
+    pub pathname: PathBuf,
+    pub flags: u32,
+    pub attr_set: u64,
+    pub attr_clr: u64,
+    pub propagation: u64,
+    pub userns_fd: u64,
+    pub size: libc::size_t,
 }
 
 #[derive(Clone, PartialEq, Eq, Debug)]
@@ -106,6 +141,10 @@ pub enum ArgName {
     UMount2,
     MoveMount,
     Fsopen,
+    Fsconfig,
+    Fsmount,
+    OpenTree,
+    MountSetattr,
 }
 
 impl ArgName {
@@ -125,6 +164,11 @@ impl ArgName {
             ArgName::IoPriority,
             ArgName::MemPolicy,
             ArgName::MoveMount,
+            ArgName::Fsopen,
+            ArgName::Fsconfig,
+            ArgName::Fsmount,
+            ArgName::OpenTree,
+            ArgName::MountSetattr,
         ]
         .iter()
         .copied()
@@ -174,6 +218,13 @@ impl MockCalls {
     fn fetch_mut(&self, name: ArgName) -> RefMut<'_, Mock> {
         self.args.get(&name).unwrap().borrow_mut()
     }
+}
+
+/// Open a fresh, valid file descriptor for use as a placeholder return value
+/// from fd-returning syscalls (`fsopen`/`fsmount`/`open_tree`). Tests don't
+/// dereference it; it only needs to be a real, owned fd.
+fn dummy_owned_fd() -> OwnedFd {
+    OwnedFd::from(File::open("/dev/null").expect("failed to open /dev/null for a test fd"))
 }
 
 #[derive(Default)]
@@ -263,7 +314,7 @@ impl Syscall for TestHelperSyscall {
     ) -> Result<()> {
         // For tests: resolve /proc/self/fd/<n> to the real path before recording.
         let target_owned = if target.starts_with(Path::new("/proc/self/fd")) {
-            std::fs::read_link(target).unwrap_or_else(|_| target.to_owned())
+            read_link(target).unwrap_or_else(|_| target.to_owned())
         } else {
             target.to_owned()
         };
@@ -298,37 +349,81 @@ impl Syscall for TestHelperSyscall {
         to_path: Option<&str>,
         flags: u32,
     ) -> Result<()> {
-        let rec = MoveMountArgs {
-            from_dirfd: from_dirfd.as_raw_fd(),
-            from_path: from_path.map(OsString::from),
-            to_dirfd: to_dirfd.as_raw_fd(),
-            to_path: to_path.map(OsString::from),
-            flags,
+        // The destination is usually passed by fd (MOVE_MOUNT_T_EMPTY_PATH), so
+        // resolve the real path it points at via /proc/self/fd while the fd is
+        // still open, for later assertions.
+        let to_dirfd_path = if to_path.is_none() {
+            read_link(format!("/proc/self/fd/{}", to_dirfd.as_raw_fd())).ok()
+        } else {
+            None
         };
-        self.mocks.act(ArgName::MoveMount, Box::new(rec))
+
+        self.mocks.act(
+            ArgName::MoveMount,
+            Box::new(MoveMountArgs {
+                from_dirfd: from_dirfd.as_raw_fd(),
+                from_path: from_path.map(OsString::from),
+                to_dirfd: to_dirfd.as_raw_fd(),
+                to_path: to_path.map(OsString::from),
+                to_dirfd_path,
+                flags,
+            }),
+        )
     }
 
-    fn fsopen(&self, _: Option<&str>, _: u32) -> Result<OwnedFd> {
-        todo!()
+    fn fsopen(&self, fstype: Option<&str>, flags: u32) -> Result<OwnedFd> {
+        self.mocks.act(
+            ArgName::Fsopen,
+            Box::new(FsopenArgs {
+                fsname: fstype.map(|s| s.to_owned()),
+                flags,
+            }),
+        )?;
+        Ok(dummy_owned_fd())
     }
 
     fn fsconfig(
         &self,
-        _: BorrowedFd<'_>,
-        _: u32,
-        _: Option<&str>,
-        _: Option<&str>,
-        _: libc::c_int,
+        _fsfd: BorrowedFd<'_>,
+        cmd: u32,
+        key: Option<&str>,
+        val: Option<&str>,
+        aux: libc::c_int,
     ) -> Result<()> {
-        todo!()
+        self.mocks.act(
+            ArgName::Fsconfig,
+            Box::new(FsconfigArgs {
+                cmd,
+                key: key.map(|s| s.to_owned()),
+                val: val.map(|s| s.to_owned()),
+                aux,
+            }),
+        )
     }
 
-    fn fsmount(&self, _: BorrowedFd<'_>, _: u32, _: Option<u64>) -> Result<OwnedFd> {
-        todo!()
+    fn fsmount(
+        &self,
+        _fsfd: BorrowedFd<'_>,
+        flags: u32,
+        attr_flags: Option<u64>,
+    ) -> Result<OwnedFd> {
+        self.mocks.act(
+            ArgName::Fsmount,
+            Box::new(FsmountArgs { flags, attr_flags }),
+        )?;
+        Ok(dummy_owned_fd())
     }
 
-    fn open_tree(&self, _: RawFd, _: Option<&str>, _: u32) -> Result<OwnedFd> {
-        todo!()
+    fn open_tree(&self, dirfd: RawFd, path: Option<&str>, flags: u32) -> Result<OwnedFd> {
+        self.mocks.act(
+            ArgName::OpenTree,
+            Box::new(OpenTreeArgs {
+                dirfd,
+                path: path.map(|s| s.to_owned()),
+                flags,
+            }),
+        )?;
+        Ok(dummy_owned_fd())
     }
 
     fn symlink(&self, original: &Path, link: &Path) -> Result<()> {
@@ -370,13 +465,25 @@ impl Syscall for TestHelperSyscall {
 
     fn mount_setattr(
         &self,
-        _: BorrowedFd<'_>,
-        _: &Path,
-        _: u32,
-        _: &linux::MountAttr,
-        _: libc::size_t,
+        dirfd: BorrowedFd<'_>,
+        pathname: &Path,
+        flags: u32,
+        mount_attr: &linux::MountAttr,
+        size: libc::size_t,
     ) -> Result<()> {
-        todo!()
+        self.mocks.act(
+            ArgName::MountSetattr,
+            Box::new(MountSetattrArgs {
+                dirfd: dirfd.as_raw_fd(),
+                pathname: pathname.to_owned(),
+                flags,
+                attr_set: mount_attr.attr_set,
+                attr_clr: mount_attr.attr_clr,
+                propagation: mount_attr.propagation,
+                userns_fd: mount_attr.userns_fd,
+                size,
+            }),
+        )
     }
 
     fn set_io_priority(&self, class: i64, priority: i64) -> Result<()> {
@@ -472,6 +579,60 @@ impl TestHelperSyscall {
             .iter()
             .map(|x| x.downcast_ref::<MountArgs>().unwrap().clone())
             .collect::<Vec<MountArgs>>()
+    }
+
+    pub fn get_fsopen_args(&self) -> Vec<FsopenArgs> {
+        self.mocks
+            .fetch(ArgName::Fsopen)
+            .values
+            .iter()
+            .map(|x| x.downcast_ref::<FsopenArgs>().unwrap().clone())
+            .collect::<Vec<FsopenArgs>>()
+    }
+
+    pub fn get_fsconfig_args(&self) -> Vec<FsconfigArgs> {
+        self.mocks
+            .fetch(ArgName::Fsconfig)
+            .values
+            .iter()
+            .map(|x| x.downcast_ref::<FsconfigArgs>().unwrap().clone())
+            .collect::<Vec<FsconfigArgs>>()
+    }
+
+    pub fn get_fsmount_args(&self) -> Vec<FsmountArgs> {
+        self.mocks
+            .fetch(ArgName::Fsmount)
+            .values
+            .iter()
+            .map(|x| x.downcast_ref::<FsmountArgs>().unwrap().clone())
+            .collect::<Vec<FsmountArgs>>()
+    }
+
+    pub fn get_open_tree_args(&self) -> Vec<OpenTreeArgs> {
+        self.mocks
+            .fetch(ArgName::OpenTree)
+            .values
+            .iter()
+            .map(|x| x.downcast_ref::<OpenTreeArgs>().unwrap().clone())
+            .collect::<Vec<OpenTreeArgs>>()
+    }
+
+    pub fn get_mount_setattr_args(&self) -> Vec<MountSetattrArgs> {
+        self.mocks
+            .fetch(ArgName::MountSetattr)
+            .values
+            .iter()
+            .map(|x| x.downcast_ref::<MountSetattrArgs>().unwrap().clone())
+            .collect::<Vec<MountSetattrArgs>>()
+    }
+
+    pub fn get_move_mount_args(&self) -> Vec<MoveMountArgs> {
+        self.mocks
+            .fetch(ArgName::MoveMount)
+            .values
+            .iter()
+            .map(|x| x.downcast_ref::<MoveMountArgs>().unwrap().clone())
+            .collect::<Vec<MoveMountArgs>>()
     }
 
     pub fn get_mount_from_fd_args(&self) -> Vec<MountFromFdArgs> {


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of your changes -->

This PR migrates the `mount_into_container` tests to fd-based tests.

It also removes the cgroup v1 tests, since cgroup v1 is no longer maintained. 
See: https://github.com/youki-dev/youki/issues/3285


## Type of Change
<!-- Mark the appropriate option with an [x] -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test updates
- [ ] CI/CD related changes
- [ ] Other (please describe):

## Testing
<!-- Describe the tests you ran and/or added to verify your changes -->
- [x] Added new unit tests
- [ ] Added new integration tests
- [ ] Ran existing test suite
- [ ] Tested manually (please provide steps)

## Related Issues
<!-- Link any related issues using the GitHub issue syntax: #issue-number
If there is no open issue for this, please add details of the problem or open a new issue. -->
Fixes #3485

## Additional Context
<!-- Add any other context about the pull request here -->
