### PR TITLE
fix(utils): reject network device names exceeding the kernel limit according to the kernel reference

### DIFF
--- a/crates/libcontainer/src/utils.rs
+++ b/crates/libcontainer/src/utils.rs
@@ -403,7 +403,7 @@ pub fn validate_mount_options(
 
 // https://elixir.bootlin.com/linux/v6.12/source/net/core/dev.c#L1066
 fn dev_valid_name(name: &str) -> bool {
-    if name.is_empty() || name.len() > IFNAMSIZ {
+    if name.is_empty() || name.len() >= IFNAMSIZ {
         return false;
     }
     if name.eq(".") || name.eq("..") {
@@ -576,7 +576,13 @@ mod tests {
         let long_name = "a".repeat(IFNAMSIZ + 1);
         assert!(!dev_valid_name(&long_name));
 
-        let valid_name = "a".repeat(IFNAMSIZ);
+        // The kernel rejects interface names whose length is >= IFNAMSIZ (16 bytes),
+        // therefore valid names must be at most IFNAMSIZ - 1 (15 bytes).
+        // https://elixir.bootlin.com/linux/v6.12/source/net/core/dev.c#L1066
+        let over_length_name = "a".repeat(IFNAMSIZ);
+        assert!(!dev_valid_name(&over_length_name));
+
+        let valid_name = "a".repeat(IFNAMSIZ - 1);
         assert!(dev_valid_name(&valid_name));
 
         assert!(!dev_valid_name("."));


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of your changes -->

- Fixed dev_vaild_name function to follow the linux kernel implementation 
- Added few test cases which validates the dev_valid_name behavior

## Type of Change
<!-- Mark the appropriate option with an [x] -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test updates
- [ ] CI/CD related changes
- [ ] Other (please describe):

## Testing
<!-- Describe the tests you ran and/or added to verify your changes -->
- [x] Added new unit tests
- [ ] Added new integration tests
- [x] Ran existing test suite
- [ ] Tested manually (please provide steps)

## Related Issues
<!-- Link any related issues using the GitHub issue syntax: #issue-number
If there is no open issue for this, please add details of the problem or open a new issue. -->
- Fixes #3607
- #279

## Additional Context
<!-- Add any other context about the pull request here -->
PR #3163 