### PR TITLE
fix(libcontainer): Bind mount detection should be based on bind/rbind options, not type == "bind"

### DIFF
--- a/crates/libcontainer/src/container/container_checkpoint.rs
+++ b/crates/libcontainer/src/container/container_checkpoint.rs
@@ -12,6 +12,7 @@ use super::container_criu::{CRIU_VERSION_MINIMUM, check_criu_version};
 use super::{Container, ContainerStatus};
 use crate::container::container::CheckpointOptions;
 use crate::error::LibcontainerError;
+use crate::rootfs::utils::is_bind;
 
 const CRIU_CHECKPOINT_LOG_FILE: &str = "dump.log";
 const DESCRIPTORS_JSON: &str = "descriptors.json";
@@ -60,45 +61,41 @@ impl Container {
         let spec = Spec::load(source_spec_path)?;
         let mounts = spec.mounts().clone();
         for m in mounts.unwrap_or_default() {
-            match m.typ().as_deref() {
-                Some("bind") => {
-                    let dest = m
-                        .destination()
-                        .clone()
-                        .into_os_string()
-                        .into_string()
-                        .expect("failed to convert mount destination");
-                    criu.set_external_mount(dest.clone(), dest);
-                }
-                Some("cgroup") => {
-                    match libcgroups::common::get_cgroup_setup()? {
-                        // For v1 it is necessary to list all cgroup mounts as external mounts
-                        Legacy | Hybrid => {
-                            #[cfg(not(feature = "v1"))]
-                            panic!(
-                                "libcontainer can't run in a Legacy or Hybrid cgroup setup without the v1 feature"
-                            );
-                            #[cfg(feature = "v1")]
-                            for mp in libcgroups::v1::util::list_subsystem_mount_points().map_err(
-                                |err| {
-                                    tracing::error!(?err, "failed to get subsystem mount points");
-                                    LibcontainerError::OtherCgroup(err.to_string())
-                                },
-                            )? {
-                                let cgroup_mount = mp
-                                    .clone()
-                                    .into_os_string()
-                                    .into_string()
-                                    .expect("failed to convert mount point");
-                                if cgroup_mount.starts_with(DEFAULT_CGROUP_ROOT) {
-                                    criu.set_external_mount(cgroup_mount.clone(), cgroup_mount);
-                                }
+            if is_bind(&m) {
+                let dest = m
+                    .destination()
+                    .clone()
+                    .into_os_string()
+                    .into_string()
+                    .expect("failed to convert mount destination");
+                criu.set_external_mount(dest.clone(), dest);
+            } else if m.typ().as_deref() == Some("cgroup") {
+                match libcgroups::common::get_cgroup_setup()? {
+                    // For v1 it is necessary to list all cgroup mounts as external mounts
+                    Legacy | Hybrid => {
+                        #[cfg(not(feature = "v1"))]
+                        panic!(
+                            "libcontainer can't run in a Legacy or Hybrid cgroup setup without the v1 feature"
+                        );
+                        #[cfg(feature = "v1")]
+                        for mp in
+                            libcgroups::v1::util::list_subsystem_mount_points().map_err(|err| {
+                                tracing::error!(?err, "failed to get subsystem mount points");
+                                LibcontainerError::OtherCgroup(err.to_string())
+                            })?
+                        {
+                            let cgroup_mount = mp
+                                .clone()
+                                .into_os_string()
+                                .into_string()
+                                .expect("failed to convert mount point");
+                            if cgroup_mount.starts_with(DEFAULT_CGROUP_ROOT) {
+                                criu.set_external_mount(cgroup_mount.clone(), cgroup_mount);
                             }
                         }
-                        _ => (),
                     }
+                    _ => (),
                 }
-                _ => (),
             }
         }
 

--- a/crates/libcontainer/src/rootfs/mount.rs
+++ b/crates/libcontainer/src/rootfs/mount.rs
@@ -28,6 +28,7 @@ use procfs::{FromRead, ProcessCGroups};
 use super::symlink::Symlink;
 use super::symlink::SymlinkError;
 use super::utils::{MountOptionConfig, parse_mount};
+use crate::rootfs::utils::is_bind;
 use crate::syscall::syscall::create_syscall;
 use crate::syscall::{Syscall, SyscallError, linux};
 use crate::utils::{PathBufExt, retry};
@@ -589,7 +590,7 @@ impl Mount {
 
         let source = m.source().as_ref().ok_or(MountError::NoSource)?;
         let dir_perm = Permissions::from_mode(0o755);
-        let src = if typ == Some("bind") {
+        let src = if is_bind(m) {
             let src = canonicalize(source).map_err(|err| {
                 tracing::error!("failed to canonicalize {:?}: {}", source, err);
                 err
@@ -629,15 +630,10 @@ impl Mount {
         let dest: OwnedFd = root.resolve(container_dest)?.into();
         let dest_fd = dest.as_fd();
 
-        let is_bind = typ == Some("bind")
-            || m.options()
-                .as_deref()
-                .is_some_and(|ops| ops.iter().any(|o| o == "bind" || o == "rbind"));
-
         // fd-based mount flow:
         // - bind: open_tree -> mount_setattr -> move_mount
         // - nonbind: fsopen -> fsconfig -> fsmount -> mount_setattr -> move_mount
-        if is_bind {
+        if is_bind(m) {
             let recursive = m
                 .options()
                 .as_ref()
@@ -957,7 +953,7 @@ impl Mount {
                     return Ok(());
                 }
 
-                if mount.typ().as_deref() == Some("bind") {
+                if is_bind(mount) {
                     if let Some(source) = mount.source() {
                         let stat = statfs(source).map_err(MountError::from)?;
                         if stat.filesystem_type() == PROC_SUPER_MAGIC {

--- a/crates/libcontainer/src/rootfs/utils.rs
+++ b/crates/libcontainer/src/rootfs/utils.rs
@@ -640,8 +640,6 @@ mod tests {
 
     #[test]
     fn test_is_bind() {
-        use oci_spec::runtime::MountBuilder;
-
         // Legacy check
         let m1 = MountBuilder::default().typ("bind").build().unwrap();
         assert!(is_bind(&m1));

--- a/crates/libcontainer/src/rootfs/utils.rs
+++ b/crates/libcontainer/src/rootfs/utils.rs
@@ -193,6 +193,10 @@ pub fn parse_mount(m: &Mount) -> std::result::Result<MountOptionConfig, MountErr
 }
 
 pub fn is_bind(m: &Mount) -> bool {
+    // The `type == "bind"` check is kept only for backward compatibility
+    // with existing configs (see issue #3603); it diverges from runc, which
+    // rejects `type: "bind"` alone, and may be removed in a future release
+    // once a deprecation path is agreed upon.
     m.typ().as_deref() == Some("bind")
         || m.options()
             .as_deref()

--- a/crates/libcontainer/src/rootfs/utils.rs
+++ b/crates/libcontainer/src/rootfs/utils.rs
@@ -192,6 +192,13 @@ pub fn parse_mount(m: &Mount) -> std::result::Result<MountOptionConfig, MountErr
     })
 }
 
+pub fn is_bind(m: &Mount) -> bool {
+    m.typ().as_deref() == Some("bind")
+        || m.options()
+            .as_deref()
+            .is_some_and(|opts| opts.iter().any(|o| o == "bind" || o == "rbind"))
+}
+
 #[cfg(test)]
 mod tests {
     use anyhow::Result;
@@ -629,5 +636,31 @@ mod tests {
         );
 
         Ok(())
+    }
+
+    #[test]
+    fn test_is_bind() {
+        use oci_spec::runtime::MountBuilder;
+
+        // Legacy check
+        let m1 = MountBuilder::default().typ("bind").build().unwrap();
+        assert!(is_bind(&m1));
+
+        // Spec-compliant checks
+        let m2 = MountBuilder::default()
+            .options(vec!["bind".to_string()])
+            .build()
+            .unwrap();
+        assert!(is_bind(&m2));
+
+        let m3 = MountBuilder::default()
+            .options(vec!["rbind".to_string()])
+            .build()
+            .unwrap();
+        assert!(is_bind(&m3));
+
+        // Negative check
+        let m4 = MountBuilder::default().typ("tmpfs").build().unwrap();
+        assert!(!is_bind(&m4));
     }
 }


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of your changes -->

## Type of Change
<!-- Mark the appropriate option with an [x] -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test updates
- [ ] CI/CD related changes
- [ ] Other (please describe):

## Testing
<!-- Describe the tests you ran and/or added to verify your changes -->
- [x] Added new unit tests
- [ ] Added new integration tests
- [ ] Ran existing test suite
- [x] Tested manually (please provide steps)

## Related Issues
<!-- Link any related issues using the GitHub issue syntax: #issue-number
If there is no open issue for this, please add details of the problem or open a new issue. -->
Fixes #3603

## Additional Context
<!-- Add any other context about the pull request here -->

```bash
{
  "destination": "/dummy.txt",
  "type": "none",
  "options": [
    "bind"
  ],
  "source": "/tmp/dummy.txt"
}

sudo ./youki-new run -b . test-container
/ # success

{
  "destination": "/dummy.txt",
  "options": [
    "rbind"
  ],
  "source": "/tmp/dummy.txt"
}

sudo ./youki-new run -b . test-container
/ # success

# backward compatibility
{
  "destination": "/dummy.txt",
  "type": "bind",
  "source": "/tmp/dummy.txt"
}

sudo ./youki-new run -b . test-container
/ # success
```
