### PR TITLE
test(contest): add cgroup v2 CPU update tests

### DIFF
--- a/tests/contest/contest/src/tests/update/common.rs
+++ b/tests/contest/contest/src/tests/update/common.rs
@@ -50,6 +50,7 @@ fn create_spec() -> Result<Spec> {
     Ok(spec)
 }
 
+// "update cgroup v1/v2 common limits"
 pub(crate) fn update_common_limits_test() -> TestResult {
     let spec = test_result!(create_spec());
 

--- a/tests/contest/contest/src/tests/update/cpu.rs
+++ b/tests/contest/contest/src/tests/update/cpu.rs
@@ -30,6 +30,7 @@ fn create_spec(cgroup_name: &str, resources: Option<LinuxResources>) -> Result<S
     Ok(spec)
 }
 
+// "cpu burst"
 pub(crate) fn cpu_burst_test() -> TestResult {
     const CGROUP_NAME: &str = "cpu_burst";
     let spec = test_result!(create_spec(CGROUP_NAME, None));
@@ -110,7 +111,7 @@ pub(crate) fn set_cpu_period_without_quota_test() -> TestResult {
     })
 }
 
-// set cpu period with no quota (invalid period)
+// "set cpu period with no quota (invalid period)"
 pub(crate) fn set_cpu_period_without_quota_invalid_test() -> TestResult {
     const CGROUP_NAME: &str = "cpu_period_invalid";
     let cpu = test_result!(
@@ -139,6 +140,7 @@ pub(crate) fn set_cpu_period_without_quota_invalid_test() -> TestResult {
     })
 }
 
+// "set cpu quota with no period"
 pub(crate) fn set_cpu_quota_without_period_test() -> TestResult {
     const CGROUP_NAME: &str = "cpu_quota_no_period";
     let cpu = test_result!(
@@ -178,6 +180,7 @@ pub(crate) fn set_cpu_quota_without_period_test() -> TestResult {
     })
 }
 
+// "update cpu period with no previous period/quota set"
 pub(crate) fn update_cpu_period_without_previous_limits_test() -> TestResult {
     const CGROUP_NAME: &str = "update_cpu_period_without_previous_limits";
     let cpu = test_result!(
@@ -219,6 +222,7 @@ pub(crate) fn update_cpu_period_without_previous_limits_test() -> TestResult {
     })
 }
 
+// "update cpu quota with no previous period/quota set"
 pub(crate) fn update_cpu_quota_without_previous_limits_test() -> TestResult {
     const CGROUP_NAME: &str = "update_cpu_quota_without_previous_limits";
     let cpu = test_result!(
@@ -260,6 +264,7 @@ pub(crate) fn update_cpu_quota_without_previous_limits_test() -> TestResult {
     })
 }
 
+// "update cgroup cpu.idle"
 pub(crate) fn update_cgroup_cpu_idle_test() -> TestResult {
     const CGROUP_NAME: &str = "update_cgroup_cpu_idle";
 
@@ -322,4 +327,11 @@ pub(crate) fn update_cgroup_cpu_idle_test() -> TestResult {
 
         TestResult::Passed
     })
+
+    // Not ported: runc's "update cpu period in a pod cgroup with pod limit set"
+    // requires cgroup v1.
+    //
+    // Not ported: runc's "update cgroup cpu.idle via systemd v252+"
+    // requires the systemd cgroup driver (systemd_v252); contest tests
+    // currently target the cgroupfs driver only.
 }

--- a/tests/contest/contest/src/tests/update/cpu.rs
+++ b/tests/contest/contest/src/tests/update/cpu.rs
@@ -8,7 +8,9 @@ use test_framework::{TestResult, test_result};
 
 use super::{check_cgroup_value, update_container_and_wait};
 use crate::utils::test_utils::check_container_created;
-use crate::utils::{start_container, test_outside_container};
+use crate::utils::{
+    start_container, test_outside_container, update_container, update_container_with_stdin,
+};
 
 fn create_spec(cgroup_name: &str, resources: Option<LinuxResources>) -> Result<Spec> {
     let mut spec = SpecBuilder::default()
@@ -171,6 +173,152 @@ pub(crate) fn set_cpu_quota_without_period_test() -> TestResult {
 
         // cpu period defaults to 100000 (100ms) when not specified
         test_result!(check_cgroup_value(&cgroup_path, "cpu.max", "5000 100000"));
+
+        TestResult::Passed
+    })
+}
+
+pub(crate) fn update_cpu_period_without_previous_limits_test() -> TestResult {
+    const CGROUP_NAME: &str = "update_cpu_period_without_previous_limits";
+    let cpu = test_result!(
+        LinuxCpuBuilder::default()
+            .build()
+            .context("failed to build empty cpu resources")
+    );
+
+    let resources = test_result!(
+        LinuxResourcesBuilder::default()
+            .cpu(cpu)
+            .build()
+            .context("failed to build resources spec")
+    );
+
+    let spec = test_result!(create_spec(CGROUP_NAME, Some(resources)));
+
+    test_outside_container(&spec, &|data| {
+        test_result!(check_container_created(&data));
+
+        let id = &data.id;
+        let dir = &data.bundle;
+
+        let start_result = start_container(id, dir).unwrap().wait().unwrap();
+        if !start_result.success() {
+            return TestResult::Failed(anyhow!("container start failed"));
+        }
+
+        let cgroup_path = Path::new("/sys/fs/cgroup/runtime-test").join(CGROUP_NAME);
+
+        test_result!(update_container_and_wait(
+            id,
+            dir,
+            &["--cpu-period", "50000"]
+        ));
+        test_result!(check_cgroup_value(&cgroup_path, "cpu.max", "max 50000"));
+
+        TestResult::Passed
+    })
+}
+
+pub(crate) fn update_cpu_quota_without_previous_limits_test() -> TestResult {
+    const CGROUP_NAME: &str = "update_cpu_quota_without_previous_limits";
+    let cpu = test_result!(
+        LinuxCpuBuilder::default()
+            .build()
+            .context("failed to build empty cpu resources")
+    );
+
+    let resources = test_result!(
+        LinuxResourcesBuilder::default()
+            .cpu(cpu)
+            .build()
+            .context("failed to build resources spec")
+    );
+
+    let spec = test_result!(create_spec(CGROUP_NAME, Some(resources)));
+
+    test_outside_container(&spec, &|data| {
+        test_result!(check_container_created(&data));
+
+        let id = &data.id;
+        let dir = &data.bundle;
+
+        let start_result = start_container(id, dir).unwrap().wait().unwrap();
+        if !start_result.success() {
+            return TestResult::Failed(anyhow!("container start failed"));
+        }
+
+        let cgroup_path = Path::new("/sys/fs/cgroup/runtime-test").join(CGROUP_NAME);
+
+        test_result!(update_container_and_wait(
+            id,
+            dir,
+            &["--cpu-quota", "30000"]
+        ));
+        test_result!(check_cgroup_value(&cgroup_path, "cpu.max", "30000 100000"));
+
+        TestResult::Passed
+    })
+}
+
+pub(crate) fn update_cgroup_cpu_idle_test() -> TestResult {
+    const CGROUP_NAME: &str = "update_cgroup_cpu_idle";
+
+    let spec = test_result!(create_spec(CGROUP_NAME, None));
+
+    test_outside_container(&spec, &|data| {
+        test_result!(check_container_created(&data));
+
+        let id = &data.id;
+        let dir = &data.bundle;
+
+        let start_result = start_container(id, dir).unwrap().wait().unwrap();
+        if !start_result.success() {
+            return TestResult::Failed(anyhow!("container start failed"));
+        }
+
+        let cgroup_path = Path::new("/sys/fs/cgroup/runtime-test").join(CGROUP_NAME);
+
+        test_result!(check_cgroup_value(&cgroup_path, "cpu.idle", "0"));
+
+        for val in ["1", "0", "1"] {
+            let json =
+                serde_json::json!({"cpu": {"idle": val.parse::<i64>().unwrap()}}).to_string();
+
+            let update_result = update_container_with_stdin(id, dir, &["-r", "-"], &json)
+                .unwrap()
+                .wait()
+                .unwrap();
+            if !update_result.success() {
+                return TestResult::Failed(anyhow!("update --cpu-idle {val} via stdin failed"));
+            }
+            test_result!(check_cgroup_value(&cgroup_path, "cpu.idle", val));
+        }
+
+        for val in ["1", "0", "1"] {
+            test_result!(update_container_and_wait(id, dir, &["--cpu-idle", val]));
+            test_result!(check_cgroup_value(&cgroup_path, "cpu.idle", val));
+        }
+
+        for val in ["-1", "2", "3"] {
+            let update_result = update_container(id, dir, &["--cpu-idle", val])
+                .unwrap()
+                .wait()
+                .unwrap();
+
+            if update_result.success() {
+                return TestResult::Failed(anyhow!(
+                    "expected --cpu-idle {val} to fail, but it succeeded"
+                ));
+            }
+            test_result!(check_cgroup_value(&cgroup_path, "cpu.idle", "1"));
+        }
+
+        test_result!(update_container_and_wait(
+            id,
+            dir,
+            &["--cpu-period", "10000"]
+        ));
+        test_result!(check_cgroup_value(&cgroup_path, "cpu.idle", "1"));
 
         TestResult::Passed
     })

--- a/tests/contest/contest/src/tests/update/mod.rs
+++ b/tests/contest/contest/src/tests/update/mod.rs
@@ -28,6 +28,9 @@ pub(super) fn check_cgroup_value(base: &Path, file: &str, expected: &str) -> any
     Ok(())
 }
 
+/// Runs `update` and waits for it to complete successfully.
+/// Intended for happy-path tests only. Use `update_container` directly
+/// when testing expected failure cases.
 pub(super) fn update_container_and_wait<P: AsRef<Path>>(
     id: &str,
     dir: P,
@@ -90,12 +93,33 @@ pub fn get_update_test() -> TestGroup {
         Box::new(cpu::set_cpu_quota_without_period_test),
     );
 
+    let update_cpu_period_without_previous_limits_test = ConditionalTest::new(
+        "update_cpu_period_without_previous_limits_test",
+        Box::new(can_run_update),
+        Box::new(cpu::update_cpu_period_without_previous_limits_test),
+    );
+
+    let update_cpu_quota_without_previous_limits_test = ConditionalTest::new(
+        "update_cpu_quota_without_previous_limits_test",
+        Box::new(can_run_update),
+        Box::new(cpu::update_cpu_quota_without_previous_limits_test),
+    );
+
+    let update_cgroup_cpu_idle_test = ConditionalTest::new(
+        "update_cgroup_cpu_idle_test",
+        Box::new(can_run_update),
+        Box::new(cpu::update_cgroup_cpu_idle_test),
+    );
+
     test_group.add(vec![
         Box::new(update_cgroup_v2_common_limits_test),
         Box::new(cpu_burst_test),
         Box::new(set_cpu_period_without_quota_test),
         Box::new(set_cpu_period_without_quota_invalid_test),
         Box::new(set_cpu_quota_without_period_test),
+        Box::new(update_cpu_period_without_previous_limits_test),
+        Box::new(update_cpu_quota_without_previous_limits_test),
+        Box::new(update_cgroup_cpu_idle_test),
     ]);
     test_group
 }


### PR DESCRIPTION
This PR adds CPU update integration tests for cgroup v2 in `contest`, as part of #3576.
Ported from runc's `update.bats`, scoped to cgroup v2 + cgroupfs driver only.

## Description

Adds 3 test cases to `tests/contest/contest/src/tests/update/cpu.rs`:

- **update cpu period without previous limits**: verify `cpu.max` becomes `max <period>` when `--cpu-period` is set on a container started with no CPU limits
- **update cpu quota without previous limits**: verify `cpu.max` becomes `<quota> 100000` when `--cpu-quota` is set on a container started with no CPU limits
- **update cgroup cpu.idle**: verify `cpu.idle` is updated correctly via both JSON stdin (`-r -`) and `--cpu-idle` flag; invalid values (`-1`, `2`, `3`) are rejected; unrelated updates (e.g. `--cpu-period`) do not affect `cpu.idle`

Also adds a doc comment to `update_container_and_wait` clarifying it is intended for happy-path tests only.

## Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test updates
- [ ] CI/CD related changes
- [ ] Other (please describe):

## Testing
- [ ] Added new unit tests
- [x] Added new integration tests
- [ ] Ran existing test suite
- [ ] Tested manually (please provide steps)

## Related Issues
#3576

## Additional Context
### Not included in this PR (out of scope):
- update cpu period in a pod cgroup with pod limit set: requires cgroup v1 (`requires cgroups_v1`); 
- update cgroup cpu.idle via systemd v252+: requires the systemd cgroup driver (`systemd_v252`); contest tests currently target the cgroupfs driver only

These were listed in the issue comment but are out of scope for this test. 

### youki version 0.6.0
```
$ sudo RUNTIME_KIND=youki ./scripts/contest.sh target/release/youki update
# Start group update
1 / 8 : cpu_burst_test : skipped
        test cannot run in the current environment (run_all, parallel)
2 / 8 : set_cpu_period_without_quota_invalid_test : ok
3 / 8 : set_cpu_period_without_quota_test : ok
4 / 8 : set_cpu_quota_without_period_test : ok
5 / 8 : update_cgroup_cpu_idle_test : skipped
        test cannot run in the current environment (run_all, parallel)
6 / 8 : update_cgroup_v2_common_limits_test : skipped
        test cannot run in the current environment (run_all, parallel)
7 / 8 : update_cpu_period_without_previous_limits_test : skipped
        test cannot run in the current environment (run_all, parallel)
8 / 8 : update_cpu_quota_without_previous_limits_test : skipped
        test cannot run in the current environment (run_all, parallel)
# End group update

Validation successful for runtime target/release/youki
```

### runc version 1.5.0-rc.2
```
$ sudo RUNTIME_KIND=runc ./scripts/contest.sh runc update
# Start group update
1 / 8 : cpu_burst_test : ok
2 / 8 : set_cpu_period_without_quota_invalid_test : ok
3 / 8 : set_cpu_period_without_quota_test : ok
4 / 8 : set_cpu_quota_without_period_test : ok
5 / 8 : update_cgroup_cpu_idle_test : ok
6 / 8 : update_cgroup_v2_common_limits_test : ok
7 / 8 : update_cpu_period_without_previous_limits_test : ok
8 / 8 : update_cpu_quota_without_previous_limits_test : ok
# End group update

Validation successful for runtime runc
```