### PR TITLE
Support `--link-remap` checkpoint option

### DIFF
--- a/crates/libcontainer/src/container/container.rs
+++ b/crates/libcontainer/src/container/container.rs
@@ -224,6 +224,7 @@ pub struct CheckpointOptions {
     pub tcp_established: bool,
     pub work_path: Option<PathBuf>,
     pub manage_cgroups_mode: rust_criu::CgMode,
+    pub link_remap: bool,
 }
 
 #[cfg(test)]

--- a/crates/libcontainer/src/container/container_checkpoint.rs
+++ b/crates/libcontainer/src/container/container_checkpoint.rs
@@ -169,6 +169,7 @@ impl Container {
                 .unwrap(),
         );
         criu.cgroups_mode(opts.manage_cgroups_mode.clone());
+        criu.set_link_remap(opts.link_remap);
 
         criu.dump().map_err(|err| {
             tracing::error!(?err, id = ?self.id(), logfile = ?opts.image_path.join(CRIU_CHECKPOINT_LOG_FILE), "checkpointing container failed");

--- a/crates/liboci-cli/src/checkpoint.rs
+++ b/crates/liboci-cli/src/checkpoint.rs
@@ -25,9 +25,9 @@ pub struct Checkpoint {
     // TODO: Skip in-flight tcp connections
     // #[arg(long)]
     // pub tcp_skip_in_flight: bool,
-    // TODO: Allow one to link unlinked files back when possible
-    // #[arg(long)]
-    // pub link_remap: bool,
+    /// Allow one to link unlinked files back when possible
+    #[arg(long)]
+    pub link_remap: bool,
     /// Allow external unix sockets
     #[arg(long)]
     pub ext_unix_sk: bool,

--- a/crates/youki/src/commands/checkpoint.rs
+++ b/crates/youki/src/commands/checkpoint.rs
@@ -18,6 +18,7 @@ pub fn checkpoint(args: Checkpoint, root_path: PathBuf) -> Result<()> {
         tcp_established: args.tcp_established,
         work_path: args.work_path,
         manage_cgroups_mode: parse_cgroups_mode(&args.manage_cgroups_mode)?,
+        link_remap: args.link_remap,
     };
     container
         .checkpoint(&opts)

--- a/tests/contest/contest/src/tests/checkpoint_restore/mod.rs
+++ b/tests/contest/contest/src/tests/checkpoint_restore/mod.rs
@@ -1454,6 +1454,103 @@ fn checkpoint_and_restore_and_exec() -> TestResult {
     TestResult::Passed
 }
 
+fn checkpoint_and_restore_with_link_remap() -> TestResult {
+    const MARKER: &str = "link-remap-marker";
+
+    let ctx = match setup_cr_test(|_, spec| {
+        // Mount a writable tmpfs so the unlinked file lives on a filesystem CRIU
+        // can dump (the default rootfs entries are read-only bind mounts).
+        let tmpfs = MountBuilder::default()
+            .typ("tmpfs".to_string())
+            .source("tmpfs")
+            .destination(PathBuf::from("/link-remap"))
+            .options(vec!["rw".to_string()])
+            .build()
+            .unwrap();
+        let mut mounts = spec.mounts().clone().unwrap_or_default();
+        mounts.push(tmpfs);
+        spec.set_mounts(Some(mounts));
+
+        // Init process: write MARKER to a file, hold it open on fd 3, unlink it,
+        // then run the same ping loop the other tests rely on. fd 3 keeps the
+        // unlinked file alive across checkpoint/restore.
+        let mut process = spec.process().clone().unwrap_or_default();
+        process.set_args(Some(vec![
+            "sh".into(),
+            "-c".into(),
+            format!(
+                "echo -n {MARKER} > /link-remap/data; exec 3< /link-remap/data; unlink /link-remap/data; \
+                 while true; do read p < /fifo; if [ \"$p\" = 'Ping' ]; then echo \"ponG $p\" > /fifo; fi; done"
+            ),
+        ]));
+        spec.set_process(Some(process));
+    }) {
+        Ok(c) => c,
+        Err(e) => return e,
+    };
+    if let Err(e) = ctx.start() {
+        return e;
+    }
+
+    let id = &ctx.id;
+    let bundle = &ctx.bundle;
+    let image_dir = &ctx.image_dir;
+    let work_dir = &ctx.work_dir;
+
+    if let Err(e) = checkpoint_container(
+        bundle.path(),
+        id,
+        image_dir,
+        Some(work_dir),
+        &["--link-remap"],
+        &[],
+    ) {
+        return TestResult::Failed(anyhow!("checkpoint with --link-remap failed: {e}"));
+    }
+
+    if let Err(e) = wait_for_state(
+        id,
+        bundle,
+        WaitTarget::Deleted,
+        Duration::from_secs(5),
+        Duration::from_millis(100),
+    ) {
+        return TestResult::Failed(anyhow!(
+            "container state still accessible after checkpoint: {e}"
+        ));
+    }
+
+    if let Err(e) = restore_container(bundle.path(), id, image_dir, Some(work_dir), &[], &[]) {
+        return TestResult::Failed(anyhow!("restore failed: {e}"));
+    }
+
+    if let Err(e) = wait_for_state(
+        id,
+        bundle,
+        WaitTarget::Status(LifecycleStatus::Running),
+        Duration::from_secs(10),
+        Duration::from_millis(100),
+    ) {
+        return TestResult::Failed(anyhow!("not running after restore: {e}"));
+    }
+
+    if let Err(e) = ping_container(bundle.path()) {
+        return TestResult::Failed(anyhow!("ping container failed after restore: {e}"));
+    }
+
+    // The unlinked file must have been linked back by CRIU on restore: its content,
+    // still held open on fd 3 by the init process, should match the original marker.
+    match exec_container(id, bundle.path(), &["cat", "/proc/1/fd/3"], None, &[]) {
+        Ok((stdout, _)) if stdout == MARKER => TestResult::Passed,
+        Ok((stdout, _)) => TestResult::Failed(anyhow!(
+            "restored unlinked file content mismatch: expected {MARKER:?}, got {stdout:?}"
+        )),
+        Err(e) => TestResult::Failed(anyhow!(
+            "failed to read restored unlinked file via /proc/1/fd/3: {e}"
+        )),
+    }
+}
+
 pub fn get_checkpoint_restore_tests() -> TestGroup {
     let mut tg = TestGroup::new("checkpoint_restore");
     // Run sequentially: CRIU uses global kernel resources and parallel
@@ -1517,6 +1614,10 @@ pub fn get_checkpoint_restore_tests() -> TestGroup {
     tg.add(vec![Box::new(cr_test!(
         "checkpoint_and_restore_and_exec",
         checkpoint_and_restore_and_exec
+    ))]);
+    tg.add(vec![Box::new(cr_test!(
+        "checkpoint_and_restore_with_link_remap",
+        checkpoint_and_restore_with_link_remap
     ))]);
 
     tg

--- a/tests/contest/contest/src/tests/checkpoint_restore/mod.rs
+++ b/tests/contest/contest/src/tests/checkpoint_restore/mod.rs
@@ -1454,106 +1454,6 @@ fn checkpoint_and_restore_and_exec() -> TestResult {
     TestResult::Passed
 }
 
-fn checkpoint_and_restore_with_link_remap() -> TestResult {
-    const MARKER: &str = "link-remap-marker";
-
-    let ctx = match setup_cr_test(|_, spec| {
-        // Mount a writable tmpfs so the unlinked file lives on a filesystem CRIU
-        // can dump (the default rootfs entries are read-only bind mounts).
-        let tmpfs = MountBuilder::default()
-            .typ("tmpfs".to_string())
-            .source("tmpfs")
-            .destination(PathBuf::from("/link-remap"))
-            .options(vec!["rw".to_string()])
-            .build()
-            .unwrap();
-        let mut mounts = spec.mounts().clone().unwrap_or_default();
-        mounts.push(tmpfs);
-        spec.set_mounts(Some(mounts));
-
-        // Init process: write MARKER to a file, add a second hard link (keep), hold the
-        // original open on fd 3, then unlink only the opened name. fd 3 now points to an
-        // unlinked-but-open file whose inode is still reachable via `keep`, which is the
-        // "invisible file" case that requires --link-remap. See:
-        // https://criu.org/Invisible_files
-        let mut process = spec.process().clone().unwrap_or_default();
-        process.set_args(Some(vec![
-            "sh".into(),
-            "-c".into(),
-            format!(
-                "echo -n {MARKER} > /link-remap/data; ln /link-remap/data /link-remap/keep; \
-                 exec 3< /link-remap/data; unlink /link-remap/data; \
-                 while true; do read p < /fifo; if [ \"$p\" = 'Ping' ]; then echo \"ponG $p\" > /fifo; fi; done"
-            ),
-        ]));
-        spec.set_process(Some(process));
-    }) {
-        Ok(c) => c,
-        Err(e) => return e,
-    };
-    if let Err(e) = ctx.start() {
-        return e;
-    }
-
-    let id = &ctx.id;
-    let bundle = &ctx.bundle;
-    let image_dir = &ctx.image_dir;
-    let work_dir = &ctx.work_dir;
-
-    if let Err(e) = checkpoint_container(
-        bundle.path(),
-        id,
-        image_dir,
-        Some(work_dir),
-        &["--link-remap"],
-        &[],
-    ) {
-        return TestResult::Failed(anyhow!("checkpoint with --link-remap failed: {e}"));
-    }
-
-    if let Err(e) = wait_for_state(
-        id,
-        bundle,
-        WaitTarget::Deleted,
-        Duration::from_secs(5),
-        Duration::from_millis(100),
-    ) {
-        return TestResult::Failed(anyhow!(
-            "container state still accessible after checkpoint: {e}"
-        ));
-    }
-
-    if let Err(e) = restore_container(bundle.path(), id, image_dir, Some(work_dir), &[], &[]) {
-        return TestResult::Failed(anyhow!("restore failed: {e}"));
-    }
-
-    if let Err(e) = wait_for_state(
-        id,
-        bundle,
-        WaitTarget::Status(LifecycleStatus::Running),
-        Duration::from_secs(10),
-        Duration::from_millis(100),
-    ) {
-        return TestResult::Failed(anyhow!("not running after restore: {e}"));
-    }
-
-    if let Err(e) = ping_container(bundle.path()) {
-        return TestResult::Failed(anyhow!("ping container failed after restore: {e}"));
-    }
-
-    // The unlinked file must have been linked back by CRIU on restore: its content,
-    // still held open on fd 3 by the init process, should match the original marker.
-    match exec_container(id, bundle.path(), &["cat", "/proc/1/fd/3"], None, &[]) {
-        Ok((stdout, _)) if stdout == MARKER => TestResult::Passed,
-        Ok((stdout, _)) => TestResult::Failed(anyhow!(
-            "restored unlinked file content mismatch: expected {MARKER:?}, got {stdout:?}"
-        )),
-        Err(e) => TestResult::Failed(anyhow!(
-            "failed to read restored unlinked file via /proc/1/fd/3: {e}"
-        )),
-    }
-}
-
 pub fn get_checkpoint_restore_tests() -> TestGroup {
     let mut tg = TestGroup::new("checkpoint_restore");
     // Run sequentially: CRIU uses global kernel resources and parallel
@@ -1618,10 +1518,5 @@ pub fn get_checkpoint_restore_tests() -> TestGroup {
         "checkpoint_and_restore_and_exec",
         checkpoint_and_restore_and_exec
     ))]);
-    tg.add(vec![Box::new(cr_test!(
-        "checkpoint_and_restore_with_link_remap",
-        checkpoint_and_restore_with_link_remap
-    ))]);
-
     tg
 }

--- a/tests/contest/contest/src/tests/checkpoint_restore/mod.rs
+++ b/tests/contest/contest/src/tests/checkpoint_restore/mod.rs
@@ -1471,15 +1471,18 @@ fn checkpoint_and_restore_with_link_remap() -> TestResult {
         mounts.push(tmpfs);
         spec.set_mounts(Some(mounts));
 
-        // Init process: write MARKER to a file, hold it open on fd 3, unlink it,
-        // then run the same ping loop the other tests rely on. fd 3 keeps the
-        // unlinked file alive across checkpoint/restore.
+        // Init process: write MARKER to a file, add a second hard link (keep), hold the
+        // original open on fd 3, then unlink only the opened name. fd 3 now points to an
+        // unlinked-but-open file whose inode is still reachable via `keep`, which is the
+        // "invisible file" case that requires --link-remap. See:
+        // https://criu.org/Invisible_files
         let mut process = spec.process().clone().unwrap_or_default();
         process.set_args(Some(vec![
             "sh".into(),
             "-c".into(),
             format!(
-                "echo -n {MARKER} > /link-remap/data; exec 3< /link-remap/data; unlink /link-remap/data; \
+                "echo -n {MARKER} > /link-remap/data; ln /link-remap/data /link-remap/keep; \
+                 exec 3< /link-remap/data; unlink /link-remap/data; \
                  while true; do read p < /fifo; if [ \"$p\" = 'Ping' ]; then echo \"ponG $p\" > /fifo; fi; done"
             ),
         ]));

--- a/tests/contest/contest/src/tests/checkpoint_restore/mod.rs
+++ b/tests/contest/contest/src/tests/checkpoint_restore/mod.rs
@@ -1454,6 +1454,106 @@ fn checkpoint_and_restore_and_exec() -> TestResult {
     TestResult::Passed
 }
 
+fn checkpoint_and_restore_with_link_remap() -> TestResult {
+    const MARKER: &str = "link-remap-marker";
+
+    let ctx = match setup_cr_test(|_, spec| {
+        // Mount a writable tmpfs so the unlinked file lives on a filesystem CRIU
+        // can dump (the default rootfs entries are read-only bind mounts).
+        let tmpfs = MountBuilder::default()
+            .typ("tmpfs".to_string())
+            .source("tmpfs")
+            .destination(PathBuf::from("/link-remap"))
+            .options(vec!["rw".to_string()])
+            .build()
+            .unwrap();
+        let mut mounts = spec.mounts().clone().unwrap_or_default();
+        mounts.push(tmpfs);
+        spec.set_mounts(Some(mounts));
+
+        // Init process: write MARKER to a file, add a second hard link (keep), hold the
+        // original open on fd 3, then unlink only the opened name. fd 3 now points to an
+        // unlinked-but-open file whose inode is still reachable via `keep`, which is the
+        // "invisible file" case that requires --link-remap. See:
+        // https://criu.org/Invisible_files
+        let mut process = spec.process().clone().unwrap_or_default();
+        process.set_args(Some(vec![
+            "sh".into(),
+            "-c".into(),
+            format!(
+                "echo -n {MARKER} > /link-remap/data; ln /link-remap/data /link-remap/keep; \
+                 exec 3< /link-remap/data; unlink /link-remap/data; \
+                 while true; do read p < /fifo; if [ \"$p\" = 'Ping' ]; then echo \"ponG $p\" > /fifo; fi; done"
+            ),
+        ]));
+        spec.set_process(Some(process));
+    }) {
+        Ok(c) => c,
+        Err(e) => return e,
+    };
+    if let Err(e) = ctx.start() {
+        return e;
+    }
+
+    let id = &ctx.id;
+    let bundle = &ctx.bundle;
+    let image_dir = &ctx.image_dir;
+    let work_dir = &ctx.work_dir;
+
+    if let Err(e) = checkpoint_container(
+        bundle.path(),
+        id,
+        image_dir,
+        Some(work_dir),
+        &["--link-remap"],
+        &[],
+    ) {
+        return TestResult::Failed(anyhow!("checkpoint with --link-remap failed: {e}"));
+    }
+
+    if let Err(e) = wait_for_state(
+        id,
+        bundle,
+        WaitTarget::Deleted,
+        Duration::from_secs(5),
+        Duration::from_millis(100),
+    ) {
+        return TestResult::Failed(anyhow!(
+            "container state still accessible after checkpoint: {e}"
+        ));
+    }
+
+    if let Err(e) = restore_container(bundle.path(), id, image_dir, Some(work_dir), &[], &[]) {
+        return TestResult::Failed(anyhow!("restore failed: {e}"));
+    }
+
+    if let Err(e) = wait_for_state(
+        id,
+        bundle,
+        WaitTarget::Status(LifecycleStatus::Running),
+        Duration::from_secs(10),
+        Duration::from_millis(100),
+    ) {
+        return TestResult::Failed(anyhow!("not running after restore: {e}"));
+    }
+
+    if let Err(e) = ping_container(bundle.path()) {
+        return TestResult::Failed(anyhow!("ping container failed after restore: {e}"));
+    }
+
+    // The unlinked file must have been linked back by CRIU on restore: its content,
+    // still held open on fd 3 by the init process, should match the original marker.
+    match exec_container(id, bundle.path(), &["cat", "/proc/1/fd/3"], None, &[]) {
+        Ok((stdout, _)) if stdout == MARKER => TestResult::Passed,
+        Ok((stdout, _)) => TestResult::Failed(anyhow!(
+            "restored unlinked file content mismatch: expected {MARKER:?}, got {stdout:?}"
+        )),
+        Err(e) => TestResult::Failed(anyhow!(
+            "failed to read restored unlinked file via /proc/1/fd/3: {e}"
+        )),
+    }
+}
+
 pub fn get_checkpoint_restore_tests() -> TestGroup {
     let mut tg = TestGroup::new("checkpoint_restore");
     // Run sequentially: CRIU uses global kernel resources and parallel
@@ -1517,6 +1617,10 @@ pub fn get_checkpoint_restore_tests() -> TestGroup {
     tg.add(vec![Box::new(cr_test!(
         "checkpoint_and_restore_and_exec",
         checkpoint_and_restore_and_exec
+    ))]);
+    tg.add(vec![Box::new(cr_test!(
+        "checkpoint_and_restore_with_link_remap",
+        checkpoint_and_restore_with_link_remap
     ))]);
     tg
 }

--- a/tests/contest/contest/src/tests/lifecycle/checkpoint.rs
+++ b/tests/contest/contest/src/tests/lifecycle/checkpoint.rs
@@ -411,6 +411,23 @@ pub fn checkpoint_link_remap() -> TestResult {
     };
 
     let result = checkpoint(bundle_path, &id, &image_path, vec!["--link-remap"], None);
+    if let TestResult::Failed(_) = &result {
+        cleanup();
+        return result;
+    }
+
+    // youki cannot restore, so instead verify CRIU recorded the link-remap into
+    // the image: dumping the open-but-unlinked file with --link-remap creates
+    // remap-fpath.img (a remap entry with the `linked` flag set).
+    let remap_img = image_path.join("remap-fpath.img");
+    let result = if remap_img.exists() {
+        TestResult::Passed
+    } else {
+        TestResult::Failed(anyhow!(
+            "expected remap-fpath.img to be created in the checkpoint image with --link-remap, \
+             but it is missing at {remap_img:?}"
+        ))
+    };
 
     cleanup();
     result

--- a/tests/contest/contest/src/tests/lifecycle/checkpoint.rs
+++ b/tests/contest/contest/src/tests/lifecycle/checkpoint.rs
@@ -1,12 +1,15 @@
 use std::path::Path;
 use std::process::{Command, Stdio};
 
-use anyhow::anyhow;
+use anyhow::{Result, anyhow};
+use oci_spec::runtime::{MountBuilder, Spec};
 use test_framework::TestResult;
 
-use super::get_result_from_output;
-use crate::utils::get_runtime_path;
-use crate::utils::test_utils::State;
+use super::{create, get_result_from_output, start};
+use crate::utils::{
+    State, delete_container, generate_uuid, get_runtime_path, kill_container, prepare_bundle,
+    set_config, wait_container_running,
+};
 
 // Simple function to figure out the PID of the first container process
 fn get_container_pid(project_path: &Path, id: &str) -> Result<i32, TestResult> {
@@ -326,4 +329,89 @@ pub fn checkpoint_manage_cgroups_mode_soft(project_path: &Path, id: &str) -> Tes
     }
 
     TestResult::Passed
+}
+
+// Builds a spec whose init holds an "invisible file" (open-but-unlinked with a
+// surviving hard link), which CRIU can only dump with `--link-remap`.
+// See https://criu.org/Invisible_files.
+fn link_remap_spec() -> Result<Spec, TestResult> {
+    let mut spec = Spec::default();
+
+    let mut process = spec.process().clone().unwrap_or_default();
+    process.set_args(Some(vec![
+        "sh".to_string(),
+        "-c".to_string(),
+        "echo -n link-remap-marker > /work/data; ln /work/data /work/keep; \
+         exec 3< /work/data; unlink /work/data; while true; do sleep 1; done"
+            .to_string(),
+    ]));
+    spec.set_process(Some(process));
+
+    let tmpfs = MountBuilder::default()
+        .typ("tmpfs".to_string())
+        .source("tmpfs")
+        .destination(std::path::PathBuf::from("/work"))
+        .options(vec!["rw".to_string(), "nosuid".to_string()])
+        .build()
+        .map_err(|e| TestResult::Failed(anyhow!("failed to build tmpfs mount: {e}")))?;
+    let mut mounts = spec.mounts().clone().unwrap_or_default();
+    mounts.push(tmpfs);
+    spec.set_mounts(Some(mounts));
+
+    Ok(spec)
+}
+
+pub fn checkpoint_link_remap() -> TestResult {
+    let bundle = match prepare_bundle() {
+        Ok(b) => b,
+        Err(e) => return TestResult::Failed(anyhow!("failed to prepare bundle: {e}")),
+    };
+    let id = generate_uuid().to_string();
+
+    let spec = match link_remap_spec() {
+        Ok(s) => s,
+        Err(e) => return e,
+    };
+    if let Err(e) = set_config(&bundle, &spec) {
+        return TestResult::Failed(anyhow!("failed to write config.json: {e}"));
+    }
+
+    let bundle_path = bundle.path();
+
+    let cleanup = || {
+        if let Ok(mut child) = kill_container(&id, bundle_path) {
+            let _ = child.wait();
+        }
+        if let Ok(mut child) = delete_container(&id, bundle_path) {
+            let _ = child.wait();
+        }
+    };
+
+    if let Err(e) = create::create(bundle_path, &id) {
+        cleanup();
+        return TestResult::Failed(anyhow!("create container failed: {e}"));
+    }
+
+    if let Err(e) = start::start(bundle_path, &id) {
+        cleanup();
+        return TestResult::Failed(anyhow!("start container failed: {e}"));
+    }
+
+    if let Err(e) = wait_container_running(&id, bundle_path) {
+        cleanup();
+        return TestResult::Failed(anyhow!("container did not reach running state: {e}"));
+    }
+
+    let (_image_temp_dir, image_path) = match create_checkpoint_image_dir() {
+        Ok(v) => v,
+        Err(e) => {
+            cleanup();
+            return e;
+        }
+    };
+
+    let result = checkpoint(bundle_path, &id, &image_path, vec!["--link-remap"], None);
+
+    cleanup();
+    result
 }

--- a/tests/contest/contest/src/tests/lifecycle/container_lifecycle.rs
+++ b/tests/contest/contest/src/tests/lifecycle/container_lifecycle.rs
@@ -129,6 +129,14 @@ impl ContainerLifecycle {
         )
     }
 
+    pub fn checkpoint_link_remap(&self) -> TestResult {
+        if !criu_installed() {
+            return TestResult::Skipped("CRIU is not installed".to_string());
+        }
+
+        checkpoint::checkpoint_link_remap()
+    }
+
     /// Wait for the container to reach a specific state
     pub fn wait_for_state(&self, expected_state: &str, timeout: Duration) -> TestResult {
         use crate::tests::lifecycle::state;
@@ -180,6 +188,7 @@ impl TestableGroup for ContainerLifecycle {
                 "checkpoint with cgroups-mode soft",
                 self.checkpoint_manage_cgroups_mode_soft(),
             ),
+            ("checkpoint with link-remap", self.checkpoint_link_remap()),
             ("kill", self.kill()),
             ("state", self.state()),
             ("delete", self.delete()),
@@ -208,6 +217,9 @@ impl TestableGroup for ContainerLifecycle {
                     "checkpoint with cgroups-mode soft",
                     self.checkpoint_manage_cgroups_mode_soft(),
                 )),
+                "checkpoint_link_remap" => {
+                    ret.push(("checkpoint with link-remap", self.checkpoint_link_remap()))
+                }
                 "kill" => ret.push(("kill", self.kill())),
                 "state" => ret.push(("state", self.state())),
                 "delete" => ret.push(("delete", self.delete())),


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of your changes -->

Pass `--link-remap` from the CLI to CRIU so files unlinked while still open are linked back on restore.

## Type of Change
<!-- Mark the appropriate option with an [x] -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test updates
- [ ] CI/CD related changes
- [ ] Other (please describe):

## Testing
<!-- Describe the tests you ran and/or added to verify your changes -->
- [ ] Added new unit tests
- [x] Added new integration tests
- [ ] Ran existing test suite
- [ ] Tested manually (please provide steps)

## Related Issues
<!-- Link any related issues using the GitHub issue syntax: #issue-number
If there is no open issue for this, please add details of the problem or open a new issue. -->

https://github.com/youki-dev/youki/issues/3394

## Additional Context
<!-- Add any other context about the pull request here -->

link-remap: https://criu.org/Invisible_files
runc checkpoint: https://github.com/opencontainers/runc/blob/bc60126ec19f1987ff8e132776342521ee6fd09f/man/runc-checkpoint.8.md
rust-criu impl: https://github.com/checkpoint-restore/rust-criu/pull/52