### PR TITLE
fix(libcontainer): scope pivot_root rslave to the old root only

### DIFF
--- a/crates/libcontainer/src/syscall/linux.rs
+++ b/crates/libcontainer/src/syscall/linux.rs
@@ -18,7 +18,7 @@ use nix::fcntl::{OFlag, open};
 use nix::mount::{MntFlags, MsFlags, mount, umount2};
 use nix::sched::{CloneFlags, unshare};
 use nix::sys::stat::{Mode, SFlag, mknod};
-use nix::unistd::{Gid, Uid, chown, chroot, close, fchdir, pivot_root, sethostname};
+use nix::unistd::{Gid, Uid, chdir, chown, chroot, fchdir, pivot_root, sethostname};
 use oci_spec::runtime::PosixRlimit;
 use pathrs::flags::OpenFlags;
 use pathrs::procfs::{ProcfsBase, ProcfsHandle};
@@ -378,14 +378,36 @@ impl Syscall for LinuxSyscall {
 
     /// Function to set given path as root path inside process
     fn pivot_rootfs(&self, path: &Path) -> Result<()> {
-        // open the path as directory and read only
-        let newroot = open(
-            path,
-            OFlag::O_DIRECTORY | OFlag::O_RDONLY | OFlag::O_CLOEXEC,
-            Mode::empty(),
-        )
-        .inspect_err(|errno| {
-            tracing::error!(?errno, ?path, "failed to open the new root for pivot root");
+        // open oldroot as directory
+        let oldroot = unsafe {
+            OwnedFd::from_raw_fd(
+                open(
+                    "/",
+                    OFlag::O_DIRECTORY | OFlag::O_PATH | OFlag::O_CLOEXEC,
+                    Mode::empty(),
+                )
+                .inspect_err(|errno| {
+                    tracing::error!(?errno, ?path, "failed to open the old root for pivot root");
+                })?,
+            )
+        };
+
+        // open newroot as directory
+        let newroot = unsafe {
+            OwnedFd::from_raw_fd(
+                open(
+                    path,
+                    OFlag::O_DIRECTORY | OFlag::O_PATH | OFlag::O_CLOEXEC,
+                    Mode::empty(),
+                )
+                .inspect_err(|errno| {
+                    tracing::error!(?errno, ?path, "failed to open the new root for pivot root");
+                })?,
+            )
+        };
+
+        fchdir(newroot.as_raw_fd()).inspect_err(|errno| {
+            tracing::error!(?errno, ?newroot, "failed to fchdir to new root");
         })?;
 
         // make the given path as the root directory for the container
@@ -396,15 +418,23 @@ impl Syscall for LinuxSyscall {
         // this path. This is done, as otherwise, we will need to create a separate temporary directory under the new root path
         // so we can move the original root there, and then unmount that. This way saves the creation of the temporary
         // directory to put original root directory.
-        pivot_root(path, path).inspect_err(|errno| {
+        pivot_root(".", ".").inspect_err(|errno| {
             tracing::error!(?errno, ?path, "failed to pivot root to");
+        })?;
+
+        // Currently our "." is oldroot (according to the current kernel code).
+        // However, purely for safety, we will fchdir(oldroot) since there isn't
+        // really any guarantee from the kernel what /proc/self/cwd will be after a
+        // pivot_root(2).
+        fchdir(oldroot.as_raw_fd()).inspect_err(|errno| {
+            tracing::error!(?errno, ?oldroot, "failed to fchdir to old root");
         })?;
 
         // Make the original root directory rslave to avoid propagating unmount event to the host mount namespace.
         // We should use MS_SLAVE not MS_PRIVATE according to https://github.com/opencontainers/runc/pull/1500.
         mount(
             None::<&str>,
-            "/",
+            ".",
             None::<&str>,
             MsFlags::MS_SLAVE | MsFlags::MS_REC,
             None::<&str>,
@@ -417,16 +447,12 @@ impl Syscall for LinuxSyscall {
         // MNT_DETACH makes the mount point unavailable to new accesses, but waits till the original mount point
         // to be free of activity to actually unmount
         // see https://man7.org/linux/man-pages/man2/umount2.2.html for more information
-        umount2("/", MntFlags::MNT_DETACH).inspect_err(|errno| {
+        umount2(".", MntFlags::MNT_DETACH).inspect_err(|errno| {
             tracing::error!(?errno, "failed to unmount old root directory");
         })?;
         // Change directory to the new root
-        fchdir(newroot).inspect_err(|errno| {
-            tracing::error!(?errno, ?newroot, "failed to change directory to new root");
-        })?;
-
-        close(newroot).inspect_err(|errno| {
-            tracing::error!(?errno, ?newroot, "failed to close new root directory");
+        chdir("/").inspect_err(|errno| {
+            tracing::error!(?errno, "failed to change directory to new root");
         })?;
 
         Ok(())


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of your changes -->

This PR fixes the mount propagation handling in `pivot_rootfs`.

In `pivot_rootfs`, after `pivot_root` is executed, the old root should be made `rslave`. However, the previous implementation made the new root, i.e. `/`, `rslave` instead.

Making the new root `rslave` can affect the mount propagation settings that were configured before `pivot_rootfs`.

This PR changes the logic so that the old root is correctly made `rslave` after `pivot_root`.

This fix is based on the `pivotRoot` implementation in runc.

https://github.com/opencontainers/runc/blob/1aff3ed358ea555c22ad75cc8f085c025f048b48/libcontainer/rootfs_linux.go#L1146

## Type of Change
<!-- Mark the appropriate option with an [x] -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test updates
- [ ] CI/CD related changes
- [ ] Other (please describe):

## Testing
<!-- Describe the tests you ran and/or added to verify your changes -->
- [ ] Added new unit tests
- [ ] Added new integration tests
- [x] Ran existing test suite
- [ ] Tested manually (please provide steps)

## Related Issues
<!-- Link any related issues using the GitHub issue syntax: #issue-number
If there is no open issue for this, please add details of the problem or open a new issue. -->


## Additional Context
<!-- Add any other context about the pull request here -->
