### PR TITLE
fix(libcgroups): `pids-limit` is set to 0, change it to 1

### DIFF
--- a/crates/libcgroups/src/v2/pids.rs
+++ b/crates/libcgroups/src/v2/pids.rs
@@ -34,6 +34,7 @@ impl StatsProvider for Pids {
 
 impl Pids {
     fn apply(root_path: &Path, pids: &LinuxPids) -> Result<(), WrappedIoError> {
+        // follow runc's behavior of mapping 0 to 1 due to systemd limitations
         let limit = match pids.limit() {
             0 => "1".to_string(),
             1.. => pids.limit().to_string(),

--- a/crates/libcgroups/src/v2/pids.rs
+++ b/crates/libcgroups/src/v2/pids.rs
@@ -34,11 +34,12 @@ impl StatsProvider for Pids {
 
 impl Pids {
     fn apply(root_path: &Path, pids: &LinuxPids) -> Result<(), WrappedIoError> {
-        let limit = if pids.limit() > 0 {
-            pids.limit().to_string()
-        } else {
-            "max".to_string()
+        let limit = match pids.limit() {
+            0 => "1".to_string(),
+            1.. => pids.limit().to_string(),
+            _ => "max".to_string(),
         };
+
         common::write_cgroup_file(root_path.join("pids.max"), limit)
     }
 }
@@ -65,7 +66,7 @@ mod tests {
     }
 
     #[test]
-    fn test_set_pids_max() {
+    fn test_set_pids_zero() {
         let pids_file_name = "pids.max";
         let tmp = tempfile::tempdir().unwrap();
         set_fixture(tmp.path(), pids_file_name, "0").expect("set fixture for 0 pids");
@@ -74,6 +75,20 @@ mod tests {
 
         Pids::apply(tmp.path(), &pids).expect("apply pids");
 
+        let content =
+            std::fs::read_to_string(tmp.path().join(pids_file_name)).expect("Read pids contents");
+        assert_eq!("1".to_string(), content);
+    }
+
+    #[test]
+    fn test_set_pids_max() {
+        let pids_file_name = "pids.max";
+        let tmp = tempfile::tempdir().unwrap();
+        set_fixture(tmp.path(), pids_file_name, "-1").expect("set fixture for -1 pids");
+
+        let pids = LinuxPidsBuilder::default().limit(-1).build().unwrap();
+
+        Pids::apply(tmp.path(), &pids).expect("apply pids");
         let content =
             std::fs::read_to_string(tmp.path().join(pids_file_name)).expect("Read pids contents");
         assert_eq!("max".to_string(), content);


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of your changes -->
When `0` is specified with the `--pids-limit` option in cgroup v2, it is now mapped to `1`.
Accordingly, unit tests for the value 0 have been added.

As a result, the behavior of `youki update --pids-limit 0` now matches that of runc.

| `--pids-limit` | youki | runc | Result |
| --- | --- | --- | --- |
| `12345` | `12345` | `12345` | same |
| `-1` | **error** | `max` | **different** |
| `0` | ~`max`~ →`1` | `1` | ~different~ → same |

## Type of Change
<!-- Mark the appropriate option with an [x] -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test updates
- [ ] CI/CD related changes
- [ ] Other (please describe):

## Testing
<!-- Describe the tests you ran and/or added to verify your changes -->
- [x] Added new unit tests
- [ ] Added new integration tests
- [ ] Ran existing test suite
- [ ] Tested manually (please provide steps)

## Related Issues
<!-- Link any related issues using the GitHub issue syntax: #issue-number
If there is no open issue for this, please add details of the problem or open a new issue. -->
#3594 

## Additional Context
<!-- Add any other context about the pull request here -->

In the unit tests, all three tests—including the newly added one—have passed.
```
$ cargo test -p libcgroups --lib v2::pids::tests
running 3 tests
test v2::pids::tests::test_set_pids_max ... ok
test v2::pids::tests::test_set_pids_zero ... ok
test v2::pids::tests::test_set_pids ... ok
```

I confirmed that when I set `pids.limit=20` in `config.json`, created a container, and then set it to 0 using `update`, it behaved the same way as `runc`.
```
$ sudo youki create runtime-test
$ cat /sys/fs/cgroup/runtime-test/update_common_limits/pids.max
20
$ sudo youki update --pids-limit 0 runtime-test
$ cat /sys/fs/cgroup/runtime-test/update_common_limits/pids.max
1

$ sudo runc create runtime-test
$ cat /sys/fs/cgroup/runtime-test/update_common_limits/pids.max
20
$ sudo runc update --pids-limit 0 runtime-test
$ cat /sys/fs/cgroup/runtime-test/update_common_limits/pids.max
1
```

However, when I set `pids.limit=0` in `config.json` and created a container, the behavior differed from that of `runc`.
While `runc` creates the container by rewriting `pids.max=1`, `youki` fails to create the container.
**Since it appears that `container_intermediate_process` and similar components are involved, I am temporarily setting aside this issue for now.**
```
$ sudo runc create runtime-test
$ cat /sys/fs/cgroup/runtime-test/update_common_limits/pids.max
1

$ sudo ../youki create runtime-test
ERROR libcontainer::process::container_intermediate_process: failed to fork init process: failed to clone process
ERROR libcontainer::process::container_main_process: failed to run intermediate process failed to launch init process
ERROR libcontainer::container::builder_impl: failed to run container process intermediate process error failed to launch init process
ERROR youki: error in executing command: failed to create container: intermediate process error failed to launch init process
Error: failed to create container: intermediate process error failed to launch init process 
```