### PR TITLE
test(contest): extract detached console-socket run into a shared helper

### DIFF
--- a/tests/contest/contest/src/tests/checkpoint_restore/mod.rs
+++ b/tests/contest/contest/src/tests/checkpoint_restore/mod.rs
@@ -19,9 +19,9 @@ use test_framework::{ConditionalTest, TestGroup, TestResult};
 use crate::utils::{
     LifecycleStatus, WaitTarget, build_checkpoint_command, checkpoint_container, criu_has_feature,
     criu_installed, delete_container, exec_container, generate_uuid, get_container_pid,
-    get_runtime_path, handle_console_socket, is_runtime_youki, kill_container, net, prepare_bundle,
-    restore_container, set_config, try_checkpoint_container, wait_container_running,
-    wait_for_state,
+    get_runtime_path, is_runtime_youki, kill_container, net, prepare_bundle, restore_container,
+    run_container_detached_with_console, set_config, try_checkpoint_container,
+    wait_container_running, wait_for_state,
 };
 
 /// Used as check_fn for all `ConditionalTests` in this module:
@@ -75,39 +75,9 @@ impl CrTestContext {
         self.restore_id = Some(rid);
     }
 
-    // TODO: Consider extracting this into test_utils.rs as run_container_with_console (see issue #3529)
     fn start(&self) -> Result<(), TestResult> {
-        let runtime_path = get_runtime_path();
-        let actual_bundle_path = self.bundle.path().join("bundle");
-        let console_socket = self.bundle.path().join("console.sock");
-        let listener = std::os::unix::net::UnixListener::bind(&console_socket)
-            .map_err(|e| TestResult::Failed(anyhow!("failed to bind console socket: {e}")))?;
-
         let run_result = (|| -> Result<()> {
-            let mut child = std::process::Command::new(runtime_path)
-                .stdin(Stdio::null())
-                .stdout(Stdio::null())
-                .stderr(Stdio::null())
-                .arg("--root")
-                .arg(self.bundle.path().join("runtime"))
-                .arg("run")
-                .arg("-d")
-                .arg("--bundle")
-                .arg(&actual_bundle_path)
-                .arg("--console-socket")
-                .arg(&console_socket)
-                .arg(&self.id)
-                .current_dir(self.bundle.path())
-                .spawn()?;
-
-            let (stream, _) = listener.accept()?;
-            handle_console_socket(stream);
-
-            let status = child.wait()?;
-            if !status.success() {
-                bail!("run -d failed ({status})");
-            }
-
+            run_container_detached_with_console(&self.id, self.bundle.path())?;
             wait_container_running(&self.id, &self.bundle)?;
             ping_container(self.bundle.path())
         })();

--- a/tests/contest/contest/src/utils/mod.rs
+++ b/tests/contest/contest/src/utils/mod.rs
@@ -10,7 +10,7 @@ pub use test_utils::{
     CreateOptions, LifecycleStatus, State, WaitTarget, build_checkpoint_command,
     checkpoint_container, create_container, criu_has_feature, criu_installed, delete_container,
     exec_container, get_container_pid, get_state, handle_console_socket, kill_container,
-    restore_container, start_container, test_inside_container, test_outside_container,
-    try_checkpoint_container, update_container, update_container_with_stdin,
+    restore_container, run_container_detached_with_console, start_container, test_inside_container,
+    test_outside_container, try_checkpoint_container, update_container, update_container_with_stdin,
     wait_container_running, wait_for_state,
 };

--- a/tests/contest/contest/src/utils/test_utils.rs
+++ b/tests/contest/contest/src/utils/test_utils.rs
@@ -565,6 +565,55 @@ pub fn handle_console_socket(stream: std::os::unix::net::UnixStream) {
     });
 }
 
+/// Spawn a container detached (`run -d`) with a console socket.
+///
+/// This is needed whenever a test relies on `terminal: true`, which requires an
+/// active console socket to receive the container's PTY master fd. It binds a
+/// Unix socket at `<bundle>/console.sock`, launches
+/// `--root <bundle>/runtime run -d --console-socket ... <id>` for the bundle at
+/// `<bundle>/bundle`, accepts the console connection, and hands the received fd
+/// to [`handle_console_socket`] so the PTY master stays open. Returns once the
+/// detached `run` process has exited successfully.
+///
+/// Extracted from the checkpoint/restore suite (see issue #3529) so other suites
+/// that need console sockets or detached runs can reuse it. Callers are
+/// responsible for waiting on the container's state afterwards (e.g. with
+/// [`wait_container_running`]).
+pub fn run_container_detached_with_console<P: AsRef<Path>>(id: &str, bundle: P) -> Result<()> {
+    let bundle = bundle.as_ref();
+    let runtime_path = get_runtime_path();
+    let actual_bundle_path = bundle.join("bundle");
+    let console_socket = bundle.join("console.sock");
+    let listener = std::os::unix::net::UnixListener::bind(&console_socket)
+        .with_context(|| format!("failed to bind console socket at {console_socket:?}"))?;
+
+    let mut child = Command::new(runtime_path)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .arg("--root")
+        .arg(bundle.join("runtime"))
+        .arg("run")
+        .arg("-d")
+        .arg("--bundle")
+        .arg(&actual_bundle_path)
+        .arg("--console-socket")
+        .arg(&console_socket)
+        .arg(id)
+        .current_dir(bundle)
+        .spawn()?;
+
+    let (stream, _) = listener.accept()?;
+    handle_console_socket(stream);
+
+    let status = child.wait()?;
+    if !status.success() {
+        bail!("run -d failed ({status})");
+    }
+
+    Ok(())
+}
+
 /// Checkpoint a running container into `image_dir`.
 ///
 /// * `global_args` are passed before the `checkpoint` subcommand (e.g., `&["--debug"]`).


### PR DESCRIPTION
## Description

Extracts the `run -d --console-socket` spawn and PTY-fd handoff logic out of `CrTestContext::start` (in `tests/contest/contest/src/tests/checkpoint_restore/mod.rs`) into a reusable helper `run_container_detached_with_console` in `tests/contest/contest/src/utils/test_utils.rs`.

This was agreed on during the review of #3493 ([comment](https://github.com/youki-dev/youki/pull/3493#discussion_r3179099731)) and deferred to a separate PR. The C/R suite now just calls the helper and keeps only its own follow-up (`wait_container_running` + `ping_container`). Any future suite that needs `terminal: true` containers or detached runs can reuse the helper instead of re-implementing the console-socket dance.

The behavior is unchanged — this is a pure extraction. The one minor difference is that a console-socket bind failure now surfaces through the same "container did not reach running state" error path as the rest of `start`, rather than its own message.

## Type of Change
- [x] Refactoring (no functional changes)
- [x] Test updates

## Testing
- [ ] Added new unit tests
- [ ] Added new integration tests
- [x] Ran existing test suite
- [ ] Tested manually (please provide steps)

The extracted helper is exercised unchanged by the existing checkpoint/restore contest suite (which is skipped unless the runtime is runc and CRIU is installed).

## Related Issues
Closes #3529

## Additional Context
The old inline `// TODO: Consider extracting this into test_utils.rs ... (see issue #3529)` comment on `start` is removed now that it's done.