### PR TITLE
ci: introduce shellcheck for shell scripts

### DIFF
--- a/.github/workflows/shellcheck.yaml
+++ b/.github/workflows/shellcheck.yaml
@@ -1,0 +1,24 @@
+name: 🐚 ShellCheck
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  shellcheck:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run ShellCheck
+        uses: ludeeus/action-shellcheck@2.0.0
+        with:
+          # Start at "warning" so this can be adopted without a large, risky
+          # sweep of the existing scripts. Info/style findings (mostly SC2086
+          # quoting) can be tightened in follow-ups.
+          severity: warning

--- a/hack/set_root_login_for_vagrant.sh
+++ b/hack/set_root_login_for_vagrant.sh
@@ -14,7 +14,7 @@ then
 file="/etc/ssh/sshd_config"
 fi
 
-for PARAM in ${param[@]}
+for PARAM in "${param[@]}"
 do
 /usr/bin/sed -i '/^'"${PARAM}"'/d' ${file}
 /usr/bin/echo "All lines beginning with '${PARAM}' were deleted from ${file}."

--- a/scripts/cargo.sh
+++ b/scripts/cargo.sh
@@ -64,7 +64,8 @@ if [ "$CARGO" == "cross" ]; then
     # we want pid ns of host, because we will be connecting to the host dbus, and it needs task pid from host
     # finally we need to mount the cgroup as read-only, as we need that to check if the tasks are correctly added
     # Note: Mount `-v /etc/passwd:/etc/passwd:ro -v /etc/group:/etc/group:ro` to read the information of the created test user.
-    export CROSS_CONTAINER_OPTS="--privileged --user `id -u`:`id -g` --pid=host -v /sys/fs/cgroup:/sys/fs/cgroup:ro -v /etc/passwd:/etc/passwd:ro -v /etc/group:/etc/group:ro -v /run:/run --mount=type=bind,source=/tmp,destination=/tmp,bind-propagation=shared"
+    CROSS_CONTAINER_OPTS="--privileged --user $(id -u):$(id -g) --pid=host -v /sys/fs/cgroup:/sys/fs/cgroup:ro -v /etc/passwd:/etc/passwd:ro -v /etc/group:/etc/group:ro -v /run:/run --mount=type=bind,source=/tmp,destination=/tmp,bind-propagation=shared"
+    export CROSS_CONTAINER_OPTS
 fi
 
 if [ "$1" == "--print-target-dir" ]; then

--- a/scripts/contest.sh
+++ b/scripts/contest.sh
@@ -40,7 +40,7 @@ else
     ${ROOT}/contest run --runtime "$RUNTIME" --runtimetest "${ROOT}/runtimetest" 2>&1 | tee "$LOGFILE"
 fi
 
-if [ 0 -ne $(grep "not ok" $LOGFILE | wc -l ) ]; then
+if [ 0 -ne "$(grep "not ok" "$LOGFILE" | wc -l)" ]; then
     exit 1
 fi
 

--- a/scripts/oci_integration_tests.sh
+++ b/scripts/oci_integration_tests.sh
@@ -121,9 +121,11 @@ for case in "${test_cases[@]}"; do
   echo "Running $case"
   logfile="./log/$case.log"
   mkdir -p "$(dirname $logfile)"
+  # $logfile lives under a user-owned ./log dir created above, so the shell (not sudo) can write it.
+  # shellcheck disable=SC2024
   sudo RUST_BACKTRACE=1 RUNTIME=${RUNTIME} ${OCI_TEST_DIR}/validation/$case >$logfile 2>&1 || (cat $logfile && exit 1)
-  if [ 0 -ne $(grep "not ok" $logfile | wc -l ) ]; then
-    if [ 0 -eq $(grep "# cgroupv2 is not supported yet " $logfile | wc -l ) ]; then
+  if [ 0 -ne "$(grep "not ok" "$logfile" | wc -l)" ]; then
+    if [ 0 -eq "$(grep "# cgroupv2 is not supported yet " "$logfile" | wc -l)" ]; then
       echo "Skip $case because oci-runtime-tools doesn't support cgroup v2"
       continue;
     fi

--- a/tests/rootless-tests/run.sh
+++ b/tests/rootless-tests/run.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 # This is a temporary test-collection for validating youki runs correctly with podman in rootless mode
 # This will be moved to a proper rust based test crate, similar to rust-integration tests soon
 
@@ -30,15 +31,15 @@ CGROUP_SUB_PATH=$(podman inspect exec-test | jq .[0].State.CgroupPath | tr -d "\
 CGROUP_PATH="/sys/fs/cgroup$CGROUP_SUB_PATH/cgroup.procs"
 
 # assert we have exactly one process in the cgroup
-test $(cat $CGROUP_PATH | wc -l) -eq 1
+test "$(cat "$CGROUP_PATH" | wc -l)" -eq 1
 # assert pid match
-test $(cat $CGROUP_PATH) -eq $(podman inspect exec-test | jq .[0].State.Pid)
+test "$(cat "$CGROUP_PATH")" -eq "$(podman inspect exec-test | jq .[0].State.Pid)"
 
 podman exec -d --runtime $runtime exec-test sleep 5m
 
 # we cannot exactly check the pid of tenant here, instead just check that there are
 # two processes in the same cgroup now
-test $(cat $CGROUP_PATH | wc -l) -eq 2
+test "$(cat "$CGROUP_PATH" | wc -l)" -eq 2
 
 podman kill exec-test
 podman rm --force --ignore exec-test

--- a/tests/runc/runc_integration_test.sh
+++ b/tests/runc/runc_integration_test.sh
@@ -18,7 +18,7 @@ fi
 cp "$RUNTIME" "$RUNC_DIR/runc"
 chmod +x "$RUNC_DIR/runc"
 
-cd "$RUNC_DIR"
+cd "$RUNC_DIR" || exit
 
 sudo make test-binaries
 


### PR DESCRIPTION
## Description

Introduces ShellCheck linting for the repository's shell scripts, as requested in #2064.

- Adds `.github/workflows/shellcheck.yaml`, which runs [`ludeeus/action-shellcheck`](https://github.com/ludeeus/action-shellcheck) on `push`/`pull_request` to `main` (and `workflow_dispatch`).
- Runs at **`warning`** severity so the check can be adopted now without a large, risky sweep of every script. The remaining `info`/`style` findings (mostly `SC2086` quoting) can be tightened in follow-up PRs.
- Fixes the existing **warning-level** findings so the new check is green:

| Code | Fix | File |
|------|-----|------|
| SC2068 | quote `"${param[@]}"` | `hack/set_root_login_for_vagrant.sh` |
| SC2155 | declare/assign `CROSS_CONTAINER_OPTS` separately | `scripts/cargo.sh` |
| SC2046 | quote command substitutions | `scripts/contest.sh`, `scripts/oci_integration_tests.sh`, `tests/rootless-tests/run.sh` |
| SC2148 | add a `bash` shebang | `tests/rootless-tests/run.sh` |
| SC2164 | guard `cd "$RUNC_DIR"` with `|| exit` | `tests/runc/runc_integration_test.sh` |
| SC2024 | scoped `disable` for the intentional user-owned redirect under `sudo` | `scripts/oci_integration_tests.sh` |

All changes are behavior-preserving.

## Type of Change
- [x] CI/CD related changes

## Testing
- [ ] Added new unit tests
- [ ] Added new integration tests
- [x] Ran existing test suite
- [x] Tested manually (please provide steps)

Ran `shellcheck --severity=warning` (v0.11.0) over every `*.sh` in the repo locally — no findings remain, so the workflow passes. The workflow itself will validate on this PR.

## Related Issues
Closes #2064

## Additional Context
Severity is intentionally set to `warning` for a low-risk first step. A natural follow-up is to lower it to `info`/`style` and fix the `SC2086` quoting across the scripts once this baseline is in place.