### PR TITLE
fix(contest): avoid flaky MAC race in checkpoint netdevice test

### DIFF
--- a/tests/contest/contest/src/tests/checkpoint_restore/mod.rs
+++ b/tests/contest/contest/src/tests/checkpoint_restore/mod.rs
@@ -416,42 +416,19 @@ fn checkpoint_and_restore_with_netdevice() -> TestResult {
         Ok(ns) => ns,
         Err(e) => return TestResult::Failed(anyhow!("Failed to create netns: {e}")),
     };
-    let _dev = match net::DummyDevice::create(dev_name.clone()) {
-        Ok(d) => d,
-        Err(e) => return TestResult::Failed(anyhow!("Failed to create dummy dev: {e}")),
-    };
-
     let mtu = "1789";
     let mac = "00:11:22:33:44:55";
     let ip = "169.254.169.77/32";
 
-    let out = match Command::new("ip")
-        .args(["link", "set", "mtu", mtu, "dev", &dev_name])
-        .output()
-    {
-        Ok(out) => out,
-        Err(e) => return TestResult::Failed(anyhow!("ip link set mtu execution failed: {e}")),
+    // Set the MAC address and MTU in the device creation request instead of
+    // separate `ip link set` commands afterwards. The latter races with
+    // systemd-udevd (MACAddressPolicy=persistent) rewriting the MAC of newly
+    // created devices, while an address given at creation time is respected.
+    // See https://github.com/opencontainers/runc/pull/5324
+    let _dev = match net::DummyDevice::create_with_attributes(dev_name.clone(), mac, mtu) {
+        Ok(d) => d,
+        Err(e) => return TestResult::Failed(anyhow!("Failed to create dummy dev: {e}")),
     };
-    if !out.status.success() {
-        return TestResult::Failed(anyhow!(
-            "ip link set mtu failed: {}",
-            String::from_utf8_lossy(&out.stderr)
-        ));
-    }
-
-    let out = match Command::new("ip")
-        .args(["link", "set", "address", mac, "dev", &dev_name])
-        .output()
-    {
-        Ok(out) => out,
-        Err(e) => return TestResult::Failed(anyhow!("ip link set address execution failed: {e}")),
-    };
-    if !out.status.success() {
-        return TestResult::Failed(anyhow!(
-            "ip link set address failed: {}",
-            String::from_utf8_lossy(&out.stderr)
-        ));
-    }
 
     let out = match Command::new("ip")
         .args(["address", "add", ip, "dev", &dev_name])

--- a/tests/contest/contest/src/utils/net.rs
+++ b/tests/contest/contest/src/utils/net.rs
@@ -45,19 +45,47 @@ pub fn cleanup_netns(name: &str) -> Result<()> {
     }
 }
 
+/// Wait until systemd-udevd finishes processing rules triggered by device
+/// creation events.
+pub fn udev_settle() {
+    let _ = std::process::Command::new("udevadm").arg("settle").output();
+}
+
 pub fn create_dummy_device(name: &str) -> Result<()> {
     let output = std::process::Command::new("ip")
         .args(vec!["link", "add", name, "type", "dummy"])
         .output()?;
 
-    if output.status.success() {
-        Ok(())
-    } else {
-        Err(anyhow!(
+    if !output.status.success() {
+        return Err(anyhow!(
             "Failed to create dummy device: {}",
             String::from_utf8_lossy(&output.stderr)
-        ))
+        ));
     }
+    udev_settle();
+    Ok(())
+}
+
+/// Create a dummy device with the MAC address and MTU set atomically in the
+/// creation request. Setting the address after creation races with
+/// systemd-udevd's MACAddressPolicy=persistent, which may overwrite it.
+/// An explicitly assigned address at creation time is left untouched.
+/// See https://github.com/opencontainers/runc/pull/5324
+pub fn create_dummy_device_with_attributes(name: &str, mac: &str, mtu: &str) -> Result<()> {
+    let output = std::process::Command::new("ip")
+        .args(vec![
+            "link", "add", name, "address", mac, "mtu", mtu, "type", "dummy",
+        ])
+        .output()?;
+
+    if !output.status.success() {
+        return Err(anyhow!(
+            "Failed to create dummy device: {}",
+            String::from_utf8_lossy(&output.stderr)
+        ));
+    }
+    udev_settle();
+    Ok(())
 }
 
 pub fn delete_dummy_device(name: &str) -> Result<()> {
@@ -83,6 +111,11 @@ pub struct DummyDevice {
 impl DummyDevice {
     pub fn create(name: String) -> Result<Self> {
         create_dummy_device(&name)?;
+        Ok(Self { name })
+    }
+
+    pub fn create_with_attributes(name: String, mac: &str, mtu: &str) -> Result<Self> {
+        create_dummy_device_with_attributes(&name, mac, mtu)?;
         Ok(Self { name })
     }
 }

--- a/tests/contest/contest/src/utils/net.rs
+++ b/tests/contest/contest/src/utils/net.rs
@@ -47,7 +47,7 @@ pub fn cleanup_netns(name: &str) -> Result<()> {
 
 /// Wait until systemd-udevd finishes processing rules triggered by device
 /// creation events.
-pub fn udev_settle() {
+fn udev_settle() {
     let _ = std::process::Command::new("udevadm").arg("settle").output();
 }
 
@@ -62,7 +62,6 @@ pub fn create_dummy_device(name: &str) -> Result<()> {
             String::from_utf8_lossy(&output.stderr)
         ));
     }
-    udev_settle();
     Ok(())
 }
 
@@ -71,7 +70,7 @@ pub fn create_dummy_device(name: &str) -> Result<()> {
 /// systemd-udevd's MACAddressPolicy=persistent, which may overwrite it.
 /// An explicitly assigned address at creation time is left untouched.
 /// See https://github.com/opencontainers/runc/pull/5324
-pub fn create_dummy_device_with_attributes(name: &str, mac: &str, mtu: &str) -> Result<()> {
+fn create_dummy_device_with_attributes(name: &str, mac: &str, mtu: &str) -> Result<()> {
     let output = std::process::Command::new("ip")
         .args(vec![
             "link", "add", name, "address", mac, "mtu", mtu, "type", "dummy",


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of your changes -->

The integration test `checkpoint_and_restore_with_netdevice` was flaky in CI. The test created a dummy netdevice and then set its MAC in a separate ip link set address step, which raced with systemd-udevd rewriting the kernel-random MAC of the newly created device. When udevd won, the test's MAC was overwritten and the later `ether {mac}` assertion failed intermittently. 

This change follows opencontainers/runc#5324 by assigning the MAC and MTU when the device is created via `ip link add NAME address MAC mtu MTU type dummy` and by running udevadm settle after creation, so the values are already in place before udev processes the creation event and are not overwritten.

## Type of Change
<!-- Mark the appropriate option with an [x] -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test updates
- [ ] CI/CD related changes
- [ ] Other (please describe):

## Testing
<!-- Describe the tests you ran and/or added to verify your changes -->
- [ ] Added new unit tests
- [ ] Added new integration tests
- [x] Ran existing test suite
- [ ] Tested manually (please provide steps)

## Related Issues
<!-- Link any related issues using the GitHub issue syntax: #issue-number
If there is no open issue for this, please add details of the problem or open a new issue. -->
Fixes #3619

## Additional Context
<!-- Add any other context about the pull request here -->
The root cause and fix follow opencontainers/runc#5324. The no-attributes create_dummy_device variant is kept for tests that only check device existence and movement and never assert on the MAC, where the udevd race is harmless.