### PR TITLE
fix: youki spec state vs runc spec state generated config differences

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7331,6 +7331,7 @@ dependencies = [
  "procfs",
  "rust-criu",
  "scopeguard",
+ "serde",
  "serde_json",
  "serial_test",
  "tabwriter",

--- a/crates/libcontainer/src/container/state.rs
+++ b/crates/libcontainer/src/container/state.rs
@@ -325,32 +325,6 @@ pub struct ContainerProcessState {
     pub state: State,
 }
 
-#[derive(Serialize, Debug)]
-#[serde(rename_all = "camelCase")]
-pub struct StateExporter<'a> {
-    pub oci_version: &'a str,
-    pub id: &'a str,
-    pub status: ContainerStatus,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub pid: Option<i32>,
-    pub bundle: &'a Path,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub annotations: Option<&'a HashMap<String, String>>,
-}
-
-impl<'a> From<&'a State> for StateExporter<'a> {
-    fn from(state: &'a State) -> Self {
-        Self {
-            oci_version: &state.oci_version,
-            id: &state.id,
-            status: state.status,
-            pid: state.pid,
-            bundle: &state.bundle,
-            annotations: state.annotations.as_ref(),
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/libcontainer/src/container/state.rs
+++ b/crates/libcontainer/src/container/state.rs
@@ -325,6 +325,32 @@ pub struct ContainerProcessState {
     pub state: State,
 }
 
+#[derive(Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct StateExporter<'a> {
+    pub oci_version: &'a str,
+    pub id: &'a str,
+    pub status: ContainerStatus,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pid: Option<i32>,
+    pub bundle: &'a Path,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub annotations: Option<&'a HashMap<String, String>>,
+}
+
+impl<'a> From<&'a State> for StateExporter<'a> {
+    fn from(state: &'a State) -> Self {
+        Self {
+            oci_version: &state.oci_version,
+            id: &state.id,
+            status: state.status,
+            pid: state.pid,
+            bundle: &state.bundle,
+            annotations: state.annotations.as_ref(),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/youki/Cargo.toml
+++ b/crates/youki/Cargo.toml
@@ -33,6 +33,7 @@ nix = { workspace = true }
 pentacle = { workspace = true }
 procfs = { workspace = true }
 serde_json = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
 tabwriter = { workspace = true }
 clap_complete = { workspace = true }
 caps = { workspace = true }

--- a/crates/youki/src/commands/spec_json.rs
+++ b/crates/youki/src/commands/spec_json.rs
@@ -13,7 +13,7 @@ use serde_json::to_writer_pretty;
 
 pub fn get_default() -> Result<Spec> {
     let spec = Spec::default();
-    get_filtered_spec(spec)
+    normalize_spec(spec)
 }
 
 pub fn get_rootless(syscall: &dyn Syscall) -> Result<Spec> {
@@ -84,7 +84,7 @@ pub fn get_rootless(syscall: &dyn Syscall) -> Result<Spec> {
 
     let mut spec = get_default()?;
     spec.set_linux(Some(linux)).set_mounts(Some(mounts));
-    get_filtered_spec(spec)
+    normalize_spec(spec)
 }
 
 fn normalize_spec(mut spec: Spec) -> Result<Spec> {

--- a/crates/youki/src/commands/spec_json.rs
+++ b/crates/youki/src/commands/spec_json.rs
@@ -12,41 +12,8 @@ use libcontainer::syscall::syscall::Syscall;
 use serde_json::to_writer_pretty;
 
 pub fn get_default() -> Result<Spec> {
-    let mut spec = Spec::default();
-
-    if let Some(mut process) = spec.process().clone() {
-        if let Some(mut capabilities) = process.capabilities().clone() {
-            capabilities.set_inheritable(Some(Capabilities::new()));
-            capabilities.set_ambient(Some(Capabilities::new()));
-            process.set_capabilities(Some(capabilities));
-        }
-
-        spec.set_process(Some(process));
-    }
-
-    if let Some(mut linux) = spec.linux().clone() {
-        if let Some(mut resources) = linux.resources().clone() {
-            let default_device = LinuxDeviceCgroupBuilder::default()
-                .allow(false)
-                .access("rwm".to_string())
-                .build()?;
-            resources.set_devices(Some(vec![default_device]));
-            linux.set_resources(Some(resources));
-        }
-
-        if let Some(namespaces) = linux.namespaces().clone() {
-            let mut filtered_namespaces = namespaces;
-            let setup = get_cgroup_setup().unwrap_or(CgroupSetup::Legacy);
-            if !matches!(setup, CgroupSetup::Unified) {
-                filtered_namespaces.retain(|ns| ns.typ() != LinuxNamespaceType::Cgroup);
-            }
-            linux.set_namespaces(Some(filtered_namespaces));
-        }
-
-        spec.set_linux(Some(linux));
-    }
-
-    Ok(spec)
+    let spec = Spec::default();
+    get_filtered_spec(spec)
 }
 
 pub fn get_rootless(syscall: &dyn Syscall) -> Result<Spec> {
@@ -117,6 +84,42 @@ pub fn get_rootless(syscall: &dyn Syscall) -> Result<Spec> {
 
     let mut spec = get_default()?;
     spec.set_linux(Some(linux)).set_mounts(Some(mounts));
+    get_filtered_spec(spec)
+}
+
+fn get_filtered_spec(mut spec: Spec) -> Result<Spec> {
+    if let Some(mut process) = spec.process().clone() {
+        if let Some(mut capabilities) = process.capabilities().clone() {
+            capabilities.set_inheritable(Some(Capabilities::new()));
+            capabilities.set_ambient(Some(Capabilities::new()));
+            process.set_capabilities(Some(capabilities));
+        }
+
+        spec.set_process(Some(process));
+    }
+
+    if let Some(mut linux) = spec.linux().clone() {
+        if let Some(mut resources) = linux.resources().clone() {
+            let default_device = LinuxDeviceCgroupBuilder::default()
+                .allow(false)
+                .access("rwm".to_string())
+                .build()?;
+            resources.set_devices(Some(vec![default_device]));
+            linux.set_resources(Some(resources));
+        }
+
+        if let Some(namespaces) = linux.namespaces().clone() {
+            let mut filtered_namespaces = namespaces;
+            let setup = get_cgroup_setup().unwrap_or(CgroupSetup::Legacy);
+            if !matches!(setup, CgroupSetup::Unified) {
+                filtered_namespaces.retain(|ns| ns.typ() != LinuxNamespaceType::Cgroup);
+            }
+            linux.set_namespaces(Some(filtered_namespaces));
+        }
+
+        spec.set_linux(Some(linux));
+    }
+
     Ok(spec)
 }
 

--- a/crates/youki/src/commands/spec_json.rs
+++ b/crates/youki/src/commands/spec_json.rs
@@ -4,14 +4,25 @@ use std::path::{Path, PathBuf};
 
 use anyhow::{Result, anyhow};
 use libcontainer::oci_spec::runtime::{
-    LinuxBuilder, LinuxIdMappingBuilder, LinuxNamespace, LinuxNamespaceBuilder, LinuxNamespaceType,
-    Mount, Spec,
+    Capabilities, LinuxBuilder, LinuxIdMappingBuilder, LinuxNamespace, LinuxNamespaceBuilder,
+    LinuxNamespaceType, Mount, Spec,
 };
 use libcontainer::syscall::syscall::Syscall;
 use serde_json::to_writer_pretty;
 
 pub fn get_default() -> Result<Spec> {
-    Ok(Spec::default())
+    let mut spec = Spec::default();
+
+    if let Some(mut process) = spec.process().clone() {
+        if let Some(mut capabilities) = process.capabilities().clone() {
+            capabilities.set_inheritable(Some(Capabilities::new()));
+            capabilities.set_ambient(Some(Capabilities::new()));
+            process.set_capabilities(Some(capabilities));
+        }
+        spec.set_process(Some(process));
+    }
+
+    Ok(spec)
 }
 
 pub fn get_rootless(syscall: &dyn Syscall) -> Result<Spec> {

--- a/crates/youki/src/commands/spec_json.rs
+++ b/crates/youki/src/commands/spec_json.rs
@@ -4,8 +4,8 @@ use std::path::{Path, PathBuf};
 
 use anyhow::{Result, anyhow};
 use libcontainer::oci_spec::runtime::{
-    Capabilities, LinuxBuilder, LinuxIdMappingBuilder, LinuxNamespace, LinuxNamespaceBuilder,
-    LinuxNamespaceType, Mount, Spec,
+    Capabilities, LinuxBuilder, LinuxDeviceCgroupBuilder, LinuxIdMappingBuilder, LinuxNamespace,
+    LinuxNamespaceBuilder, LinuxNamespaceType, Mount, Spec,
 };
 use libcontainer::syscall::syscall::Syscall;
 use serde_json::to_writer_pretty;
@@ -20,6 +20,18 @@ pub fn get_default() -> Result<Spec> {
             process.set_capabilities(Some(capabilities));
         }
         spec.set_process(Some(process));
+    }
+
+    if let Some(mut linux) = spec.linux().clone() {
+        if let Some(mut resources) = linux.resources().clone() {
+            let default_device = LinuxDeviceCgroupBuilder::default()
+                .allow(false)
+                .access("rwm".to_string())
+                .build()?;
+            resources.set_devices(Some(vec![default_device]));
+            linux.set_resources(Some(resources));
+        }
+        spec.set_linux(Some(linux));
     }
 
     Ok(spec)

--- a/crates/youki/src/commands/spec_json.rs
+++ b/crates/youki/src/commands/spec_json.rs
@@ -88,36 +88,29 @@ pub fn get_rootless(syscall: &dyn Syscall) -> Result<Spec> {
 }
 
 fn normalize_spec(mut spec: Spec) -> Result<Spec> {
-    if let Some(mut process) = spec.process().clone() {
-        if let Some(mut capabilities) = process.capabilities().clone() {
-            capabilities.set_inheritable(None);
-            capabilities.set_ambient(None);
-            process.set_capabilities(Some(capabilities));
-        }
-
-        spec.set_process(Some(process));
+    if let Some(process) = spec.process_mut()
+        && let Some(mut capabilities) = process.capabilities().clone()
+    {
+        capabilities.set_inheritable(None);
+        capabilities.set_ambient(None);
+        process.set_capabilities(Some(capabilities));
     }
 
-    if let Some(mut linux) = spec.linux().clone() {
-        if let Some(mut resources) = linux.resources().clone() {
+    if let Some(linux) = spec.linux_mut() {
+        if let Some(resources) = linux.resources_mut() {
             let default_device = LinuxDeviceCgroupBuilder::default()
                 .allow(false)
                 .access("rwm".to_string())
                 .build()?;
             resources.set_devices(Some(vec![default_device]));
-            linux.set_resources(Some(resources));
         }
 
-        if let Some(namespaces) = linux.namespaces().clone() {
-            let mut filtered_namespaces = namespaces;
+        if let Some(namespaces) = linux.namespaces_mut() {
             let setup = get_cgroup_setup().unwrap_or(CgroupSetup::Legacy);
             if !matches!(setup, CgroupSetup::Unified) {
-                filtered_namespaces.retain(|ns| ns.typ() != LinuxNamespaceType::Cgroup);
+                namespaces.retain(|ns| ns.typ() != LinuxNamespaceType::Cgroup);
             }
-            linux.set_namespaces(Some(filtered_namespaces));
         }
-
-        spec.set_linux(Some(linux));
     }
 
     Ok(spec)

--- a/crates/youki/src/commands/spec_json.rs
+++ b/crates/youki/src/commands/spec_json.rs
@@ -5,7 +5,7 @@ use std::path::{Path, PathBuf};
 use anyhow::{Result, anyhow};
 use libcgroups::common::{CgroupSetup, get_cgroup_setup};
 use libcontainer::oci_spec::runtime::{
-    Capabilities, LinuxBuilder, LinuxDeviceCgroupBuilder, LinuxIdMappingBuilder, LinuxNamespace,
+    LinuxBuilder, LinuxDeviceCgroupBuilder, LinuxIdMappingBuilder, LinuxNamespace,
     LinuxNamespaceBuilder, LinuxNamespaceType, Mount, Spec,
 };
 use libcontainer::syscall::syscall::Syscall;
@@ -90,8 +90,8 @@ pub fn get_rootless(syscall: &dyn Syscall) -> Result<Spec> {
 fn normalize_spec(mut spec: Spec) -> Result<Spec> {
     if let Some(mut process) = spec.process().clone() {
         if let Some(mut capabilities) = process.capabilities().clone() {
-            capabilities.set_inheritable(Some(Capabilities::new()));
-            capabilities.set_ambient(Some(Capabilities::new()));
+            capabilities.set_inheritable(None);
+            capabilities.set_ambient(None);
             process.set_capabilities(Some(capabilities));
         }
 

--- a/crates/youki/src/commands/spec_json.rs
+++ b/crates/youki/src/commands/spec_json.rs
@@ -87,7 +87,7 @@ pub fn get_rootless(syscall: &dyn Syscall) -> Result<Spec> {
     get_filtered_spec(spec)
 }
 
-fn get_filtered_spec(mut spec: Spec) -> Result<Spec> {
+fn normalize_spec(mut spec: Spec) -> Result<Spec> {
     if let Some(mut process) = spec.process().clone() {
         if let Some(mut capabilities) = process.capabilities().clone() {
             capabilities.set_inheritable(Some(Capabilities::new()));

--- a/crates/youki/src/commands/spec_json.rs
+++ b/crates/youki/src/commands/spec_json.rs
@@ -3,6 +3,7 @@ use std::io::{BufWriter, ErrorKind, Write};
 use std::path::{Path, PathBuf};
 
 use anyhow::{Result, anyhow};
+use libcgroups::common::{CgroupSetup, get_cgroup_setup};
 use libcontainer::oci_spec::runtime::{
     Capabilities, LinuxBuilder, LinuxDeviceCgroupBuilder, LinuxIdMappingBuilder, LinuxNamespace,
     LinuxNamespaceBuilder, LinuxNamespaceType, Mount, Spec,
@@ -19,6 +20,7 @@ pub fn get_default() -> Result<Spec> {
             capabilities.set_ambient(Some(Capabilities::new()));
             process.set_capabilities(Some(capabilities));
         }
+
         spec.set_process(Some(process));
     }
 
@@ -31,6 +33,16 @@ pub fn get_default() -> Result<Spec> {
             resources.set_devices(Some(vec![default_device]));
             linux.set_resources(Some(resources));
         }
+
+        if let Some(namespaces) = linux.namespaces().clone() {
+            let mut filtered_namespaces = namespaces;
+            let setup = get_cgroup_setup().unwrap_or(CgroupSetup::Legacy);
+            if !matches!(setup, CgroupSetup::Unified) {
+                filtered_namespaces.retain(|ns| ns.typ() != LinuxNamespaceType::Cgroup);
+            }
+            linux.set_namespaces(Some(filtered_namespaces));
+        }
+
         spec.set_linux(Some(linux));
     }
 

--- a/crates/youki/src/commands/state.rs
+++ b/crates/youki/src/commands/state.rs
@@ -1,12 +1,14 @@
 use std::path::PathBuf;
 
 use anyhow::Result;
+use libcontainer::container::state::StateExporter;
 use liboci_cli::State;
 
 use crate::commands::load_container;
 
 pub fn state(args: State, root_path: PathBuf) -> Result<()> {
     let container = load_container(root_path, &args.container_id)?;
-    println!("{}", serde_json::to_string_pretty(&container.state)?);
+    let export = StateExporter::from(&container.state);
+    println!("{}", serde_json::to_string_pretty(&export)?);
     std::process::exit(0);
 }

--- a/crates/youki/src/commands/state.rs
+++ b/crates/youki/src/commands/state.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
 use anyhow::Result;
-use libcontainer::container::state::{ContainerStatus, State as LibState};
+use libcontainer::container::state::{ContainerStatus, State as ContainerState};
 use liboci_cli::State;
 use serde::Serialize;
 
@@ -28,8 +28,8 @@ pub struct StateExporter<'a> {
     pub annotations: Option<&'a HashMap<String, String>>,
 }
 
-impl<'a> From<&'a LibState> for StateExporter<'a> {
-    fn from(state: &'a LibState) -> Self {
+impl<'a> From<&'a ContainerState> for StateExporter<'a> {
+    fn from(state: &'a ContainerState) -> Self {
         Self {
             oci_version: &state.oci_version,
             id: &state.id,

--- a/crates/youki/src/commands/state.rs
+++ b/crates/youki/src/commands/state.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
 use anyhow::Result;
+use chrono::{DateTime, Utc};
 use libcontainer::container::state::{ContainerStatus, State as ContainerState};
 use liboci_cli::State;
 use serde::Serialize;
@@ -26,6 +27,10 @@ pub struct StateExporter<'a> {
     pub bundle: &'a Path,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub annotations: Option<&'a HashMap<String, String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub created: Option<&'a DateTime<Utc>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub owner: Option<u32>,
 }
 
 impl<'a> From<&'a ContainerState> for StateExporter<'a> {
@@ -37,6 +42,8 @@ impl<'a> From<&'a ContainerState> for StateExporter<'a> {
             pid: state.pid,
             bundle: &state.bundle,
             annotations: state.annotations.as_ref(),
+            created: state.created.as_ref(),
+            owner: state.creator,
         }
     }
 }

--- a/crates/youki/src/commands/state.rs
+++ b/crates/youki/src/commands/state.rs
@@ -1,8 +1,10 @@
-use std::path::PathBuf;
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
 
 use anyhow::Result;
-use libcontainer::container::state::StateExporter;
+use libcontainer::container::state::{ContainerStatus, State as LibState};
 use liboci_cli::State;
+use serde::Serialize;
 
 use crate::commands::load_container;
 
@@ -11,4 +13,30 @@ pub fn state(args: State, root_path: PathBuf) -> Result<()> {
     let export = StateExporter::from(&container.state);
     println!("{}", serde_json::to_string_pretty(&export)?);
     std::process::exit(0);
+}
+
+#[derive(Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct StateExporter<'a> {
+    pub oci_version: &'a str,
+    pub id: &'a str,
+    pub status: ContainerStatus,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pid: Option<i32>,
+    pub bundle: &'a Path,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub annotations: Option<&'a HashMap<String, String>>,
+}
+
+impl<'a> From<&'a LibState> for StateExporter<'a> {
+    fn from(state: &'a LibState) -> Self {
+        Self {
+            oci_version: &state.oci_version,
+            id: &state.id,
+            status: state.status,
+            pid: state.pid,
+            bundle: &state.bundle,
+            annotations: state.annotations.as_ref(),
+        }
+    }
 }


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of your changes -->

## Type of Change
<!-- Mark the appropriate option with an [x] -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test updates
- [ ] CI/CD related changes
- [ ] Other (please describe):

## Testing
<!-- Describe the tests you ran and/or added to verify your changes -->
- [ ] Added new unit tests
- [ ] Added new integration tests
- [ ] Ran existing test suite
- [x] Tested manually (please provide steps)

## Related Issues
<!-- Link any related issues using the GitHub issue syntax: #issue-number
If there is no open issue for this, please add details of the problem or open a new issue. -->
Fixes #3560 and #3626

## Additional Context
<!-- Add any other context about the pull request here -->

```bash
jq '.process.capabilities' /tmp/spec-compare/runc-bundle/config.json

{
  "bounding": [
    "CAP_AUDIT_WRITE",
    "CAP_KILL",
    "CAP_NET_BIND_SERVICE"
  ],
  "effective": [
    "CAP_AUDIT_WRITE",
    "CAP_KILL",
    "CAP_NET_BIND_SERVICE"
  ],
  "permitted": [
    "CAP_AUDIT_WRITE",
    "CAP_KILL",
    "CAP_NET_BIND_SERVICE"
  ]
}

jq '.process.capabilities' /tmp/spec-compare/youki-bundle/config.json
{
  "bounding": [
    "CAP_NET_BIND_SERVICE",
    "CAP_KILL",
    "CAP_AUDIT_WRITE"
  ],
  "effective": [
    "CAP_NET_BIND_SERVICE",
    "CAP_KILL",
    "CAP_AUDIT_WRITE"
  ],
  "permitted": [
    "CAP_NET_BIND_SERVICE",
    "CAP_KILL",
    "CAP_AUDIT_WRITE"
  ],
}

### 

jq '.linux.resources.devices' /tmp/spec-compare/runc-bundle/config.json
[
  {
    "allow": false,
    "access": "rwm"
  }
]

jq '.linux.resources.devices' /tmp/spec-compare/youki-bundle/config.json
[
  {
    "allow": false,
    "access": "rwm"
  }
]

### 

jq '.linux.namespaces' /tmp/spec-compare/runc-bundle/config.json
[
  {
    "type": "pid"
  },
  {
    "type": "network"
  },
  {
    "type": "ipc"
  },
  {
    "type": "uts"
  },
  {
    "type": "mount"
  },
  {
    "type": "cgroup"
  }
]

jq '.linux.namespaces' /tmp/spec-compare/youki-bundle/config.json
[
  {
    "type": "pid"
  },
  {
    "type": "network"
  },
  {
    "type": "ipc"
  },
  {
    "type": "uts"
  },
  {
    "type": "mount"
  },
  {
    "type": "cgroup"
  }
]

### 3626

cargo run --bin youki --manifest-path /home/arch/code/tommady/youki-dev/close-issue-3560/Cargo.toml -- --root /tmp/youki-state state my-container

    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.10s
     Running `/home/arch/code/tommady/youki-dev/close-issue-3560/target/debug/youki --root /tmp/youki-state state my-container`
DEBUG youki: started by user 1000 with ArgsOs { inner: ["/home/arch/code/tommady/youki-dev/close-issue-3560/target/debug/youki", "--root", "/tmp/youki-state", "state", "my-container"] }
{
  "ociVersion": "1.1.0",
  "id": "my-container",
  "status": "created",
  "pid": 899759,
  "bundle": "/tmp/youki-test",
  "annotations": {},
  "created": "2026-07-11T05:10:40.065638090Z",
  "owner": 1000
}



bat /tmp/youki-state/my-container/state.json | jq
{
  "ociVersion": "1.1.0",
  "id": "my-container",
  "status": "created",
  "pid": 899759,
  "bundle": "/tmp/youki-test",
  "annotations": {},
  "created": "2026-07-11T05:10:40.065638090Z",
  "creator": 1000,
  "useSystemd": false,
  "intelRdtDir": null
}
```
