### PR TITLE
feat(checkpoint): Added support for the --tcp-skip-in-flight option

### DIFF
--- a/crates/libcontainer/src/container/container.rs
+++ b/crates/libcontainer/src/container/container.rs
@@ -240,6 +240,7 @@ pub struct CheckpointOptions {
     pub leave_running: bool,
     pub shell_job: bool,
     pub tcp_established: bool,
+    pub tcp_skip_in_flight: bool,
     pub work_path: Option<PathBuf>,
     pub manage_cgroups_mode: rust_criu::CgMode,
     pub link_remap: bool,

--- a/crates/libcontainer/src/container/container_checkpoint.rs
+++ b/crates/libcontainer/src/container/container_checkpoint.rs
@@ -157,6 +157,7 @@ impl Container {
         criu.set_ext_unix_sk(opts.ext_unix_sk);
         criu.set_shell_job(opts.shell_job);
         criu.set_tcp_established(opts.tcp_established);
+        criu.set_tcp_skip_in_flight(opts.tcp_skip_in_flight);
         criu.set_file_locks(opts.file_locks);
         criu.set_orphan_pts_master(true);
         criu.set_manage_cgroups(true);

--- a/crates/liboci-cli/src/checkpoint.rs
+++ b/crates/liboci-cli/src/checkpoint.rs
@@ -22,9 +22,9 @@ pub struct Checkpoint {
     /// Allow open tcp connections
     #[arg(long)]
     pub tcp_established: bool,
-    // TODO: Skip in-flight tcp connections
-    // #[arg(long)]
-    // pub tcp_skip_in_flight: bool,
+    /// Skip in-flight tcp connections
+    #[arg(long)]
+    pub tcp_skip_in_flight: bool,
     /// Allow one to link unlinked files back when possible
     #[arg(long)]
     pub link_remap: bool,

--- a/crates/youki/src/commands/checkpoint.rs
+++ b/crates/youki/src/commands/checkpoint.rs
@@ -16,6 +16,7 @@ pub fn checkpoint(args: Checkpoint, root_path: PathBuf) -> Result<()> {
         leave_running: args.leave_running,
         shell_job: args.shell_job,
         tcp_established: args.tcp_established,
+        tcp_skip_in_flight: args.tcp_skip_in_flight,
         work_path: args.work_path,
         manage_cgroups_mode: parse_cgroups_mode(&args.manage_cgroups_mode)?,
         link_remap: args.link_remap,

--- a/tests/contest/contest/src/tests/lifecycle/checkpoint.rs
+++ b/tests/contest/contest/src/tests/lifecycle/checkpoint.rs
@@ -433,6 +433,158 @@ pub fn checkpoint_link_remap() -> TestResult {
     result
 }
 
+// Polls until the listen socket on `port` has a queued, unaccepted connection,
+// which is the in-flight state.
+fn wait_in_flight(
+    project_path: &Path,
+    id: &str,
+    port: u16,
+    timeout: std::time::Duration,
+) -> Result<(), TestResult> {
+    // The in-flight connection only exists once lo is up. Until then the clients
+    // running inside the container cannot reach 127.0.0.1, so no connection is
+    // established and nothing accumulates in the accept queue for `ss` to report.
+    // The container itself cannot bring lo up because the default spec grants no
+    // NET_ADMIN, so we do it here from the host before polling. `checkpoint` brings
+    // it up again later, but `ip link set up` is idempotent.
+    setup_network_namespace(project_path, id)?;
+
+    let pid = get_container_pid(project_path, id)?;
+    let deadline = std::time::Instant::now() + timeout;
+
+    loop {
+        let output = Command::new("nsenter")
+            .args(["-t", &pid.to_string(), "-n"])
+            .args(["ss", "-Htl", &format!("sport = :{port}")])
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .output()
+            .map_err(|e| TestResult::Failed(anyhow!("failed to exec ss via nsenter: {e}")))?;
+
+        // second column of `ss` is Recv-Q which is the accepted accept backlog depth.
+        if String::from_utf8_lossy(&output.stdout).lines().any(|line| {
+            line.split_whitespace()
+                .nth(1)
+                .and_then(|recv_q| recv_q.parse::<u32>().ok())
+                .is_some_and(|recv_q| recv_q > 0)
+        }) {
+            return Ok(());
+        }
+
+        if std::time::Instant::now() >= deadline {
+            return Err(TestResult::Failed(anyhow!(
+                "timed out waiting for an in-flight connection on port {port}"
+            )));
+        }
+        std::thread::sleep(std::time::Duration::from_millis(100));
+    }
+}
+
+struct ContainerCleanup<'a> {
+    id: &'a str,
+    bundle_path: &'a Path,
+}
+
+impl Drop for ContainerCleanup<'_> {
+    fn drop(&mut self) {
+        if let Ok(mut child) = kill_container(self.id, self.bundle_path) {
+            let _ = child.wait();
+        }
+        if let Ok(mut child) = delete_container(self.id, self.bundle_path) {
+            let _ = child.wait();
+        }
+    }
+}
+
+pub fn checkpoint_tcp_skip_in_flight() -> TestResult {
+    const PORT: u16 = 11111;
+
+    let bundle = match prepare_bundle() {
+        Ok(b) => b,
+        Err(e) => return TestResult::Failed(anyhow!("failed to prepare bundle: {e}")),
+    };
+    let id = generate_uuid().to_string();
+
+    let mut spec = Spec::default();
+    let mut process = spec.process().clone().unwrap_or_default();
+    // We need an unaccepted connection sitting in the listen socket's accept queue at
+    // dump time, because that is the only state `--tcp-skip-in-flight` acts on.
+    // `-c` caps the number of simultaneously accepted connections, so `tcpsvd -c 0`
+    // never calls accept(). The kernel still completes the handshake for the `nc`
+    // connect, leaving it ESTABLISHED but unaccepted in the accept queue: in-flight.
+    process.set_args(Some(vec![
+        "sh".to_string(),
+        "-c".to_string(),
+        format!(
+            "until ip addr show lo | grep -q 127.0.0.1; do sleep 0.1; done; \
+             tcpsvd -c 0 0.0.0.0 {PORT} sleep 100000 & \
+             sleep 100000 | nc 127.0.0.1 {PORT} & \
+             while true; do sleep 1; done"
+        ),
+    ]));
+    spec.set_process(Some(process));
+
+    if let Err(e) = set_config(&bundle, &spec) {
+        return TestResult::Failed(anyhow!("failed to write config.json: {e}"));
+    }
+
+    let bundle_path = bundle.path();
+
+    let _cleanup = ContainerCleanup {
+        id: &id,
+        bundle_path,
+    };
+
+    if let Err(e) = create::create(bundle_path, &id) {
+        return TestResult::Failed(anyhow!("create container failed: {e}"));
+    }
+
+    if let Err(e) = start::start(bundle_path, &id) {
+        return TestResult::Failed(anyhow!("start container failed: {e}"));
+    }
+
+    if let Err(e) = wait_container_running(&id, bundle_path) {
+        return TestResult::Failed(anyhow!("container did not reach running state: {e}"));
+    }
+
+    if let Err(e) = wait_in_flight(bundle_path, &id, PORT, std::time::Duration::from_secs(10)) {
+        return e;
+    }
+
+    let (_image_temp_dir, image_path) = match create_checkpoint_image_dir() {
+        Ok(v) => v,
+        Err(e) => return e,
+    };
+
+    let result = checkpoint(
+        bundle_path,
+        &id,
+        &image_path,
+        vec!["--tcp-established", "--tcp-skip-in-flight"],
+        None,
+    );
+    if let TestResult::Failed(_) = &result {
+        return result;
+    }
+
+    let has_tcp_stream_img = match std::fs::read_dir(&image_path) {
+        Ok(entries) => entries
+            .flatten()
+            .any(|e| e.file_name().to_string_lossy().starts_with("tcp-stream-")),
+        Err(e) => {
+            return TestResult::Failed(anyhow!("failed to read image dir {image_path:?}: {e}"));
+        }
+    };
+    if has_tcp_stream_img {
+        TestResult::Passed
+    } else {
+        TestResult::Failed(anyhow!(
+            "checkpoint with --tcp-skip-in-flight succeeded but no tcp-stream-*.img \
+             was written to {image_path:?}; the TCP connection state was not dumped"
+        ))
+    }
+}
+
 /// Check that a namespace was treated as external by CRIU.
 /// Fails if `<img_prefix>-*.img` is absent or lacks `ext_key`.
 /// CRIU img files embed protobuf strings as raw UTF-8, so a byte search suffices.

--- a/tests/contest/contest/src/tests/lifecycle/container_lifecycle.rs
+++ b/tests/contest/contest/src/tests/lifecycle/container_lifecycle.rs
@@ -222,6 +222,14 @@ impl ContainerLifecycle {
         checkpoint::checkpoint_link_remap()
     }
 
+    pub fn checkpoint_tcp_skip_in_flight() -> TestResult {
+        if !criu_installed() {
+            return TestResult::Skipped("CRIU is not installed".to_string());
+        }
+
+        checkpoint::checkpoint_tcp_skip_in_flight()
+    }
+
     pub fn checkpoint_with_external_namespaces() -> TestResult {
         if !criu_installed() {
             return TestResult::Skipped("criu not installed".to_string());
@@ -327,6 +335,10 @@ impl TestableGroup for ContainerLifecycle {
             ),
             ("checkpoint with link-remap", Self::checkpoint_link_remap()),
             (
+                "checkpoint with tcp-skip-in-flight",
+                Self::checkpoint_tcp_skip_in_flight(),
+            ),
+            (
                 "checkpoint with external namespaces",
                 Self::checkpoint_with_external_namespaces(),
             ),
@@ -361,6 +373,10 @@ impl TestableGroup for ContainerLifecycle {
                 "checkpoint_link_remap" => {
                     ret.push(("checkpoint with link-remap", Self::checkpoint_link_remap()))
                 }
+                "checkpoint_tcp_skip_in_flight" => ret.push((
+                    "checkpoint with tcp-skip-in-flight",
+                    Self::checkpoint_tcp_skip_in_flight(),
+                )),
                 "checkpoint_with_external_namespaces" => ret.push((
                     "checkpoint with external namespaces",
                     Self::checkpoint_with_external_namespaces(),


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of your changes -->

This PR enables specifying the `--tcp-skip-in-flight` option to CRIU via the CLI.  Previously, when only --tcp-established was specified, dump operations would fail if any in-flight TCP connections existed. With this change, checkpoints can now be performed while ignoring in-flight TCP connections.

## Type of Change
<!-- Mark the appropriate option with an [x] -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test updates
- [ ] CI/CD related changes
- [ ] Other (please describe):

## Testing
<!-- Describe the tests you ran and/or added to verify your changes -->
- [ ] Added new unit tests
- [x] Added new integration tests
- [ ] Ran existing test suite
- [ ] Tested manually (please provide steps)

## Related Issues
<!-- Link any related issues using the GitHub issue syntax: #issue-number
If there is no open issue for this, please add details of the problem or open a new issue. -->
https://github.com/youki-dev/youki/issues/3394

## Additional Context
<!-- Add any other context about the pull request here -->
- About `--tcp-skip-in-flight` in CRIU: https://criu.org/CLI/opt/--skip-in-flight
- In this PR, I utilize `tcpsvd(8)` to make an in-flight TCP connection
  - Because the `bundle(busybox)` has `tcpsvd(8)`
  - Also allows connections to remain queued (backlogged) in the kernel easily
