### PR TITLE
fix: reorder liboci-cli dep fields so  matches the line

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ fixedbitset = "0.5.7"
 flate2 = "1.1"
 libbpf-sys = "1.6.4"
 libc = "0.2.186"
-liboci-cli = { version = "0.6.0", path = "crates/liboci-cli" } # MARK: Version
+liboci-cli = { path = "crates/liboci-cli", version = "0.6.0" } # MARK: Version
 libseccomp = "0.4.0"
 mockall = "0.15.0"
 nc = "0.9.8"


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of your changes -->

The sed pattern in the version-up recipe only matches inline tables where `version` is the last field (`version = "x.y.z" } # MARK: Version`).
The liboci-cli entry in the workspace Cargo.toml had `version` first, so it was silently left behind on version bumps. Reorder the fields tomatch the convention used by the other `# MARK: Version` lines.

## Type of Change
<!-- Mark the appropriate option with an [x] -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test updates
- [ ] CI/CD related changes
- [ ] Other (please describe): 

## Testing
<!-- Describe the tests you ran and/or added to verify your changes -->
- [ ] Added new unit tests
- [ ] Added new integration tests
- [ ] Ran existing test suite
- [x] Tested manually (please provide steps)

```
just version-up 0.7.0
```

## Related Issues
<!-- Link any related issues using the GitHub issue syntax: #issue-number
If there is no open issue for this, please add details of the problem or open a new issue. -->
Fixes #

## Additional Context
<!-- Add any other context about the pull request here -->

It seems the order was changed when the dependencies were refactored in the following PR.

https://github.com/youki-dev/youki/pull/3477


