### PR TITLE
bump version to 0.7.0 and fix version-up regex in justfile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2635,7 +2635,7 @@ checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libcgroups"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2661,7 +2661,7 @@ dependencies = [
 
 [[package]]
 name = "libcontainer"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "caps",
@@ -2711,7 +2711,7 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "liboci-cli"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "clap",
 ]
@@ -7325,7 +7325,7 @@ dependencies = [
 
 [[package]]
 name = "youki"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "caps",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ fixedbitset = "0.5.7"
 flate2 = "1.1"
 libbpf-sys = "1.6.4"
 libc = "0.2.186"
-liboci-cli = { version = "0.6.0", path = "crates/liboci-cli" } # MARK: Version
+liboci-cli = { version = "0.7.0", path = "crates/liboci-cli" } # MARK: Version
 libseccomp = "0.4.0"
 mockall = "0.15.0"
 nc = "0.9.8"

--- a/justfile
+++ b/justfile
@@ -265,7 +265,7 @@ version-up version:
     #!/usr/bin/bash
     set -ex
     git grep -l "^version = .* # MARK: Version" | xargs sed -i 's/version = "[0-9]\.[0-9]\.[0-9]" # MARK: Version/version = "{{version}}" # MARK: Version/g'
-    git grep -l "} # MARK: Version" | grep -v justfile | xargs sed -i 's/version = "[0-9]\.[0-9]\.[0-9]" } # MARK: Version/version = "{{version}}" } # MARK: Version/g'
+    git grep -l "} # MARK: Version" | grep -v justfile | xargs sed -i 's/version = "[0-9]\.[0-9]\.[0-9]"\([^}]*\)} # MARK: Version/version = "{{version}}"\1} # MARK: Version/g'
     {{ cwd }}/scripts/release_tag.sh {{version}}
     NEXT_VERSION=$(echo {{version}} | awk -F. -v OFS=. '{$NF += 1 ; print}')
     sed -i "s/{{version}}/$NEXT_VERSION/g" .tagpr


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of your changes -->
Bump all crate versions from 0.6.0 to 0.7.0 and fix the `version-up` recipe regex in `justfile`.

The previous regex failed to match dependency entries that have extra fields between the version and `}`, such as:

```toml
liboci-cli = { version = "0.6.0", path = "crates/liboci-cli" } # MARK: Version
```

The updated regex uses `\([^}]*\)` to capture any characters between the version string and `}`, so all variants are handled correctly.

## Type of Change
<!-- Mark the appropriate option with an [x] -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test updates
- [ ] CI/CD related changes
- [ ] Other (please describe):

## Testing
<!-- Describe the tests you ran and/or added to verify your changes -->
- [ ] Added new unit tests
- [ ] Added new integration tests
- [ ] Ran existing test suite
- [ ] Tested manually (please provide steps)

## Related Issues
<!-- Link any related issues using the GitHub issue syntax: #issue-number
If there is no open issue for this, please add details of the problem or open a new issue. -->
Fixes #

## Additional Context
<!-- Add any other context about the pull request here -->